### PR TITLE
GH-44: Add headings

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -138,11 +138,15 @@ impl TryFrom<Ast> for Element {
                 }),
                 MaybeArgs::Error(error) => Err(error),
             },
-            Ast::Heading(heading) => Node {
+            Ast::Heading(heading) => Ok(Node {
                 name: format!("Heading{}", heading.level),
                 environment: HashMap::new(),
-                children: heading.elements.into_iter().map(|e| e.into()).collect(),
-            },
+                children: heading
+                    .elements
+                    .into_iter()
+                    .map(|e| e.try_into())
+                    .collect::<Result<Vec<Element>, ParseError>>()?,
+            }),
         }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -177,7 +177,7 @@ pub struct Module {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Heading {
-    pub level: usize,
+    pub level: u8,
     pub elements: Vec<Ast>,
 }
 
@@ -295,11 +295,13 @@ fn parse_document_blocks(input: &str) -> IResult<&str, Vec<Ast>> {
 fn parse_heading(input: &str) -> IResult<&str, Heading> {
     map(
         pair(
-            verify(take_while1(|c| c == '#'), |s: &str| s.len() <= 6),
+            verify(take_while1(|c| c == '#'), |s: &str| {
+                s.len() <= u8::MAX as usize
+            }),
             preceded(space0, parse_heading_text),
         ),
         |(start, body)| Heading {
-            level: start.len(),
+            level: start.len() as u8,
             elements: tag::extract_tags(vec![Text(body.into())]),
         },
     )(input)

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -291,7 +291,7 @@ fn parse_document_blocks(input: &str) -> IResult<&str, Vec<Ast>> {
 fn parse_heading(input: &str) -> IResult<&str, Heading> {
     map(
         pair(
-            verify(take_while1(|c: char| c.eq(&'#')), |s: &str| s.len() <= 6),
+            verify(take_while1(|c| c == '#'), |s: &str| s.len() <= 6),
             preceded(space0, parse_heading_text),
         ),
         |(start, body)| Heading {
@@ -309,7 +309,7 @@ fn parse_heading(input: &str) -> IResult<&str, Heading> {
 ///
 /// returns: The parsed text, if a successful parse occurs, otherwise the parse error
 fn parse_heading_text(input: &str) -> IResult<&str, &str> {
-    take_till(|c: char| c.eq(&'\r') || c.eq(&'\n'))(input)
+    take_till(|c| c == '\r' || c == '\n')(input)
 }
 
 /// Parses a paragraph which consists of multiple paragraph elements, and puts all those into a

--- a/parser/tests/compilation_test.rs
+++ b/parser/tests/compilation_test.rs
@@ -125,6 +125,12 @@ fn ast_to_json(ast: &Ast) -> JsonValue {
                 }
             }
         },
+        Ast::Heading(h) => {
+            object! {
+                name: format!("Heading{}", h.level).as_str(),
+                children: h.elements.iter().map(ast_to_json).collect::<Vec<JsonValue>>()
+            }
+        }
     }
 }
 

--- a/parser/tests/compilation_tests/heading_levels.mdmtest
+++ b/parser/tests/compilation_tests/heading_levels.mdmtest
@@ -8,7 +8,7 @@ is not allowed and should therefore be parsed as a paragraph.
 
 ### Level 3
 
-####### paragraph text
+########## Level 10
 ```
 
 ```json
@@ -34,9 +34,9 @@ is not allowed and should therefore be parsed as a paragraph.
             ]
         },
         {
-            "name": "Paragraph",
+            "name": "Heading10",
             "children": [
-                "####### paragraph text"
+                "Level 10"
             ]
         }
     ]

--- a/parser/tests/compilation_tests/heading_levels.mdmtest
+++ b/parser/tests/compilation_tests/heading_levels.mdmtest
@@ -1,4 +1,4 @@
-Testing headings of different levels. Seven consecutive hashtags
+Tests headings of different levels. Seven consecutive hashtags
 is not allowed and should therefore be parsed as a paragraph.
 
 ```mdm

--- a/parser/tests/compilation_tests/heading_levels.mdmtest
+++ b/parser/tests/compilation_tests/heading_levels.mdmtest
@@ -1,0 +1,44 @@
+Testing headings of different levels. Seven consecutive hashtags
+is not allowed and should therefore be parsed as a paragraph.
+
+```mdm
+# Level 1
+
+## Level 2
+
+### Level 3
+
+####### paragraph text
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Heading1",
+            "children": [
+                "Level 1"
+            ]
+        },
+        {
+            "name": "Heading2",
+            "children": [
+                "Level 2"
+            ]
+        },
+        {
+            "name": "Heading3",
+            "children": [
+                "Level 3"
+            ]
+        },
+        {
+            "name": "Paragraph",
+            "children": [
+                "####### paragraph text"
+            ]
+        }
+    ]
+}
+```

--- a/parser/tests/compilation_tests/headings_and_paragraphs.mdmtest
+++ b/parser/tests/compilation_tests/headings_and_paragraphs.mdmtest
@@ -1,0 +1,55 @@
+Testing headings of different levels. Seven consecutive hashtags
+is not allowed and should therefore be parsed as a paragraph.
+
+```mdm
+This is a paragraph.
+# and this is part of the paragraph
+instead of a heading.
+
+# Heading
+Using headings and paragraphs like
+this is allowed.
+
+# Headings work in the same manner with modules
+[module]
+This actually creates a multiline invocation
+of the module.
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Paragraph",
+            "children": [
+                "This is a paragraph.\n# and this is part of the paragraph\ninstead of a heading."
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                "Heading"
+            ]
+        },
+        {
+            "name": "Paragraph",
+            "children": [
+                "Using headings and paragraphs like\nthis is allowed."
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                "Headings work in the same manner with modules"
+            ]
+        },
+        {
+            "name": "module",
+            "args": {},
+            "body": "This actually creates a multiline invocation\nof the module.",
+            "one_line": false
+        }
+    ]
+}
+```

--- a/parser/tests/compilation_tests/headings_in_blocks.mdmtest
+++ b/parser/tests/compilation_tests/headings_in_blocks.mdmtest
@@ -1,5 +1,4 @@
-Testing headings of different levels. Seven consecutive hashtags
-is not allowed and should therefore be parsed as a paragraph.
+Tests behaviour of parser when combining headings, paragraphs and modules
 
 ```mdm
 This is a paragraph.
