### PR TITLE
Add smart punctuation

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -399,69 +399,88 @@ fn smart_punctuate<T>(input: &mut T)
 where
     T: CompoundAST,
 {
-    let mut sgl_open = false;
-    let mut dbl_open = false;
+    let mut backtrack: Vec<(usize, bool)> = vec![]; // bool indicates dbl or sgl
+    let mut sgl_open: Option<usize> = None;
+    let mut dbl_open: Option<usize> = None;
 
-    input.elements_mut().iter_mut().for_each(|e| match e {
-        Text(str) => {
-            let mut acc = String::new();
-            let mut lines = str.lines().peekable();
+    input
+        .elements_mut()
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, e)| match e {
+            Text(str) => {
+                let mut acc = String::new();
+                let mut lines = str.lines().peekable();
 
-            while let Some(line) = lines.next() {
-                let mut tmp = line
-                    .replace("...", "\u{2026}")
-                    .replace("---", "\u{2014}")
-                    .replace("--", "\u{2013}");
+                while let Some(line) = lines.next() {
+                    let mut tmp = line
+                        .replace("...", "\u{2026}")
+                        .replace("---", "\u{2014}")
+                        .replace("--", "\u{2013}");
 
+                    if let Some(ii) = &sgl_open {
+                        tmp = tmp.replacen("\'", "\u{2019}", 1);
+                        backtrack.push((*ii, false));
+                    }
+                    if let Some(ii) = &dbl_open {
+                        tmp = tmp.replacen("\"", "\u{201D}", 1);
+                        backtrack.push((*ii, true));
+                    }
 
-                if sgl_open {
-                    tmp = tmp.replacen("\'", "\u{2019}", 1)
+                    let sgl_occs = tmp.matches("\'").count();
+                    for _ in 0..sgl_occs / 2 {
+                        tmp = tmp
+                            .replacen("\'", "\u{2018}", 1)
+                            .replacen("\'", "\u{2019}", 1);
+                    }
+                    let dbl_occs = tmp.matches("\"").count();
+                    for _ in 0..dbl_occs / 2 {
+                        tmp = tmp
+                            .replacen("\"", "\u{201C}", 1)
+                            .replacen("\"", "\u{201D}", 1);
+                    }
+
+                    acc.push_str(tmp.as_str());
+
+                    if lines.peek().is_none() {
+                        sgl_open = if sgl_occs % 2 != 0 { Some(i) } else { None };
+                        dbl_open = if dbl_occs % 2 != 0 { Some(i) } else { None };
+                    } else {
+                        acc.push_str("\n");
+                        dbl_open = None;
+                        sgl_open = None;
+                    }
                 }
-                if dbl_open {
-                    tmp = tmp.replacen("\"", "\u{201D}", 1);
-                }
 
-                let sgl_occs = tmp.matches("\'").count();
-                for _ in 0..sgl_occs/2 {
-                    tmp = tmp
-                        .replacen("\'", "\u{2018}", 1)
-                        .replacen("\'", "\u{2019}", 1);
-                }
-                let dbl_occs = tmp.matches("\"").count();
-                for _ in 0..dbl_occs/2 {
-                    tmp = tmp
-                        .replacen("\"", "\u{201C}", 1)
-                        .replacen("\"", "\u{201D}", 1);
-                }
-
-                if lines.peek().is_none() {
-                    sgl_open = sgl_occs % 2 != 0;
-                    dbl_open = dbl_occs % 2 != 0;
-                } else {
-                    dbl_open = false;
-                    sgl_open = false;
-                }
-
-                acc.push_str(tmp.as_str());
-                acc.push('\n');
+                mem::swap(str, &mut acc);
             }
+            Ast::Document(d) => {
+                smart_punctuate(&mut d.elements);
+            }
+            Ast::Paragraph(p) => {
+                smart_punctuate(&mut p.elements);
+            }
+            Ast::Tag(t) => {
+                smart_punctuate(&mut t.elements);
+            }
+            Ast::Heading(h) => {
+                smart_punctuate(&mut h.elements);
+            }
+            _ => {}
+        });
 
-            mem::swap(str, &mut acc);
+    let v = input.elements_mut();
+    for (i, b) in backtrack {
+        if let Some(Text(str)) = v.get_mut(i) {
+            let mut tmp;
+            if b {
+                tmp = str.replacen("\"", "\u{201C}", 1);
+            } else {
+                tmp = str.replacen("\'", "\u{2018}", 1);
+            }
+            mem::swap(str, &mut tmp);
         }
-        Ast::Document(d) => {
-            smart_punctuate(&mut d.elements);
-        }
-        Ast::Paragraph(p) => {
-            smart_punctuate(&mut p.elements);
-        }
-        Ast::Tag(t) => {
-            smart_punctuate(&mut t.elements);
-        }
-        Ast::Heading(h) => {
-            smart_punctuate(&mut h.elements);
-        }
-        _ => {}
-    })
+    }
 }
 
 /// Converts an Ast into a vector of strings suitable for a text representation.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -435,7 +435,11 @@ fn pretty_ast(ast: &Ast) -> Vec<String> {
             }
         }
 
