### PR TITLE
GH-66: Do not build pages when pull request is closed

### DIFF
--- a/.github/workflows/DeployPreview.yml
+++ b/.github/workflows/DeployPreview.yml
@@ -36,24 +36,32 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Setup output directory
+        if: github.event.action != 'closed'
         run: mkdir build
       - name: Install toolchain (minimal, stable, wasm32-unknown-unknown + wasm32-wasi)
+        if: github.event.action != 'closed'
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, wasm32-wasi
       - name: Install wasm-pack
+        if: github.event.action != 'closed'
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Make build script executable
+        if: github.event.action != 'closed'
         run: chmod +x ./build-playground.sh
       - name: Build Playground
+        if: github.event.action != 'closed'
         run: ./build-playground.sh
       - name: Remove auto-generated .gitignore
+        if: github.event.action != 'closed'
         run: rm build/pkg/.gitignore
       - name: Copy deployment files
+        if: github.event.action != 'closed'
         run: |
           mkdir site-deploy
           cp -r build/* site-deploy
       - name: Print generated files
+        if: github.event.action != 'closed'
         run: ls -R site-deploy
       - name: Deploy Playground preview
         uses: rossjrw/pr-preview-action@v1


### PR DESCRIPTION
This PR changes `DeployPreview.yml` to not build the page if the pull request is closed. It is still important that the workflow runs, since it needs to do that to remove the preview playground page when the PR is closed.