### PR TITLE
Resolve GH-5: Improve playground and initial AST

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 use parser::Element;
+use std::collections::HashMap;
 
 // It is still somewhat unclear how we want to structure this part of the code base.
 // But basically we would transform the document tree by evaluating all of the nodes
@@ -6,9 +7,33 @@ use parser::Element;
 
 pub fn eval(document: &Element) -> String {
     // Note that the real program of course won't be hard-coded to transpile into html like this
-    match document {
-        Element::Document(content) => format!("<main>{}</main>", eval(content)),
-        Element::Paragraph(content) => format!("<p>{}</p>", eval(content)),
-        Element::Text(content) => content.to_owned(),
+    return elem_to_html(&document);
+}
+
+// Example function turning an element to html
+fn elem_to_html(elem: &Element) -> String {
+    match elem {
+        Element::Data(str) => str.to_string(),
+        Element::Node { name, attributes, children } => {
+            inode_to_html(&name, &attributes, &children)
+        }
+    }
+}
+
+// Example turning inode (non-leaf node) to html, to make above function cleaner
+fn inode_to_html(name: &str, attributes: &HashMap<String, String>, children: &Vec<Element>) -> String {
+    match name {
+        "Document" => format!("<main>\n{}\n</main>",
+                              children.iter()
+                                  .map(|e| elem_to_html(&e))
+                                  .collect::<Vec<String>>()
+                                  .join("\n")
+        ),
+        "Paragraph" => format!("<p>\n{}\n</p>",
+                               children.iter()
+                                   .map(|e| elem_to_html(&e))
+                                   .collect::<Vec<String>>()
+                                   .join("\n")),
+        &_ => panic!("No inode=>html for node '{name}'")
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,33 +7,44 @@ use std::collections::HashMap;
 
 pub fn eval(document: &Element) -> String {
     // Note that the real program of course won't be hard-coded to transpile into html like this
-    return elem_to_html(&document);
+    elem_to_html(document)
 }
 
 // Example function turning an element to html
 fn elem_to_html(elem: &Element) -> String {
     match elem {
         Element::Data(str) => str.to_string(),
-        Element::Node { name, attributes, children } => {
-            inode_to_html(&name, &attributes, &children)
-        }
+        Element::Node {
+            name,
+            attributes,
+            children,
+        } => inode_to_html(name, attributes, children),
     }
 }
 
 // Example turning inode (non-leaf node) to html, to make above function cleaner
-fn inode_to_html(name: &str, attributes: &HashMap<String, String>, children: &Vec<Element>) -> String {
+fn inode_to_html(
+    name: &str,
+    _attributes: &HashMap<String, String>,
+    children: &[Element],
+) -> String {
     match name {
-        "Document" => format!("<main>\n{}\n</main>",
-                              children.iter()
-                                  .map(|e| elem_to_html(&e))
-                                  .collect::<Vec<String>>()
-                                  .join("\n")
+        "Document" => format!(
+            "<main>\n{}\n</main>",
+            children
+                .iter()
+                .map(elem_to_html)
+                .collect::<Vec<String>>()
+                .join("\n")
         ),
-        "Paragraph" => format!("<p>\n{}\n</p>",
-                               children.iter()
-                                   .map(|e| elem_to_html(&e))
-                                   .collect::<Vec<String>>()
-                                   .join("\n")),
-        &_ => panic!("No inode=>html for node '{name}'")
+        "Paragraph" => format!(
+            "<p>\n{}\n</p>",
+            children
+                .iter()
+                .map(elem_to_html)
+                .collect::<Vec<String>>()
+                .join("\n")
+        ),
+        &_ => panic!("No inode=>html for node '{name}'"),
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -91,7 +91,7 @@ pub fn parse(source: &str) -> Element {
         } else {
             match &mut current_paragraph {
                 Element::Node { name: _, attributes: _, children } =>
-                    children.push(Element::Data(str.clone().into())),
+                    children.push(Element::Data(str.into())),
                 _ => { () }
             }
         }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -89,7 +89,8 @@ pub fn parse(source: &str) -> Element {
                 name: _,
                 attributes: _,
                 children,
-            } = &mut doc {
+            } = &mut doc
+            {
                 children.push(current_paragraph.clone())
             }
             current_paragraph = default_paragraph.clone();
@@ -97,7 +98,8 @@ pub fn parse(source: &str) -> Element {
             name: _,
             attributes: _,
             children,
-        } = &mut current_paragraph {
+        } = &mut current_paragraph
+        {
             children.push(Element::Data(str.into()))
         }
     });
@@ -106,7 +108,8 @@ pub fn parse(source: &str) -> Element {
         name: _,
         attributes: _,
         children,
-    } = &mut doc {
+    } = &mut doc
+    {
         children.push(current_paragraph)
     }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,15 +1,107 @@
 // Just some placeholder code. We will decide how to structure
 // our parser and what internal representation to use later :)
 
+use std::collections::HashMap;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
-    Document(Box<Self>),
-    Paragraph(Box<Self>),
-    Text(String),
+    Data(String),
+    Node {
+        name: String,
+        attributes: HashMap<String, String>,
+        children: Vec<Element>,
+    },
+}
+
+impl Element {
+    pub fn tree_string(&self, include_attributes: bool) -> String {
+        pretty_rows(&self, include_attributes).join("\n")
+    }
+}
+
+fn pretty_rows(element: &Element, include_attributes: bool) -> Vec<String> {
+    let indent = "  ";
+    let mut strs = vec![];
+
+    match element {
+        Element::Data(str) => strs.push(format!(r#""{str}""#)),
+        Element::Node { name, attributes, children } =>
+            {
+                strs.push(format!("{name} {{"));
+                if attributes.is_empty() {
+                    strs.push(format!("{indent}attributes: {{ <empty> }}"));
+                } else if include_attributes {
+                    strs.push(format!("{indent}attributes: {{"));
+
+                    attributes.iter().for_each(
+                        |(k, v)|
+                            strs.push(format!(r#"{indent}{indent}"{k}": "{v}""#))
+                    );
+
+                    strs.push(format!("{indent}}}"));
+                } else {
+                    strs.push(format!("{indent}attributes: {{ < {len} attributes > }}", len = &attributes.len().to_string()))
+                }
+
+                if children.is_empty() {
+                    strs.push(format!("{indent}children: [ none ]"));
+                } else {
+                    strs.push(format!("{indent}children: ["));
+
+                    children.into_iter().for_each(|c|
+                        pretty_rows(&c, include_attributes)
+                            .iter()
+                            .for_each(|s|
+                                strs.push(format!("{indent}{indent}{s}"))
+                            )
+                    );
+
+                    strs.push(format!("{indent}]"));
+                }
+                strs.push("}".to_string());
+            }
+    }
+
+    return strs;
 }
 
 pub fn parse(source: &str) -> Element {
-    Element::Document(Box::new(Element::Paragraph(Box::new(Element::Text(
-        source.to_string(),
-    )))))
+    let mut doc: Element = Element::Node {
+        name: "Document".into(),
+        attributes: HashMap::new(),
+        children: vec![],
+    };
+
+    let default_paragraph: Element = Element::Node {
+        name: "Paragraph".into(),
+        attributes: HashMap::new(),
+        children: vec![],
+    };
+
+    let mut current_paragraph: Element = default_paragraph.clone();
+
+    source.lines().for_each(|str|
+        if str.trim().is_empty() {
+            match &mut doc {
+                Element::Node { name: _, attributes: _, children } =>
+                    children.push(current_paragraph.clone()),
+                _ => {}
+            }
+            current_paragraph = default_paragraph.clone();
+        } else {
+            match &mut current_paragraph {
+                Element::Node { name: _, attributes: _, children } =>
+                    children.push(Element::Data(str.clone().into())),
+                _ => { () }
+            }
+        }
+    );
+
+    match &mut doc {
+        Element::Node { name: _, attributes: _, children } =>
+            children.push(current_paragraph),
+        _ => {}
+    }
+
+    return doc;
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -11,7 +11,7 @@
     <title>Modmark Playground</title>
     <link rel="stylesheet" href="style.css">
     <script type="module">
-        import init, { parse, transpile } from "./pkg/web_bindings.js";
+        import init, {parse, raw_tree, transpile} from "./pkg/web_bindings.js";
 
         const editor = document.getElementById("editor");
         const output = document.getElementById("output");
@@ -23,11 +23,22 @@
 
 
         function updateOutput(input) {
-            if (selector.value === "parse") {
-                output.innerHTML = `<pre>${parse(input)}</pre>`
-            } else if (selector.value === "transpile") {
-                output.innerHTML = transpile(input)
+            let pre = document.createElement("pre")
+            switch (selector.value) {
+                case "parse":
+                    pre.innerText = parse(input)
+                    break;
+                case "raw_tree":
+                    pre.innerText = raw_tree(input)
+                    break;
+                case "transpile":
+                    pre.innerText = transpile(input);
+                    break;
+                case "render":
+                    output.innerHTML = transpile(input);
+                    break;
             }
+            if (selector.value !== "render") output.innerHTML = pre.outerHTML;
         }
 
         init().then(() => {
@@ -40,21 +51,21 @@
 </head>
 
 <body>
-    <div class="menu">
-        <h1>Modmark playground</h1>
-        <select name="selector" id="selector">
-            <option value="parse">Document tree</option>
-            <option value="transpile">Transpiled output</option>
-        </select>
-        <a href="https://github.com/modmark-org/modmark">Github repo</a>
+<div class="menu">
+    <h1>Modmark playground</h1>
+    <select name="selector" id="selector">
+        <option value="parse">Document tree</option>
+        <option value="raw_tree">Raw tree</option>
+        <option value="transpile">HTML output</option>
+        <option value="render">Rendered HTML</option>
+    </select>
+    <a href="https://github.com/modmark-org/modmark">Github repo</a>
+</div>
+<main id="wrapper">
+    <textarea id="editor"></textarea>
+    <div id="output">
+
     </div>
-    <main id="wrapper">
-        <textarea id="editor"></textarea>
-        <div id="output">
-
-        </div>
-    </main>
-
+</main>
 </body>
-
 </html>

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -4,6 +4,14 @@ use wasm_bindgen::prelude::*;
 pub fn parse(source: &str) -> String {
     set_panic_hook();
     let document = parser::parse(source);
+    let pretty = document.tree_string(true);
+    format!("{pretty}")
+}
+
+#[wasm_bindgen]
+pub fn raw_tree(source: &str) -> String {
+    set_panic_hook();
+    let document = parser::parse(source);
     format!("{document:#?}")
 }
 

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -4,8 +4,7 @@ use wasm_bindgen::prelude::*;
 pub fn parse(source: &str) -> String {
     set_panic_hook();
     let document = parser::parse(source);
-    let pretty = document.tree_string(true);
-    format!("{pretty}")
+    document.tree_string(true)
 }
 
 #[wasm_bindgen]
@@ -18,8 +17,7 @@ pub fn raw_tree(source: &str) -> String {
 #[wasm_bindgen]
 pub fn transpile(source: &str) -> String {
     let document = parser::parse(source);
-    let output = core::eval(&document);
-    format!("{output}")
+    core::eval(&document)
 }
 
 pub fn set_panic_hook() {


### PR DESCRIPTION
This PR contains some improvements to the playground and the document tree first written by @adelhult , see GH-6 for the initial pull request. The changes were focused on making the initial tree look more like what might appear in the final product.

The project structure remains the same as implemented by @adelhult , however some internal restructurings were made: 

First of all, the `Element` enum now only has two cases, `Data(String)` and `Node{name: String, attributes: [String:String], children: [Element]}`, instead of the previous three, `Document(Box<Self>)`, `Paragraph(Box<Self>)` and `Text(String)`. Since the tree should be sent to and from different WASM-modules dynamically, it isn't possible to know the different possible nodes before-hand. Now, we have one leaf node, `Data(String)`, and one inode, `Node{..}`, which contains a string representing the type of that node. Later on, we might want to change the `Data` node to a node containing binary data, or to add a new leaf node containing binary data, or just keeping it as-is, and store binary data within external blobs and reference them from the tree. The `attributes` map is unused for now, but might store some state or configurations later on.

Second of all, a new string representation for `Element` was developed. The derived implementation would look something like this:
```
Node {
    name: "Paragraph",
    attributes: {},
    children: [
        Data(
            "Hej hej",
        ),
    ],
},
```
...the custom string representation would look like this:
```
Paragraph {
    attributes: { <empty> }
    children: [
        "Hej hej"
    ]
}
```

Since the `name` field is meant to signify different `Node` types, it improves readability a lot by having a custom string implementation.

The third thing that was added was two more output modes for the playground. In previous versions, there were two: `Document tree` and `Transpiled output`, but now there are four:

- Document tree (using the new custom string representation)
- Raw tree (using the one derived by rustc)
- HTML output (inspecing the HTML output without rendering it)
- Rendered HTML (renders the HTML output)

Additionally, some few changes were made in the wasm-bindings to accommodate the new features, in addition to a few changes in `core` to accommodate the merging of `Paragraph` and `Document` element (into the `Node` element).

This PR resolves GH-5