@@ -7,8 +6,7 @@ This is a paragraph.
 instead of a heading.
 
 # Heading
-Using headings and paragraphs like
-this is allowed.
+Using headings and paragraphs like this works.
 
 # Headings work in the same manner with modules
 [module]
@@ -35,7 +33,7 @@ of the module.
         {
             "name": "Paragraph",
             "children": [
-                "Using headings and paragraphs like\nthis is allowed."
+                "Using headings and paragraphs like this works."
             ]
         },
         {

--- a/parser/tests/compilation_tests/headings_with_tags.mdmtest
+++ b/parser/tests/compilation_tests/headings_with_tags.mdmtest
@@ -1,0 +1,86 @@
+Tests headings with tags such as **bold**.
+The test also includes cases with nested tags,
+and one with an inline module (which shouldn't
+be parsed as a module).
+
+```mdm
+# nnn **bbb** nnn
+
+# // italic text //
+
+# // italic
+text //
+
+# **bbbb //ibib// bbbb** nnnn
+
+# title [math]{x^2}
+```
+
+```json
+{
+    "name": "Document",
+    "children": [
+        {
+            "name": "Heading1",
+            "children": [
+                "nnn ",
+                {
+                    "name": "Bold",
+                    "children": [
+                        "bbb"
+                    ]
+                },
+                " nnn"
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                {
+                    "name": "Italic",
+                    "children": [
+                        " italic text "
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                "// italic"
+            ]
+        },
+        {
+            "name": "Paragraph",
+            "children": [
+                "text //"
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                {
+                    "name": "Bold",
+                    "children": [
+                        "bbbb ",
+                        {
+                            "name": "Italic",
+                            "children": [
+                                "ibib"
+                            ]
+                        },
+                        " bbbb"
+                    ]
+                },
+                " nnnn"
+            ]
+        },
+        {
+            "name": "Heading1",
+            "children": [
+                "title [math]{x^2}"
+            ]
+        }
+    ]
+}
+```


### PR DESCRIPTION
Resolves: #44 

Adds headings in the parser. This allows syntax like ``# Title`` to be parsed as a "Heading1" node.