### PR TITLE
GH-32: Adds error handeling for wrong argument order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.idea

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -97,7 +97,12 @@ fn watch(args: &Args, target: &String) -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<()> {
+fn main(){
+    let source = fs::read_to_string("parser/test.mdm").unwrap();
+    let document = parse(&source);
+    println!("{}", document.tree_string(false));
+}
+/*fn main() -> Result<()> {
     let args = Args::parse();
     let current_path = env::current_dir()?;
     let target = current_path.into_os_string().into_string().unwrap();
@@ -127,3 +132,4 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+*/

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 regex = "1"
 lazy_static = "1.4.0"
 nom = "7.1.3"
+
+[dev-dependencies]
+json = "0.12.4"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -12,3 +12,8 @@ nom = "7.1.3"
 
 [dev-dependencies]
 json = "0.12.4"
+datatest-stable = "0.1.3"
+
+[[test]]
+name = "compilation_test"
+harness = false

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,10 @@
+# ModMark: Parser
+This is the parser for the ModMark language
+
+## Testing
+Integration tests that aim to test a successful compilation of the document and want to assert a certain tree structure should be placed in `tests/compilation_tests`. Such tests come in two flavors: unified and split. Both of them take a ModMark text as input, parses it, and compares the resulting tree to an expected JSON structure. If there is a mismatch, the test fails and both the expected and actual structure is printed. The ModMark file is compiled two times, once using LF line endings and once using CRLF line endings.
+
+ * Split tests have two files, `test_name.mdm` and `test_name.json` containing the input ModMark and expected JSON structure respectively.
+ * Unified test have one file, `test_name.mdmtest`. The file is formatted in Markdown and have two code blocks, the first one with the input, marked `modmark` or `mdm`, and the second one with the output marked `json`. Lines starting with triple backticks may not occur in the input or output. Arbitrary text, like comments, may be placed before, after and in between the two code blocks. It might be easier to see both the input and output in the same file and some IDE:s may allow for syntax highlighting inside the code blocks.
+
+Two different tests may not have the same name.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -51,6 +51,7 @@ enum AST {
     Paragraph(Paragraph),
     Tag(Tag),
     Module(Module),
+    Error(String),
 }
 
 impl From<AST> for Element {
@@ -78,6 +79,7 @@ impl From<AST> for Element {
                 body: module.body,
                 one_line: module.one_line,
             },
+            AST::Error(error) => panic!("{}", error),
         }
     }
 }
