### PR TITLE
Add wasm32-wasi to the name of the CI steps

### DIFF
--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install toolchain (minimal, stable, wasm32-unknown-unknown)
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown, wasm32-wasi
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Make build script executable

--- a/.github/workflows/DeployPages.yml
+++ b/.github/workflows/DeployPages.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/configure-pages@v2
       - name: Setup output directory
         run: mkdir build
-      - name: Install toolchain (minimal, stable, wasm32-unknown-unknown)
+      - name: Install toolchain (minimal, stable, wasm32-unknown-unknown + wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, wasm32-wasi

--- a/.github/workflows/RustCI.yml
+++ b/.github/workflows/RustCI.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain (minimal, stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasi
       - name: Run cargo check
         run: cargo check --verbose
 
@@ -29,6 +31,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain (minimal, stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasi
       - name: Run cargo test
         run: cargo test --verbose --no-fail-fast
 
@@ -42,6 +46,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-wasi
       - name: Run cargo clippy
         run: cargo clippy --verbose -- -D warnings
 
@@ -55,5 +60,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+          targets: wasm32-wasi
       - name: Run cargo fmt
         run: cargo fmt --verbose -- --check

--- a/.github/workflows/RustCI.yml
+++ b/.github/workflows/RustCI.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install toolchain (minimal, stable)
+      - name: Install toolchain (minimal, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install toolchain (minimal, stable)
+      - name: Install toolchain (minimal, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install toolchain (minimal+clippy, stable)
+      - name: Install toolchain (minimal+clippy, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install toolchain (minimal+rustfmt, stable)
+      - name: Install toolchain (minimal+rustfmt, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt


### PR DESCRIPTION
This adds `wasm32-wasi` to the name of the CI steps, so that it more clearly shows that an additional target is installed