### PR TITLE
GH-3: Add --no-fail-fast flag to continue test on fail

### DIFF
--- a/.github/workflows/RustCI.yml
+++ b/.github/workflows/RustCI.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install toolchain (minimal, stable)
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        run: cargo test --verbose
+        run: cargo test --verbose --no-fail-fast
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR adds the `--no-fail-fast` flag to `cargo test` to continue running tests even if one test fail.