### PR TITLE
GH-32: Add error checking for unnamed arguments after named arguments

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,7 +42,7 @@ fn print_tree(tree: parser::Element) {
 
 fn compile_file(args: &Args) -> Result<Element, CliError> {
     let source = fs::read_to_string(&args.input)?;
-    let document = parse(&source);
+    let document = parse(&source).unwrap();
 
     let mut ctx = Context::default();
     let output = eval(&document, &mut ctx);

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 nom = "7.1.3"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 json = "0.12.4"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -479,9 +479,9 @@ fn pretty_ast(ast: &Ast) -> Vec<String> {
             args,
             body,
             one_line,
-        }) => match args {
-            MaybeArgs::ModuleArguments(arguments) => {
-                let args = {
+        }) => {
+            let args = match args {
+                MaybeArgs::ModuleArguments(arguments) => {
                     let p1 = &arguments.positioned;
                     let p2 = arguments.named.as_ref().map(|args| {
                         args.iter()
@@ -492,24 +492,22 @@ fn pretty_ast(ast: &Ast) -> Vec<String> {
                     let mut args_vec = p1.clone().unwrap_or_default();
                     args_vec.extend_from_slice(&p2.unwrap_or_default());
                     args_vec.join(", ")
-                };
-                if *one_line {
-                    strs.push(format!("{name}({args}){{{body}}}"));
-                } else {
-                    strs.push(format!("{name}({args}){{"));
-                    body.lines().enumerate().for_each(|(idx, line)| {
-                        strs.push(format!(
-                            "{indent}{} {line}",
-                            if idx == 0 { '>' } else { '|' }
-                        ))
-                    });
-                    strs.push("} [multiline invocation]".to_string());
                 }
-            }
-            MaybeArgs::Error(err) => {
-                panic!("{}", err)
-            }
-        },
+                MaybeArgs::Error(_) => "ERR".to_string(),
+            };
+            if *one_line {
+                strs.push(format!("{name}({args}){{{body}}}"));
+            } else {
+                strs.push(format!("{name}({args}){{"));
+                body.lines().enumerate().for_each(|(idx, line)| {
+                    strs.push(format!(
+                        "{indent}{} {line}",
+                        if idx == 0 { '>' } else { '|' }
+                    ))
+                });
+                strs.push("} [multiline invocation]".to_string());
+            };
+        }
     }
 
     strs

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -9,6 +9,8 @@ use nom::multi::{fold_many1, many0, many1, separated_list0};
 use nom::sequence::{preceded, terminated};
 use nom::{combinator::*, Finish, IResult, Parser};
 
+use thiserror::Error;
+
 use Element::Node;
 
 use crate::tag::CompoundAST;
@@ -66,8 +68,9 @@ pub enum Ast {
     Module(Module),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Error)]
 pub enum ParseError {
+    #[error("Unnamed argument after named argument")]
     ArgumentOrderError,
 }
 
@@ -202,8 +205,8 @@ impl Element {
 /// * `source`: The source text to parse
 ///
 /// returns: Element The parsed element
-pub fn parse(source: &str) -> Element{
-    parse_to_ast(source).try_into().unwrap()
+pub fn parse(source: &str) -> Result<Element, ParseError>{
+    parse_to_ast(source).try_into()
 }
 
 pub fn parse_to_ast(source: &str) -> Ast {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -105,16 +105,15 @@ impl From<Ast> for Element {
                 environment: HashMap::new(),
                 children: tag.elements.into_iter().map(|e| e.into()).collect(),
             },
-            Ast::Module(module) => {
-                match module.args {
-                    MaybeArgs::ModuleArguments(args) => ModuleInvocation {
-                        name: module.name,
-                        args,
-                        body: module.body,
-                        one_line: module.one_line,
-                    },
-                    MaybeArgs::Error(error) => panic!("{}", error),
-                }},
+            Ast::Module(module) => match module.args {
+                MaybeArgs::ModuleArguments(args) => ModuleInvocation {
+                    name: module.name,
+                    args,
+                    body: module.body,
+                    one_line: module.one_line,
+                },
+                MaybeArgs::Error(error) => panic!("{}", error),
+            },
         }
     }
 }
@@ -466,41 +465,38 @@ fn pretty_ast(ast: &Ast) -> Vec<String> {
             args,
             body,
             one_line,
-        }) => {
-            match args {
-                MaybeArgs::ModuleArguments(arguments) => {
-                    let args = {
-                        let p1 = &arguments.positioned;
-                        let p2 = arguments.named.as_ref().map(|args| {
-                            args.iter()
-                                .map(|(k, v)| format!("{k}={v}"))
-                                .collect::<Vec<String>>()
-                        });
-        
-                        let mut args_vec = p1.clone().unwrap_or_default();
-                        args_vec.extend_from_slice(&p2.unwrap_or_default());
-                        args_vec.join(", ")
-                    };
-                    if *one_line {
-                        strs.push(format!("{name}({args}){{{body}}}"));
-                    } else {
-                        strs.push(format!("{name}({args}){{"));
-                        body.lines().enumerate().for_each(|(idx, line)| {
-                            strs.push(format!(
-                                "{indent}{} {line}",
-                                if idx == 0 { '>' } else { '|' }
-                            ))
-                        });
-                        strs.push("} [multiline invocation]".to_string());
-                    }
-                }
-                MaybeArgs::Error(err) => {
-                    panic!("{}", err)
-                    }
-            }
-            }
-        }
+        }) => match args {
+            MaybeArgs::ModuleArguments(arguments) => {
+                let args = {
+                    let p1 = &arguments.positioned;
+                    let p2 = arguments.named.as_ref().map(|args| {
+                        args.iter()
+                            .map(|(k, v)| format!("{k}={v}"))
+                            .collect::<Vec<String>>()
+                    });
 
+                    let mut args_vec = p1.clone().unwrap_or_default();
+                    args_vec.extend_from_slice(&p2.unwrap_or_default());
+                    args_vec.join(", ")
+                };
+                if *one_line {
+                    strs.push(format!("{name}({args}){{{body}}}"));
+                } else {
+                    strs.push(format!("{name}({args}){{"));
+                    body.lines().enumerate().for_each(|(idx, line)| {
+                        strs.push(format!(
+                            "{indent}{} {line}",
+                            if idx == 0 { '>' } else { '|' }
+                        ))
+                    });
+                    strs.push("} [multiline invocation]".to_string());
+                }
+            }
+            MaybeArgs::Error(err) => {
+                panic!("{}", err)
+            }
+        },
+    }
 
     strs
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -44,7 +44,7 @@ pub struct ModuleArguments {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MaybeArgs {
     ModuleArguments(ModuleArguments),
-    Error(String),
+    Error(ParseError),
 }
 
 impl Default for MaybeArgs {
@@ -64,6 +64,11 @@ pub enum Ast {
     Paragraph(Paragraph),
     Tag(Tag),
     Module(Module),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParseError {
+    ArgumentOrderError,
 }
 
 impl Ast {
@@ -87,7 +92,7 @@ impl Ast {
 }
 
 impl TryFrom<Ast> for Element {
-    type Error = String;
+    type Error = ParseError;
 
     fn try_from(value: Ast) -> Result<Self, Self::Error> {
         match value {
@@ -99,7 +104,7 @@ impl TryFrom<Ast> for Element {
                     .elements
                     .into_iter()
                     .map(|e| e.try_into())
-                    .collect::<Result<Vec<Element>, String>>()?,
+                    .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Paragraph(paragraph) => Ok(Node {
                 name: "Paragraph".to_string(),
@@ -108,7 +113,7 @@ impl TryFrom<Ast> for Element {
                     .elements
                     .into_iter()
                     .map(|e| e.try_into())
-                    .collect::<Result<Vec<Element>, String>>()?,
+                    .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Tag(tag) => Ok(Node {
                 name: tag.tag_name,
@@ -117,7 +122,7 @@ impl TryFrom<Ast> for Element {
                     .elements
                     .into_iter()
                     .map(|e| e.try_into())
-                    .collect::<Result<Vec<Element>, String>>()?,
+                    .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Module(module) => match module.args {
                 MaybeArgs::ModuleArguments(args) => Ok(ModuleInvocation {
@@ -197,7 +202,7 @@ impl Element {
 /// * `source`: The source text to parse
 ///
 /// returns: Element The parsed element
-pub fn parse(source: &str) -> Element {
+pub fn parse(source: &str) -> Element{
     parse_to_ast(source).try_into().unwrap()
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -205,7 +205,7 @@ impl Element {
 /// * `source`: The source text to parse
 ///
 /// returns: Element The parsed element
-pub fn parse(source: &str) -> Result<Element, ParseError>{
+pub fn parse(source: &str) -> Result<Element, ParseError> {
     parse_to_ast(source).try_into()
 }
 

--- a/parser/src/module.rs
+++ b/parser/src/module.rs
@@ -302,7 +302,7 @@ fn get_module_args_parser<'a>(inline: bool) -> impl Parser<&'a str, MaybeArgs, E
                 ),
                 |(unnamed, named)| {
                     MaybeArgs::ModuleArguments(ModuleArguments {
-                        positioned: Some({ unnamed }),
+                        positioned: Some(unnamed),
                         named: Some(named.into_iter().collect()),
                     })
                 },
@@ -314,7 +314,7 @@ fn get_module_args_parser<'a>(inline: bool) -> impl Parser<&'a str, MaybeArgs, E
                 ),
                 |unnamed| {
                     MaybeArgs::ModuleArguments(ModuleArguments {
-                        positioned: Some({ unnamed }),
+                        positioned: Some(unnamed),
                         named: None,
                     })
                 },
@@ -327,7 +327,7 @@ fn get_module_args_parser<'a>(inline: bool) -> impl Parser<&'a str, MaybeArgs, E
                 |named| {
                     MaybeArgs::ModuleArguments(ModuleArguments {
                         positioned: None,
-                        named: Some({ named.into_iter().collect() }),
+                        named: Some(named.into_iter().collect()),
                     })
                 },
             ),

--- a/parser/src/module.rs
+++ b/parser/src/module.rs
@@ -289,7 +289,7 @@ fn get_module_args_parser<'a>(
                     ),
 
                 )), 
-                |tuple| MaybeArgs::Error("Unnamed arguments after Named Arguments".to_string()),
+                |_tuple| MaybeArgs::Error("Unnamed arguments after Named Arguments".to_string()),
             ),
             map(
                 separated_pair(

--- a/parser/src/module.rs
+++ b/parser/src/module.rs
@@ -1,13 +1,13 @@
 //! This module provides the function the Parser needs to parse modules. It exposes two functions;
 //! [parse_inline_module] and [parse_multiline_module], which parses inline modules and multiline
 //! modules respectively.
-use crate::{Module, ModuleArguments, MaybeArgs};
+use crate::{MaybeArgs, Module, ModuleArguments};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take, take_till, take_until, take_until1, take_while1};
 use nom::character::complete::{char, line_ending, multispace0, multispace1, space0, space1};
 use nom::combinator::{fail, flat_map, map, not, opt, peek, rest, verify};
 use nom::error::Error;
-use nom::multi::{separated_list1, separated_list0, many0};
+use nom::multi::{many0, separated_list0, separated_list1};
 use nom::sequence::{delimited, pair, preceded, separated_pair, terminated, tuple};
 use nom::{FindSubstring, IResult, InputTake, Parser};
 
@@ -266,9 +266,7 @@ fn parse_module_name(input: &str) -> IResult<&str, &str> {
 ///
 /// returns: impl Parser<&str, ModuleArguments, Error<&str>>+Sized
 ///
-fn get_module_args_parser<'a>(
-    inline: bool,
-) -> impl Parser<&'a str, MaybeArgs, Error<&'a str>> {
+fn get_module_args_parser<'a>(inline: bool) -> impl Parser<&'a str, MaybeArgs, Error<&'a str>> {
     map(
         opt(alt((
             map(
@@ -287,8 +285,7 @@ fn get_module_args_parser<'a>(
                         get_arg_separator_parser(inline),
                         get_unnamed_arg_parser(inline),
                     ),
-
-                )), 
+                )),
                 |_tuple| MaybeArgs::Error("Unnamed arguments after Named Arguments".to_string()),
             ),
             map(
@@ -303,35 +300,37 @@ fn get_module_args_parser<'a>(
                         get_named_arg_parser(inline),
                     ),
                 ),
-                |(unnamed, named)| MaybeArgs::ModuleArguments(ModuleArguments {
-                    positioned: Some({
-                        unnamed
-                    }),
-                    named: Some(named.into_iter().collect()),
-                },),
+                |(unnamed, named)| {
+                    MaybeArgs::ModuleArguments(ModuleArguments {
+                        positioned: Some({ unnamed }),
+                        named: Some(named.into_iter().collect()),
+                    })
+                },
             ),
             map(
                 separated_list1(
                     get_arg_separator_parser(inline),
                     get_unnamed_arg_parser(inline),
                 ),
-                |unnamed| MaybeArgs::ModuleArguments(ModuleArguments {
-                    positioned: Some({
-                        unnamed}),
-                    named: None,
-                },),
+                |unnamed| {
+                    MaybeArgs::ModuleArguments(ModuleArguments {
+                        positioned: Some({ unnamed }),
+                        named: None,
+                    })
+                },
             ),
             map(
                 separated_list1(
                     get_arg_separator_parser(inline),
                     get_named_arg_parser(inline),
                 ),
-                |named| MaybeArgs::ModuleArguments(ModuleArguments {
-                    positioned: None,
-                    named: Some({
-                        named.into_iter().collect()}),
+                |named| {
+                    MaybeArgs::ModuleArguments(ModuleArguments {
+                        positioned: None,
+                        named: Some({ named.into_iter().collect() }),
+                    })
                 },
-            ),),
+            ),
         ))),
         |x| x.unwrap_or_default(),
     )

--- a/parser/tests/compilation_test.rs
+++ b/parser/tests/compilation_test.rs
@@ -125,23 +125,21 @@ fn ast_to_json(ast: &Ast) -> JsonValue {
                 children: t.elements.iter().map(ast_to_json).collect::<Vec<JsonValue>>()
             }
         }
-        Ast::Module(m) => {
-            match &m.args {
-                MaybeArgs::Error(err) => {
-                    panic!("Error in module args: {}", err)
-                },
-                MaybeArgs::ModuleArguments(args) => {
-                    object! {
-                        name: m.name.as_str(),
-                        args: JsonValue::from(args.positioned.clone().unwrap_or_default().iter().enumerate().map(|(a,b)| (a.to_string(),b.to_string())).chain(
-                            args.named.clone().unwrap_or_default().iter().map(|(a,b)| (a.to_string(), b.to_string()))
-                        ).collect::<HashMap<String, String>>()),
-                        body: m.body.as_str(),
-                        one_line: JsonValue::from(m.one_line),
-                    }
+        Ast::Module(m) => match &m.args {
+            MaybeArgs::Error(err) => {
+                panic!("Error in module args: {}", err)
+            }
+            MaybeArgs::ModuleArguments(args) => {
+                object! {
+                    name: m.name.as_str(),
+                    args: JsonValue::from(args.positioned.clone().unwrap_or_default().iter().enumerate().map(|(a,b)| (a.to_string(),b.to_string())).chain(
+                        args.named.clone().unwrap_or_default().iter().map(|(a,b)| (a.to_string(), b.to_string()))
+                    ).collect::<HashMap<String, String>>()),
+                    body: m.body.as_str(),
+                    one_line: JsonValue::from(m.one_line),
                 }
             }
-        }
+        },
     }
 }
 

--- a/parser/tests/compilation_test.rs
+++ b/parser/tests/compilation_test.rs
@@ -128,7 +128,6 @@ fn ast_to_json(ast: &Ast) -> JsonValue {
     }
 }
 
-
 datatest_stable::harness!(
     split_test,
     "tests/compilation_tests",

--- a/parser/tests/compilation_test.rs
+++ b/parser/tests/compilation_test.rs
@@ -141,7 +141,6 @@ fn ast_to_json(ast: &Ast) -> JsonValue {
                     }
                 }
             }
-            
         }
     }
 }

--- a/parser/tests/compilation_tests/invalid_module_invocation.mdmtest
+++ b/parser/tests/compilation_tests/invalid_module_invocation.mdmtest
@@ -1,0 +1,30 @@
+Testing parsing of modules with only named arguments
+
+```mdm
+[code lang=py indent=tabs missplacedArgument]
+print("hello world")
+
+[code py indent=tabs missplacedArgument]
+print("hello world")
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "code",
+      "args": "Unnamed argument after named argument",
+      "body": "print(\"hello world\")",
+      "one_line": false
+    },
+    {
+      "name": "code",
+      "args": "Unnamed argument after named argument",
+      "body": "print(\"hello world\")",
+      "one_line": false
+    }
+  ]
+}
+```
+

--- a/parser/tests/compilation_tests/invocation_with_named_arguments.mdmtest
+++ b/parser/tests/compilation_tests/invocation_with_named_arguments.mdmtest
@@ -1,0 +1,24 @@
+Testing parsing of modules with only named arguments
+
+```mdm
+[code lang=py indent=tabs]
+print("hello world")
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+        "name": "code",
+        "args": {
+            "lang": "py",
+            "indent": "tabs"
+        },
+        "body": "print(\"hello world\")",
+        "one_line": false
+    }
+  ]
+}
+```
+

--- a/parser/tests/compilation_tests/invocation_with_unnamed_arguments.mdmtest
+++ b/parser/tests/compilation_tests/invocation_with_unnamed_arguments.mdmtest
@@ -1,0 +1,23 @@
+Testing parsing of modules with only unnamed arguments
+
+```mdm
+[code py tabs]
+print("hello world")
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+        "name": "code",
+        "args": {
+            "0": "py",
+            "1": "tabs"
+        },
+        "body": "print(\"hello world\")",
+        "one_line": false
+    }
+  ]
+}
+```

--- a/parser/tests/compilation_tests/invocation_with_unnamed_then_named.mdmtest
+++ b/parser/tests/compilation_tests/invocation_with_unnamed_then_named.mdmtest
@@ -1,0 +1,23 @@
+Testing the parsing of modules with unnamed then named
+
+```mdm
+[code py indent=tabs]
+print("hello world")
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "code",
+      "args": {
+        "indent": "tabs",
+        "0": "py"
+      },
+      "body": "print(\"hello world\")",
+      "one_line": false
+    }
+  ]
+}
+```

--- a/parser/tests/compilation_tests/invocation_without_arguments.mdmtest
+++ b/parser/tests/compilation_tests/invocation_without_arguments.mdmtest
@@ -1,0 +1,19 @@
+Testing the parsing of modules without arguments
+```mdm
+[code]
+print("hello world")
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "code",
+      "args": {},
+      "body": "print(\"hello world\")",
+      "one_line": false
+    }
+  ]
+}
+```


### PR DESCRIPTION
Resolves: GH-32

Adds the enum MaybeArgs instead of Modulearguments to be able to handle when no valid arguments exists.