### PR TITLE
GH-3: Add wasm32-wasi target to toolchain for modules

### DIFF
--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install toolchain (minimal, stable, wasm32-unknown-unknown)
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown, wasm32-wasi
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Make build script executable

--- a/.github/workflows/RustCI.yml
+++ b/.github/workflows/RustCI.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain (minimal, stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasi
       - name: Run cargo check
         run: cargo check --verbose
 
@@ -29,6 +31,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain (minimal, stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasi
       - name: Run cargo test
         run: cargo test --verbose --no-fail-fast
 
@@ -42,6 +46,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-wasi
       - name: Run cargo clippy
         run: cargo clippy --verbose -- -D warnings
 
@@ -55,5 +60,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+          targets: wasm32-wasi
       - name: Run cargo fmt
         run: cargo fmt --verbose -- --check


### PR DESCRIPTION
This PR adds the wasm32-wasi target to the toolchains for both CI and Deploy to be able to compile and build WASI modules