### PR TITLE
Add automatic deployment of Playground to GitHub Pages

### DIFF
--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -33,6 +33,10 @@ jobs:
         uses: actions/configure-pages@v2
       - name: Setup output directory
         run: mkdir public
+      - name: Install toolchain (minimal, stable, wasm32-unknown-unknown)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Run wasm-pack

--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -1,0 +1,53 @@
+# This is a workflow based on an example provided by GitHub
+name: Deploy Playground to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "cmdjojo/GH-9/0"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./playground
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Setup output directory
+        run: mkdir public
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+      - name: Run wasm-pack
+        run: wasm-pack build ./web_bindings --target web --out-dir ../public/pkg
+      - name: Copy sources
+        run: cp index.html style.css public
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: ./playground/public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -21,11 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,13 +37,21 @@ jobs:
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Run wasm-pack
         run: wasm-pack build ./web_bindings --target web --out-dir ../public/pkg
+      # If new static sources are added, make sure to copy them to the ./playground/public directory here
       - name: Copy sources
         run: cp index.html style.css public
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
           path: ./playground/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -4,7 +4,7 @@ name: Deploy Playground to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "cmdjojo/GH-9/0"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This PR contains a workflow for building and deploying the Playground to GitHub Pages on pushes to the `main` branch.

As a result of GH-5, we created a playground site which, in the current state, is a simple HTML page with an input box, which then uses simple JS to compile that input using our library and display either the parsed document tree or the output HTML. Together with the build instructions provided in the `playground` subdirectory, this is useful to visualize progress of our parser and tree model, and is an useful tool for development.

As a natural next step, GH-9 was created to automatically deploy this playground site to GitHub Pages. As discussed in GH-5, other markup languages such as Djot also have a [playground](https://www.djot.net/playground/), and it is very likely that this tool may be useful not only for development but also for testing and experimenting with the language itself, and that is also a reason for having the deployment of the most recent stable version automated.

This workflow works by creating a sub-directory `playground/public` on the runner, copying the static files (currently `index.html` and `style.css`) to that directory, using `wasm-bindgen` to generate the wasm bindings into `playground/public/pkg` and then uploading the  `playground/public` as an artifact which then gets deployed. The workflow is contained in the `DeployPages.yml` file and is inspired (and indeed very similar to) [static.yml](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) by GitHub. The job is split into two tasks, like [jekyll.yml](https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml), also from GitHub, where the first job `build` builds the static file, makes the artifact and uploads it, and the second job `deploy` deploys that artifact.

This code was tested by temporarily changing it from running on `branches: ["main"]` to `branches: ["main", "cmdjojo/GH-9/0"]` so that it would run on pushes to this testing branch, and then temporarily changing the environment protection rules to allow the `cmdjojo/GH-9/0` branch to publish to GitHub pages. The workflow worked fine, and the site was hosted at [modmark-org.github.io/modmark](https://modmark-org.github.io/modmark/). These two temporary changes, which was done for testing purposes, have both been reverted. Since the testing resulted in a success, I think the branch is ready to be merged into main. When done, the workflow will compile and publish a site at each push to `main`.

Here is a screenshot of how the current page looks like when deployed:
<img width="1180" alt="screenshot" src="https://user-images.githubusercontent.com/25929684/213949566-bdfa7e84-2f98-496f-9d4e-8c98ceadd1bc.png">

It is important for any change to the structure of the playground to be reflected in the workflow. If a static file is added into the `playground` directory but not to the workflow, that file won't be a part of the GitHub page. Failure to do so may result in a broken experience on the hosted site, but won't affect any other workflows.

Additionally, in the development of this workflow, installing the rust toolchain was added as a separate task from installing the (pre-built) wasm-bindgen binary since I thought it might improve build times. The result of this wasn't a significant decrease in build time, but a small decrease was noted. This might be due to chance alone or due to an actual improvement. Since the toolchain installation takes around a second in most cases, I think it is fine to leave that in the file, in the case of that it actually improves build times.

Resolves GH-9