-        Ast::Tag(Tag { tag_name, elements, recurse: _ }) => {
+        Ast::Tag(Tag {
+            tag_name,
+            elements,
+            recurse: _,
+        }) => {
             strs.push(format!("{tag_name}:"));
             if elements.is_empty() {
                 strs.push(format!("{indent}[no elements]"));

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -96,6 +96,7 @@ impl Ast {
 pub struct Tag {
     pub tag_name: String,
     pub elements: Vec<Ast>,
+    pub recurse: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -434,7 +435,7 @@ fn pretty_ast(ast: &Ast) -> Vec<String> {
             }
         }
 
-        Ast::Tag(Tag { tag_name, elements }) => {
+        Ast::Tag(Tag { tag_name, elements, recurse: _ }) => {
             strs.push(format!("{tag_name}:"));
             if elements.is_empty() {
                 strs.push(format!("{indent}[no elements]"));

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -339,8 +339,8 @@ fn parse_paragraph_elements(input: &str) -> IResult<&str, Vec<Ast>> {
             tag::extract_tags,
         ),
         |mut x| {
-            remove_escape_chars(&mut x);
             smart_punctuate(&mut x);
+            remove_escape_chars(&mut x);
             x
         },
     )(input)

--- a/parser/src/punct.rs
+++ b/parser/src/punct.rs
@@ -1,6 +1,6 @@
 use crate::tag::CompoundAST;
 use crate::Ast;
-use crate::Ast::Text;
+use crate::Ast::{Text};
 use std::mem;
 
 const ENDASH: &str = "\u{2013}";
@@ -11,10 +11,6 @@ const RSQUO: &str = "\u{2019}";
 const LDQUO: &str = "\u{201C}";
 const RDQUO: &str = "\u{201D}";
 
-/// Replace certain sequences with unicode characters according to our specification for
-/// smart punctuation.
-///
-/// The function takes a mutable `CompoundAST` and walks through it, mutating its texts in-place
 pub fn smart_punctuate<T>(input: &mut T)
 where
     T: CompoundAST,
@@ -25,115 +21,99 @@ where
 
     for elem_index in 0..elems.len() {
         let (prev, rest) = elems.as_mut_slice().split_at_mut(elem_index);
-        match rest.get_mut(0) {
-            Some(Text(str)) => {
-                let mut chars = str.chars().peekable();
-                let mut acc = String::new();
-                let mut row = String::new();
-                let mut seq = String::new();
-                let mut escaped = false;
-                let mut last_char = ' ';
-                let mut left_flanking;
-                let mut right_flanking;
+        let curr_elem = rest.get_mut(0);
+        if let Some(Text(str)) = curr_elem {
+            let mut chars = str.chars().peekable();
+            let mut acc = String::new();
+            let mut escaped = false;
+            let mut last_escape = None;
 
-                while let Some(c) = chars.next() {
-                    left_flanking = last_char.is_ascii_whitespace();
-                    right_flanking = chars.peek().unwrap_or(&' ').is_ascii_whitespace();
+            while let Some(c) = chars.next() {
+                let last_char = acc.chars().rev().next().unwrap_or(' ');
+                let left_flanking = last_char.is_whitespace();
+                let right_flanking = chars.peek().unwrap_or(&' ').is_whitespace();
+                let len = acc.len();
 
-                    if c != '.' && c != '-' && !seq.is_empty() {
-                        row = format!("{}{}", row, smart_sequence(seq));
-                        seq = String::new();
-                    }
-                    match c {
-                        '\r' | '\n' => {
-                            row.push(c);
-                            acc = format!("{}{}", acc, row);
-                            row = String::new();
-                            open_single = None;
-                            open_double = None;
-                            escaped = false;
-                        }
-                        '\'' => {
-                            if escaped {
-                                row.push(c);
-                            } else if left_flanking {
-                                open_single = Some((elem_index, acc.len() + row.len()));
-                                row.push(c);
-                            } else if open_single.is_some() && right_flanking {
-                                let (ei, i) = open_single.unwrap();
-                                if ei != elem_index {
-                                    if let Some(Text(str)) = prev.get_mut(ei) {
-                                        str.replace_range(i..i + 1, LSQUO);
-                                    }
-                                } else {
-                                    let curr_i = i - acc.len();
-                                    row.replace_range(curr_i..curr_i + 1, LSQUO);
-                                }
-                                row.push_str(RSQUO);
-                                open_single = None;
-                            } else {
-                                row.push(c);
-                            }
-                            escaped = false;
-                        }
-                        '\"' => {
-                            if escaped {
-                                row.push(c)
-                            } else if open_double.is_some() {
-                                let (ei, i) = open_double.unwrap();
-                                if ei != elem_index {
-                                    if let Some(Text(str)) = prev.get_mut(ei) {
-                                        str.replace_range(i..i + 1, LDQUO);
-                                    }
-                                } else {
-                                    let curr_i = i - acc.len();
-                                    row.replace_range(curr_i..curr_i + 1, LDQUO);
-                                }
-                                row.push_str(RDQUO);
-                                open_double = None;
-                            } else {
-                                open_double = Some((elem_index, acc.len() + row.len()));
-                                row.push(c);
-                            }
-                            escaped = false;
-                        }
-                        '.' | '-' => {
-                            if escaped {
-                                row.push(c);
-                            } else if seq.is_empty() || seq.contains(c) {
-                                seq.push(c);
-                            } else {
-                                row = format!("{}{}", row, smart_sequence(seq));
-                                seq = String::from(c)
-                            }
-                        }
-                        '\\' => {
-                            row.push(c);
-                            escaped = !escaped;
-                        }
-                        _ => {
-                            row.push(c);
-                            escaped = false;
-                        }
-                    }
-                    last_char = c;
+                if c != last_char {
+                    try_smart_sequence(&mut acc, last_escape);
                 }
-                mem::swap(str, &mut format!("{}{}{}", acc, row, smart_sequence(seq)));
+
+                if c == '\n' || c == '\r' {
+                    open_single = None;
+                    open_double = None;
+                }
+
+                if c == '\"' && !escaped {
+                    if let Some((ei, ci)) = open_double {
+                        if ei == elem_index {
+                            acc.replace_range(ci..ci + 1, LDQUO);
+                        } else if let Some(Text(other)) = prev.get_mut(ei) {
+                            other.replace_range(ci..ci + 1, LDQUO);
+                        }
+                        open_double = None;
+                        acc.push_str(RDQUO);
+                        continue;
+                    } else {
+                        open_double = Some((elem_index, len))
+                    }
+                }
+
+                if c == '\'' && !escaped {
+                    if left_flanking {
+                        open_single = Some((elem_index, len))
+                    } else if open_single.is_some() && right_flanking {
+                        let (ei, ci) = open_single.unwrap();
+                        if ei == elem_index {
+                            acc.replace_range(ci..ci + 1, LSQUO);
+                        } else if let Some(Text(other)) = prev.get_mut(ei) {
+                            other.replace_range(ci..ci + 1, LSQUO);
+                        }
+                        open_single = None;
+                        acc.push_str(RSQUO);
+                        continue;
+                    }
+                }
+
+                if escaped {
+                    last_escape = Some(acc.len())
+                }
+                escaped = if c == '\\' { !escaped } else { false };
+                acc.push(c)
             }
-            Some(Ast::Document(d)) => smart_punctuate(d),
-            Some(Ast::Paragraph(p)) => smart_punctuate(p),
-            Some(Ast::Tag(t)) => smart_punctuate(t),
-            Some(Ast::Heading(h)) => smart_punctuate(h),
-            _ => {}
+            try_smart_sequence(&mut acc, last_escape);
+            mem::swap(str, &mut acc);
+        } else {
+            match curr_elem {
+                Some(Ast::Document(d)) => smart_punctuate(d),
+                Some(Ast::Paragraph(p)) => smart_punctuate(p),
+                Some(Ast::Heading(h)) => smart_punctuate(h),
+                Some(Ast::Tag(t)) => {
+                    if t.recurse {
+                        smart_punctuate(t)
+                    }
+                },
+                _ => {}
+            }
         }
     }
 }
 
-fn smart_sequence(seq: String) -> String {
-    return match seq.as_str() {
-        "..." => ELLIP.to_string(),
-        "--" => ENDASH.to_string(),
-        "---" => EMDASH.to_string(),
-        _ => seq,
-    };
+fn try_smart_sequence(str: &mut String, last_escape: Option<usize>) {
+    if let Some(last_char) = str.chars().rev().next() {
+        let mut seq = str
+            .chars()
+            .rev()
+            .take_while(|ch| ch == &last_char)
+            .collect::<String>();
+        if let Some(i) = last_escape {
+            seq.truncate(str.len()-i-1);
+        }
+        let range = str.len() - seq.len()..str.len();
+        match seq.as_str() {
+            "..." => str.replace_range(range, ELLIP),
+            "--" => str.replace_range(range, ENDASH),
+            "---" => str.replace_range(range, EMDASH),
+            _ => {}
+        }
+    }
 }

--- a/parser/src/punct.rs
+++ b/parser/src/punct.rs
@@ -1,0 +1,125 @@
+use crate::tag::CompoundAST;
+use crate::Ast;
+use crate::Ast::Text;
+use std::mem;
+
+const ENDASH: &str = "\u{2013}";
+const EMDASH: &str = "\u{2014}";
+const ELLIP: &str = "\u{2026}";
+const LSQUO: &str = "\u{2018}";
+const RSQUO: &str = "\u{2019}";
+const LDQUO: &str = "\u{201C}";
+const RDQUO: &str = "\u{201D}";
+
+/// Replace certain sequences with unicode characters according to our specification for
+/// smart punctuation.
+///
+/// The function takes a mutable `CompoundAST` and walks through it, mutating its texts in-place
+pub fn smart_punctuate<T>(input: &mut T)
+where
+    T: CompoundAST,
+{
+    let elems: &mut Vec<Ast> = input.elements_mut();
+    let mut open_elem_sg: Option<usize> = None;
+    let mut open_elem_db: Option<usize> = None;
+
+    for i in 0..elems.len() {
+        let (prev, rest) = elems.as_mut_slice().split_at_mut(i);
+        if let Some(e) = rest.get_mut(0) {
+            match e {
+                Text(str) => {
+                    let mut res = String::new();
+                    let mut curr = String::new();
+                    let mut open_sg = open_elem_sg.is_some();
+                    let mut open_db = open_elem_db.is_some();
+
+                    if let Some(ii) = open_elem_sg {
+                        if let Some(e) = prev.get_mut(ii) {
+                            try_close_quote(&str, e, "\'", LSQUO)
+                        }
+                    }
+
+                    if let Some(ii) = open_elem_db {
+                        if let Some(e) = prev.get_mut(ii) {
+                            try_close_quote(&str, e, "\"", LDQUO)
+                        }
+                    }
+
+                    for c in str.chars() {
+                        match c {
+                            '\r' | '\n' => {
+                                curr.push(c);
+                                res = format!("{}{}", res, curr);
+                                curr = String::new();
+                                open_sg = false;
+                                open_db = false;
+                            }
+                            '\"' => {
+                                if open_db {
+                                    curr = curr.replace("\"", LDQUO);
+                                    curr.push_str(RDQUO)
+                                } else {
+                                    curr.push(c)
+                                }
+                                open_db = !open_db
+                            }
+                            '\'' => {
+                                if open_sg {
+                                    curr = curr.replace("\'", LSQUO);
+                                    curr.push_str(RSQUO)
+                                } else {
+                                    curr.push(c)
+                                }
+                                open_sg = !open_sg
+                            }
+                            _ => {
+                                curr.push(c);
+                            }
+                        }
+                    }
+
+                    res = format!("{}{}", res, curr)
+                        .replace("...", ELLIP)
+                        .replace("---", EMDASH)
+                        .replace("--", ENDASH);
+
+                    mem::swap(str, &mut res);
+
+                    open_elem_sg = if open_sg { Some(i) } else { None };
+                    open_elem_db = if open_db { Some(i) } else { None };
+                }
+                Ast::Document(d) => {
+                    smart_punctuate(&mut d.elements);
+                }
+                Ast::Paragraph(p) => {
+                    smart_punctuate(&mut p.elements);
+                }
+                Ast::Tag(t) => {
+                    smart_punctuate(&mut t.elements);
+                }
+                Ast::Heading(h) => {
+                    smart_punctuate(&mut h.elements);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn try_close_quote(str: &String, e: &mut Ast, pat: &str, to: &str) {
+    if let Text(other) = e {
+        if let Some(line) = str.lines().next() {
+            if line.contains(pat) {
+                let mut res = other
+                    .chars()
+                    .rev()
+                    .collect::<String>()
+                    .replacen(pat, to, 1)
+                    .chars()
+                    .rev()
+                    .collect::<String>();
+                mem::swap(other, &mut res)
+            }
+        }
+    }
+}

--- a/parser/src/tag.rs
+++ b/parser/src/tag.rs
@@ -198,6 +198,7 @@ where
         let tag_element = Tag {
             tag_name: tag.name.to_string(),
             elements: content,
+            recurse: tag.recurse,
         };
 
         ast.elements_mut().push(Ast::Tag(tag_element));
@@ -270,6 +271,7 @@ where
     let tag = Tag {
         tag_name: tag.name.clone(),
         elements: removed_elems,
+        recurse: tag.recurse,
     };
 
     if !end_suffix.is_empty() {

--- a/parser/src/tag.rs
+++ b/parser/src/tag.rs
@@ -4,7 +4,7 @@
 //! exposes a function, [extract_tags], which goes through all text segments of an Ast, finds all
 //! tags and moves the content of the tags out to a different Ast structure, [Tag]
 use crate::Ast::Text;
-use crate::{Ast, Document, Paragraph, Tag};
+use crate::{Ast, Document, Heading, Paragraph, Tag};
 
 /// The position of a character inside a compound AST. One compound AST consists of a list of
 /// children, and those children can be any of the types defined in the AST enum. You can position
@@ -439,6 +439,16 @@ impl CompoundAST for Paragraph {
 }
 
 impl CompoundAST for Tag {
+    fn elements(&self) -> &Vec<Ast> {
+        &self.elements
+    }
+
+    fn elements_mut(&mut self) -> &mut Vec<Ast> {
+        &mut self.elements
+    }
+}
+
+impl CompoundAST for Heading {
     fn elements(&self) -> &Vec<Ast> {
         &self.elements
     }

--- a/parser/tests/compilation_tests/smart_punctuation_mixed_quotes.mdmtest
+++ b/parser/tests/compilation_tests/smart_punctuation_mixed_quotes.mdmtest
@@ -1,0 +1,29 @@
+This tests jagged and nested quotes for smart punctuation.
+
+```mdm
+'one "two three' four"
+"one 'two three" four'
+
+'one "two three" four'
+"one 'two three' four"
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "Paragraph",
+      "children": [
+        "'one “two three' four”\n“one 'two three” four'"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "‘one “two three” four’\n“one ‘two three’ four”"
+      ]
+    }
+  ]
+}
+```

--- a/parser/tests/compilation_tests/smart_punctuation_quotes.mdmtest
+++ b/parser/tests/compilation_tests/smart_punctuation_quotes.mdmtest
@@ -1,0 +1,101 @@
+This tests quotes and some corner cases for smart punctuation
+
+```mdm
+"smart quotes"
+"smart quotes with **bold** between"
+"smart quotes with **bold** and //italic// between"
+
+'single quotes'
+'single quotes with can't won't don't'
+
+\"not smart quotes"
+"smart \" quotes"
+
+"not
+smart quotes"
+
+'not
+smart quotes'
+
+"not **smart quotes"**
+"smart **bold"** quotes"
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "Paragraph",
+      "children": [
+        "“smart quotes”\n“smart quotes with ",
+        {
+          "name": "Bold",
+          "children": [
+            "bold"
+          ]
+        },
+        " between”\n“smart quotes with ",
+        {
+          "name": "Bold",
+          "children": [
+            "bold"
+          ]
+        },
+        " and ",
+        {
+          "name": "Italic",
+          "children": [
+            "italic"
+          ]
+        },
+        " between”"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "‘single quotes’\n‘single quotes with can't won't don't’"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "\"not smart quotes\"\n“smart \" quotes”"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "\"not\nsmart quotes\""
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "'not\nsmart quotes'"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "\"not ",
+        {
+          "name": "Bold",
+          "children": [
+            "smart quotes\""
+          ]
+        },
+        "\n“smart ",
+        {
+          "name": "Bold",
+          "children": [
+            "bold\""
+          ]
+        },
+        " quotes”"
+      ]
+    }
+  ]
+}
+```

--- a/parser/tests/compilation_tests/smart_punctuation_sequences.mdmtest
+++ b/parser/tests/compilation_tests/smart_punctuation_sequences.mdmtest
@@ -1,0 +1,51 @@
+This tests sequences and some corner cases for smart punctuation
+
+```mdm
+...
+....
+......
+
+\...
+\....
+\.....
+
+--
+---
+-----
+
+\--
+\---
+\-----
+```
+
+```json
+{
+  "name": "Document",
+  "children": [
+    {
+      "name": "Paragraph",
+      "children": [
+        "…\n....\n......"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "...\n.…\n....."
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "–\n—\n-----"
+      ]
+    },
+    {
+      "name": "Paragraph",
+      "children": [
+        "--\n-–\n-----"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
Resolves: #55 

This PR adds smart punctuation.

TODO:
- [x] Fix smart quotes with elements between
- [x] Fix newlines to pass tests
- [x] Allow escaping quotes and sequences
- [x] Avoid replacing longer sequences such as "----"
- [x] Avoid using single quotes in words like "can't", possibly by using left- and right-flanking quotes
- [x] Bugfixes: escaped quotes like ``"one \" two"`` and single quotes like ``'one two t'hree four'``
- [x] Clean-up