@@ -494,6 +496,7 @@ fn parse_module_name(input: &str) -> IResult<&str, &str> {
 fn get_module_args_parser<'a>(
     inline: bool,
 ) -> impl Parser<&'a str, ModuleArguments, Error<&'a str>> {
+    let mut first_named = false;
     map(
         opt(alt((
             map(
@@ -585,7 +588,7 @@ fn get_unnamed_arg_parser<'a>(inline: bool) -> impl Parser<&'a str, String, Erro
 /// | `delim = "yes box"`             | `(delim, yes box)`|
 /// | `"fake" = news`                 | `<Fail>`          |
 /// | `<space>`                       | `<Fail>`          |
-/// returns: a parser parsing one named argument
+/// returns: aget_arg_separator_parser parser parsing one named argument
 ///
 fn get_named_arg_parser<'a>(
     inline: bool,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -39,8 +39,8 @@ pub enum Element {
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct ModuleArguments {
-    positioned: Option<Vec<String>>,
-    named: Option<HashMap<String, String>>,
+    pub positioned: Option<Vec<String>>,
+    pub named: Option<HashMap<String, String>>,
 }
 
 impl Element {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -242,7 +242,7 @@ fn parse_paragraph_elements(input: &str) -> IResult<&str, Vec<AST>> {
         |(a, b)| {
             let mut elems = a;
             if !b.is_empty() {
-                elems.push(Data(b))
+                elems.push(Text(b))
             }
             elems
         },
@@ -266,7 +266,7 @@ fn second_pass_escape(char: char) -> String {
     }
 }
 
-fn second_pass(input: Vec<Element>) -> Vec<Element> {
+fn second_pass(input: Vec<AST>) -> Vec<AST> {
     input
 }
 

--- a/parser/src/or.rs
+++ b/parser/src/or.rs
@@ -1,3 +1,31 @@
+//! Or combinator for the Nom library.
+//!
+//! There is a default or combinator (with method chaining) in the Nom library already, but it
+//! does only work outputs of the same type, such as `char('a').or(char('b'))`, which then
+//! results in a parser returning that same type. This works fine if all parsers handles strings,
+//! however if you want to chain a parser which maps to one type with another parser which maps
+//! to a different type, you will need to make an enum just for that case.
+//!
+//! This file contains functions to combine parsers with .or semantics of different types. The
+//! first parser is attempted to match the input, and if it doesn't match, the second parser is
+//! attempted at matching. The result of the parser is a tuple of `Option`s, one for each parser,
+//! with all of them being `None` but the one matching being `Some` holding the result. If none
+//! of the parsers match, the or combinator fails.
+//!
+//! The functions are called `or{n}` with `n` being the amount of parsers to be combined, currently
+//! implemented from 2 up to 7.
+//!
+//! Example
+//! ```rust,ignore
+//! let num_parser = map(alphanumeric1, |n| usize::from_str(n).unwrap()); // parse int as usize
+//! let abc_parser = is_a("abc"); // parse long string containing "a"s, "b"s and "c"s
+//! let parser = or2(num_parser, abc_parser);
+//! ```
+//! |Input|Output            |
+//! -------------------------|
+//! |"123"|(Some(123), None) |
+//! |"aba"|(None, Some("aba")|
+//! |"eed"|Error             |
 use nom::Parser;
 
 #[allow(dead_code)]

--- a/parser/src/or.rs
+++ b/parser/src/or.rs
@@ -22,7 +22,7 @@
 //! let parser = or2(num_parser, abc_parser);
 //! ```
 //! |Input|Output            |
-//! -------------------------|
+//! |-----|------------------|
 //! |"123"|(Some(123), None) |
 //! |"aba"|(None, Some("aba")|
 //! |"eed"|Error             |

--- a/parser/test.mdm
+++ b/parser/test.mdm
@@ -1,0 +1,1 @@
+[code hej=hej hej]

--- a/parser/tests/compilation_test.rs
+++ b/parser/tests/compilation_test.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use json::{object, JsonValue};
+
+use parser::{parse, Element};
+
+fn split_test(input: &Path) -> datatest_stable::Result<()> {
+    let output = input.with_extension("json");
+
+    // We want to test the input one time with LF line endings and one time with CRLF endings.
+    // For this, we first need to ensure that the input file ends with \n and not \r\n (normalize
+    // it).
+    // For the output file, we don't actually need to care about the line endings, but we want to
+    // care about
+    let input_data = fs::read_to_string(input).unwrap().replace("\r\n", "\n");
+    let output_data = fs::read_to_string(&output)
+        .unwrap_or_else(|_| {
+            panic!(
+                "Input file should have matching output file {}",
+                output.display()
+            )
+        })
+        .replace(r"\r\n", r"\n");
+
+    test_lf(&input_data, &output_data);
+    test_crlf(&input_data, &output_data);
+
+    Ok(())
+}
+
+fn unified_test(input: &Path) -> datatest_stable::Result<()> {
+    let inp = fs::read_to_string(input).unwrap();
+    let lines = inp.lines().collect::<Vec<&str>>();
+    let blocks = lines
+        .split(|l| l.starts_with("```"))
+        .enumerate()
+        .filter_map(|(idx, l)| (idx % 2 == 1).then_some(l))
+        .collect::<Vec<&[&str]>>();
+
+    let input = blocks.get(0).unwrap().join("\n");
+    let output = blocks.get(1).unwrap().join("\n");
+
+    test_lf(&input, &output);
+    test_crlf(&input, &output);
+    Ok(())
+}
+
+fn test_lf(input: &str, output: &str) {
+    let mdm_obj = elem_to_json(&parse(input));
+    let json_obj = json::parse(output).expect("JSON should be parsable");
+
+    // note: we DO NOT want assert_eq here since that would print the mismatched
+    // json IR:s, but the custom error message is much easier to read
+    if mdm_obj != json_obj {
+        panic!(
+            "Failed using LF,\nEXPECTED\n{}\nGOT\n{}",
+            json_obj.pretty(2),
+            mdm_obj.pretty(2),
+        );
+    }
+}
+
+fn test_crlf(input: &str, output: &str) {
+    let mdm_obj = elem_to_json(&parse(&input.replace('\n', "\r\n")));
+    let json_obj = json::parse(&output.replace(r"\n", r"\r\n")).expect("JSON should be parsable");
+
+    // note: we DO NOT want assert_eq here since that would print the mismatched
+    // json IR:s, but the custom error message is much easier to read
+    if mdm_obj != json_obj {
+        panic!(
+            "Failed using CRLF,\nEXPECTED\n{}\nGOT\n{}",
+            json_obj.pretty(2),
+            mdm_obj.pretty(2),
+        );
+    }
+}
+
+fn elem_to_json(elem: &Element) -> JsonValue {
+    match elem {
+        Element::Data(str) => str.as_str().into(),
+        Element::Node {
+            name,
+            environment: _environment,
+            children,
+        } => {
+            object! {
+                name: name.as_str(),
+                children: children.iter().map(elem_to_json).collect::<Vec<JsonValue>>()
+            }
+        }
+        Element::ModuleInvocation {
+            name,
+            args,
+            body,
+            one_line,
+        } => {
+            object! {
+                name: name.as_str(),
+                args: JsonValue::from(args.positioned.clone().unwrap_or_default().iter().enumerate().map(|(a,b)| (a.to_string(),b.to_string())).chain(
+                    args.named.clone().unwrap_or_default().iter().map(|(a,b)| (a.to_string(), b.to_string()))
+                ).collect::<HashMap<String, String>>()),
+                body: body.as_str(),
+                one_line: JsonValue::from(*one_line),
+            }
+        }
+    }
+}
+
+datatest_stable::harness!(
+    split_test,
+    "tests/compilation_tests",
+    r"^.*.mdm$",
+    unified_test,
+    "tests/compilation_tests",
+    r"^.*.mdmtest$"
+);

--- a/parser/tests/compilation_tests/inline_module.mdmtest
+++ b/parser/tests/compilation_tests/inline_module.mdmtest
@@ -1,0 +1,76 @@
+Testing parsing of inline modules with various spacing, and
+inclusion of delimiters and/or args. "yes" are meant to be
+captured, "no" isn't.
+
+Cases below:
+1. Without spaces, take next string
+2. With space, take next string
+3. Should take "\[" as delim, capture "abc", leaving "no"
+4. Should capture "[abc]yes" as string
+5. Should include spaces
+6. Should not stop at single quote
+
+```mdm
+Equations:
+[one]yes no
+[two] yes no
+[tre][abc]no
+[for] [abc]yes
+[fiv]" yes space "
+[six]""yes1 "yes2" yes3""
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Paragraph",
+            "children": [
+                "Equations:\n",
+                {
+                    "name": "one",
+                    "args": {},
+                    "body": "yes",
+                    "one_line": true
+                },
+                " no\n",
+                {
+                    "name": "two",
+                    "args": {},
+                    "body": "yes",
+                    "one_line": true
+                },
+                " no\n",
+                {
+                    "name": "tre",
+                    "args": {},
+                    "body": "abc",
+                    "one_line": true
+                },
+                "no\n",
+                {
+                    "name": "for",
+                    "args": {},
+                    "body": "[abc]yes",
+                    "one_line": true
+                },
+                "\n",
+                {
+                    "name": "fiv",
+                    "args": {},
+                    "body": " yes space ",
+                    "one_line": true
+                },
+                "\n",
+                {
+                    "name": "six",
+                    "args": {},
+                    "body": "yes1 \"yes2\" yes3",
+                    "one_line": true
+                }
+            ]
+        }
+    ]
+}
+```

--- a/parser/tests/compilation_tests/multiple_paragraphs.mdmtest
+++ b/parser/tests/compilation_tests/multiple_paragraphs.mdmtest
@@ -1,0 +1,41 @@
+Testing parsing of two paragraphs.
+Note that some newlines are escaped, while
+some are not. In the second example,
+note that there is a space between the first
+and second line, and the second and
+third line (right behind the backslash),
+while between the third and forth line,
+there isn't a space.
+
+```mdm
+This is the first paragraph \
+of the document. Slashes \
+are used to escape new-\
+lines.
+
+This is the second paragraph.
+Here, escaped newlines are \
+used sometimes, while sometimes
+not
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Paragraph",
+            "children": [
+                "This is the first paragraph of the document. Slashes are used to escape new-lines."
+            ]
+        },
+        
+        {
+            "name": "Paragraph",
+            "children": [
+                "This is the second paragraph.\nHere, escaped newlines are used sometimes, while sometimes\nnot"
+            ]
+        }
+    ]
+}
+```

--- a/parser/tests/compilation_tests/simple_paragraph.json
+++ b/parser/tests/compilation_tests/simple_paragraph.json
@@ -1,0 +1,11 @@
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Paragraph",
+            "children": [
+                "This is a simple paragraph.\nIt should be easy to parse.\nIt contains a couple of hard\nbreaks"
+            ]
+        }
+    ]
+}

--- a/parser/tests/compilation_tests/simple_paragraph.mdm
+++ b/parser/tests/compilation_tests/simple_paragraph.mdm
@@ -1,0 +1,4 @@
+This is a simple paragraph.
+It should be easy to parse.
+It contains a couple of hard
+breaks

--- a/parser/tests/compilation_tests/simple_paragraph.mdmtest
+++ b/parser/tests/compilation_tests/simple_paragraph.mdmtest
@@ -1,0 +1,22 @@
+Testing the parsing of a simple paragraph with some hard breaks
+
+```mdm
+This is a simple paragraph.
+It should be easy to parse.
+It contains a couple of hard
+breaks
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Paragraph",
+            "children": [
+                "This is a simple paragraph.\nIt should be easy to parse.\nIt contains a couple of hard\nbreaks"
+            ]
+        }
+    ]
+}
+```

--- a/parser/tests/parser_tests.rs
+++ b/parser/tests/parser_tests.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+
+use std::path::{PathBuf};
+
+use json::{object, JsonValue};
+
+use parser::{parse, Element};
+
+#[test]
+fn test_a() {
+    let filename = format!(
+        "{}/tests/compilation_tests/simple_paragraph.mdm",
+        env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
+    let lines = fs::read_to_string(filename).unwrap().lines().count();
+    assert_eq!(dbg!(lines), 4);
+
+    let root = dbg!(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let tests = CompilationTest::find_tests_in_folder(&(root.clone() + "/tests/compilation_tests"));
+    tests.iter().for_each(|t| t.run_test());
+
+    test_file("simple_paragraph", &root);
+}
+
+fn test_file(name: &str, root: &str) {
+    let mdm_path = format!("{root}/tests/compilation_tests/{name}.mdm");
+    let mdm_file = fs::read_to_string(mdm_path).unwrap();
+    let json_path = format!("{root}/tests/compilation_tests/{name}.json");
+    let json_file = fs::read_to_string(json_path).unwrap();
+
+    let mdm_obj = elem_to_json(&parse(&mdm_file));
+    let json_obj = json::parse(&json_file).unwrap();
+
+    assert_eq!(mdm_obj, json_obj);
+}
+
+struct CompilationTest {
+    name: String,
+    json_text: String,
+    mdm_lines: Vec<String>,
+}
+
+impl CompilationTest {
+    const MODMARK_FILE_EXT: &'static str = "mdm";
+    const JSON_FILE_EXT: &'static str = "json";
+    const UNIFIED_FILE_EXT: &'static str = "mdmtest";
+
+    fn find_tests_in_folder(path: &str) -> Vec<CompilationTest> {
+        fs::read_dir(path)
+            .unwrap()
+            .map(|f| dbg!(f.unwrap().path()))
+            .filter_map(|p| {
+                if let Some(ext) = p.extension() {
+                    if ext == CompilationTest::MODMARK_FILE_EXT {
+                        Some(CompilationTest::parse_split( p))
+                    } else if ext == CompilationTest::UNIFIED_FILE_EXT {
+                        Some(CompilationTest::parse_unified(p))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn parse_unified(path: PathBuf) -> CompilationTest {
+        let file: Vec<String> = fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .map(|l| l.to_string())
+            .collect();
+
+        let mdm_lines: Vec<String> = file
+            .splitn(2, |x| x == "```mdm" || x == "```modmark")
+            .nth(1)
+            .unwrap()
+            .splitn(2, |x| x == "```")
+            .next()
+            .unwrap()
+            .into();
+
+        let json_text: String = file
+            .splitn(2, |x| x == "```json")
+            .nth(1)
+            .unwrap()
+            .splitn(2, |x| x == "```")
+            .next()
+            .unwrap()
+            .join("\n");
+
+        dbg!(&mdm_lines, &json_text);
+
+        CompilationTest {
+            name: path.file_name().unwrap().to_str().unwrap().to_string(),
+            json_text,
+            mdm_lines,
+        }
+    }
+
+    fn parse_split(path: PathBuf) -> CompilationTest {
+        // path is modmark path
+        let name = path.file_name().unwrap().to_str().unwrap().to_string();
+        let mut path = path;
+        let mdm_lines = fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .map(|l| l.to_string())
+            .collect();
+        path.set_extension(OsString::from(CompilationTest::JSON_FILE_EXT));
+        let json_file = fs::read_to_string(&path).unwrap();
+
+        CompilationTest {
+            name,
+            json_text: json_file,
+            mdm_lines,
+        }
+    }
+
+    fn run_test(&self) {
+        println!("Running test for {}", self.name);
+
+        let json_parse = json::parse(&self.json_text);
+        assert!(
+            json_parse.is_ok(),
+            "Failed to parse json for test {}",
+            self.name
+        );
+        let expected_json = json_parse.unwrap();
+
+        let lf_body = self.mdm_lines.join("\n");
+        let lf_elem = parse(&lf_body);
+        let lf_json = elem_to_json(&lf_elem);
+        assert_eq!(
+            lf_json,
+            expected_json,
+            "Failed for test {} using LF, expected {} got {}",
+            self.name,
+            self.json_text,
+            lf_json.dump()
+        );
+
+        let json_parse = json::parse(&self.json_text.replace("\\n","\\r\\n"));
+        let expected_json = json_parse.unwrap();
+
+        let crlf_body = self.mdm_lines.join("\r\n");
+        let crlf_elem = parse(&crlf_body);
+        let crlf_json = elem_to_json(&crlf_elem);
+        assert_eq!(
+            crlf_json,
+            expected_json,
+            "Failed for test {} using CRLF, expected {} got {}",
+            self.name,
+            self.json_text,
+            crlf_json.dump()
+        );
+    }
+}
+
+fn elem_to_json(elem: &Element) -> JsonValue {
+    match elem {
+        Element::Data(str) => str.as_str().into(),
+        Element::Node {
+            name,
+            environment: _environment,
+            children,
+        } => {
+            object! {
+                name: name.as_str(),
+                children: children.iter().map(elem_to_json).collect::<Vec<JsonValue>>()
+            }
+        }
+        Element::ModuleInvocation {
+            name,
+            args,
+            body,
+            one_line,
+        } => {
+            object! {
+                name: name.as_str(),
+                args: JsonValue::from(args.positioned.clone().unwrap_or_default().iter().enumerate().map(|(a,b)| (a.to_string(),b.to_string())).chain(
+                    args.named.clone().unwrap_or_default().iter().map(|(a,b)| (a.to_string(), b.to_string()))
+                ).collect::<HashMap<String, String>>()),
+                body: body.as_str(),
+                one_line: JsonValue::from(*one_line),
+            }
+        }
+    }
+}

--- a/parser/tests/parser_tests.rs
+++ b/parser/tests/parser_tests.rs
@@ -9,7 +9,8 @@ use json::{object, JsonValue};
 
 use parser::{parse, Element};
 
-#[test]
+//Old runner, don't use, see compilation_test.rs for using datatest-stable runner
+//#[test]
 fn test_a() {
     let filename = format!(
         "{}/tests/compilation_tests/simple_paragraph.mdm",


### PR DESCRIPTION
Resolves: GH-32

Adds error handling for unnamed arguments after named arguments. Right now it just panics if someone uses arguments wrong. But i am up for suggestions if someone has a better idea. The playground still works, the only difference is it does not update if there is a syntax error.

It is only the changes to the lib.rs file that is relevent. All other changes where just for my testing and will not be merged into main.