### PR TITLE
Fix deployment and clean up error handling

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -99,7 +99,7 @@ impl TryFrom<Ast> for Element {
 
     fn try_from(value: Ast) -> Result<Self, Self::Error> {
         match value {
-            Ast::Text(s) => Ok(Data(s)),
+            Text(s) => Ok(Data(s)),
             Ast::Document(doc) => Ok(Node {
                 name: "Document".to_string(),
                 environment: HashMap::new(),
@@ -225,11 +225,9 @@ pub fn parse_to_ast_document(source: &str) -> Document {
     parse_document(source)
         .finish()
         .map(|(_, x)| x)
-        .map_err(|e| dbg!(e))
         .unwrap_or_else(|e: Error<&str>| Document {
             elements: vec![
-                Text("Document failed to parse".to_string()),
-                Text(format!("Error: {e}")),
+                Text(format!("A nom error occurred when parsing the document\nError: {e}"))
             ],
         })
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -226,9 +226,9 @@ pub fn parse_to_ast_document(source: &str) -> Document {
         .finish()
         .map(|(_, x)| x)
         .unwrap_or_else(|e: Error<&str>| Document {
-            elements: vec![
-                Text(format!("A nom error occurred when parsing the document\nError: {e}"))
-            ],
+            elements: vec![Text(format!(
+                "A nom error occurred when parsing the document\nError: {e}"
+            ))],
         })
 }
 

--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -13,7 +13,7 @@
     <title>Modmark Playground</title>
     <link rel="stylesheet" href="style.css">
     <script type="module">
-        import init, { parse, raw_tree, transpile, inspect_context, ast } from "./pkg/web_bindings.js";
+        import init, {transpile, inspect_context, ast } from "./pkg/web_bindings.js";
 
         let view = "editor";
 
@@ -70,12 +70,6 @@
                 case "ast":
                     pre.innerText = ast(input)
                     break;
-                case "parse":
-                    pre.innerText = parse(input)
-                    break;
-                case "raw_tree":
-                    pre.innerText = raw_tree(input)
-                    break;
                 case "transpile":
                     pre.innerText = transpile(input);
                     break;
@@ -102,8 +96,6 @@
                 <h1>Modmark playground</h1>
                 <select name="selector" id="selector">
                     <option value="ast">Abstract syntax tree</option>
-                    <option value="parse">Document tree</option>
-                    <option value="raw_tree">Raw tree</option>
                     <option value="transpile">HTML output</option>
                     <option value="render">Rendered HTML</option>
                 </select>

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -7,13 +7,6 @@ thread_local! {
 }
 
 #[wasm_bindgen]
-pub fn parse(source: &str) -> String {
-    set_panic_hook();
-    let document = parser::parse(source);
-    document.tree_string(true)
-}
-
-#[wasm_bindgen]
 pub fn ast(source: &str) -> String {
     set_panic_hook();
     let document = parser::parse_to_ast(source);
@@ -21,15 +14,8 @@ pub fn ast(source: &str) -> String {
 }
 
 #[wasm_bindgen]
-pub fn raw_tree(source: &str) -> String {
-    set_panic_hook();
-    let document = parser::parse(source);
-    format!("{document:#?}")
-}
-
-#[wasm_bindgen]
 pub fn transpile(source: &str) -> String {
-    let document = parser::parse(source);
+    let document = parser::parse(source).unwrap();
     let mut result = String::new();
 
     CONTEXT.with(|ctx| {


### PR DESCRIPTION
This is a small increment to #50 and does the following:
 1. Clarify the error message that appears on Nom errors (which normally shouldn't appear at all, but must be handled anyways)
 2. Removes `Element` views from the playground; they aren't that useful and is a struggle to maintain. The `Ast` view may represent the same data as the `Element` does and more. The `Ast` view may show errors while the `Element` would fail and need a fall-back or force-unwrapping which are both bad

Resolves GH-32