### PR TITLE
GH-34: Add context inspector + better styling

### DIFF
--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -6,20 +6,62 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap" rel="stylesheet">
     <title>Modmark Playground</title>
     <link rel="stylesheet" href="style.css">
     <script type="module">
-        import init, {parse, raw_tree, transpile, ast} from "./pkg/web_bindings.js";
+        import init, { parse, raw_tree, transpile, inspect_context, ast } from "./pkg/web_bindings.js";
+
+        let view = "editor";
 
         const editor = document.getElementById("editor");
         const output = document.getElementById("output");
         const selector = document.getElementById("selector");
+        const packageView = document.getElementById("package-view");
+        const packageContent = document.getElementById("package-content");
+        const editorView = document.getElementById("editor-view");
+        const viewToggle = document.getElementById("view-toggle");
 
-        // Once we have loaded the wasm module, just bind the parse function
-        // to the editor. Later once we have a runtime/compiler up and running
-        // we will add multiple output options here.
+
+        function buttonContent(text, icon) {
+            return `
+            <span class="material-symbols-outlined">
+                ${icon}
+            </span>
+            ${text}
+            `;
+        }
+
+
+        function toggleView() {
+            console.log("yo");
+            switch (view) {
+                case "editor":
+                    // open the package view
+                    view = "package";
+                    packageView.style.width = "100%";
+                    editorView.style.width = "0";
+                    viewToggle.innerHTML = buttonContent("View editor", "edit");
+                    packageContent.innerText = inspect_context();
+                    selector.setAttribute("disabled", true);
+                    break;
+                case "package":
+                    // close the package view and return to the editor
+                    view = "editor";
+                    packageView.style.width = "0";
+                    editorView.style.width = "100%";
+                    viewToggle.innerHTML = buttonContent("View packages", "widgets");
+                    selector.removeAttribute("disabled");
+                    break;
+            }
+        }
+
+        addEventListener("load", (event) => {
+            viewToggle.onclick = toggleView;
+        });
 
 
         function updateOutput(input) {
@@ -54,22 +96,48 @@
 </head>
 
 <body>
-<div class="menu">
-    <h1>Modmark playground</h1>
-    <select name="selector" id="selector">
-        <option value="ast">Abstract syntax tree</option>
-        <option value="parse">Document tree</option>
-        <option value="raw_tree">Raw tree</option>
-        <option value="transpile">HTML output</option>
-        <option value="render">Rendered HTML</option>
-    </select>
-    <a href="https://github.com/modmark-org/modmark">GitHub repo</a>
-</div>
-<main id="wrapper">
-    <textarea id="editor"></textarea>
-    <div id="output">
-
+    <div class="menu">
+        <div class="menu-items">
+            <div class="left-menu">
+                <h1>Modmark playground</h1>
+                <select name="selector" id="selector">
+                    <option value="ast">Abstract syntax tree</option>
+                    <option value="parse">Document tree</option>
+                    <option value="raw_tree">Raw tree</option>
+                    <option value="transpile">HTML output</option>
+                    <option value="render">Rendered HTML</option>
+                </select>
+                <button id="view-toggle">
+                    <span class="material-symbols-outlined">
+                        widgets
+                    </span>
+                    View packages
+                </button>
+            </div>
+            <a href="https://github.com/modmark-org/modmark">
+                <span class="material-symbols-outlined">
+                    info
+                </span>
+                Github
+            </a>
+        </div>
     </div>
-</main>
+    <main id="wrapper">
+        <div id="editor-view">
+            <textarea id="editor"></textarea>
+            <div id="output"> </div>
+        </div>
+        <div id="package-view">
+            <div id="packages">
+                <h2>Packages</h2>
+                <div class="note">Note: this will be made a lot easier to use once we
+                    have a more stable package API.
+                </div>
+                <pre id="package-content">
+                </pre>
+            </div>
+        </div>
+    </main>
 </body>
+
 </html>

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -4,32 +4,101 @@ body {
     font-family: 'IBM Plex Mono', monospace;
 }
 
+.material-symbols-outlined {
+    position: relative;
+    font-variation-settings:
+        'FILL' 0,
+        'wght' 400,
+        'GRAD' 0,
+        'opsz' 48;
+    font-size: 1rem;
+    top: 1px;
+}
+
+a {
+    font-size: 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    text-decoration: none;
+    color: black;
+    transition: 0.3s background-color;
+    box-sizing: border-box;
+    padding: 0.5rem;
+    border-radius: 0.3rem;
+}
+
+a:hover {
+    background-color: rgb(222, 222, 222);
+}
+
+
 pre,
 textarea {
     font-family: 'IBM Plex Mono', monospace;
 }
 
+button,
+select {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    border: none;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.501);
+    border-radius: 0.3rem;
+    padding: 0.5rem 1rem 0.5rem 1rem;
+    background: rgb(231, 231, 231);
+    transition: 0.2s background;
+}
+
+button:hover,
+select:hover {
+    background: rgb(222, 222, 222);
+}
+
 .menu {
+    background: #f3f4f6;
+    box-shadow: 0 0px 2px rgba(0, 0, 0, 0.353);
     position: relative;
     margin: 0;
     height: 4rem;
     width: 100%;
-    display: flex;
-    align-items: center;
     padding: 1rem;
     box-sizing: border-box;
-    gap: 2rem;
+    overflow-y: scroll;
+}
+
+.menu-items {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.left-menu {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
 }
 
 .menu h1 {
     margin: 0;
-    font-size: 1.5rem;
+    font-size: 1.3rem;
 }
 
 #wrapper {
     width: 100%;
     display: flex;
     height: calc(100vh - 4rem);
+}
+
+#editor-view {
+    width: 100%;
+    display: flex;
+    overflow-x: hidden;
+    transition: 0.3s width;
 }
 
 #output,
@@ -40,8 +109,55 @@ textarea {
     overflow: auto;
     margin: 0;
     padding: 1rem;
+    border: none;
+    transition: 0.3s width;
 }
 
 #output {
-    background: rgb(228, 228, 228);
+    background: rgb(242, 242, 242);
+}
+
+#package-view {
+    width: 0;
+    overflow-x: hidden;
+    box-sizing: border-box;
+    transition: 0.3s width;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.16);
+}
+
+#packages {
+    max-width: 60rem;
+    box-sizing: border-box;
+    padding: 1rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#packages h2 {
+    margin-bottom: 0.5rem;
+}
+
+.note {
+    opacity: 0.6;
+    max-width: 30rem;
+}
+
+@media only screen and (max-width: 800px) {
+    #editor-view {
+        height: auto;
+        flex-direction: column;
+    }
+
+    #editor,
+    #output {
+        height: auto;
+        height: calc((100vh - 4rem)/2);
+        width: 100%;
+    }
+
+    .menu-items {
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
 }

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -65,7 +65,8 @@ select:hover {
     width: 100%;
     padding: 1rem;
     box-sizing: border-box;
-    overflow-y: scroll;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .menu-items {

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -16,4 +16,4 @@ wasm-bindgen = "0.2.63"
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.6" }

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -59,6 +59,5 @@ pub fn set_panic_hook() {
     //
     // For more details see
     // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
This PR resolves GH-34 by adding an extra tab where the context (and the packages) can be inspected (see screen-shot).

The styling of the playground is also improved by adding nicer buttons, a better layout for phone sized screens and a few icons here and there.

![image](https://user-images.githubusercontent.com/11508459/218434985-b386f971-42a2-438d-b4a9-6e3186b6f7e3.png)
