### PR TITLE
GH-66: Simplify preview workflow

### DIFF
--- a/.github/workflows/DeployMain.yml
+++ b/.github/workflows/DeployMain.yml
@@ -1,5 +1,5 @@
 # This is a workflow based on an example provided by GitHub and on rossjrw/pr-preview-action
-name: Deploy main Playground to Pages
+name: Deploy main Playground
 
 on:
   # Runs on pushes targeting the default branch

--- a/.github/workflows/DeployPreview.yml
+++ b/.github/workflows/DeployPreview.yml
@@ -1,5 +1,5 @@
 # This is a workflow based on an example provided by GitHub and on rossjrw/pr-preview-action
-name: Deploy Playground preview to Pages
+name: Deploy Playground Preview
 
 on:
   # Runs on pushes targeting the default branch
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -33,40 +34,43 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
       - name: Setup output directory
-        if: github.event.action != 'closed'
         run: mkdir build
       - name: Install toolchain (minimal, stable, wasm32-unknown-unknown + wasm32-wasi)
-        if: github.event.action != 'closed'
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, wasm32-wasi
       - name: Install wasm-pack
-        if: github.event.action != 'closed'
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Make build script executable
-        if: github.event.action != 'closed'
         run: chmod +x ./build-playground.sh
       - name: Build Playground
-        if: github.event.action != 'closed'
         run: ./build-playground.sh
       - name: Remove auto-generated .gitignore
-        if: github.event.action != 'closed'
         run: rm build/pkg/.gitignore
       - name: Copy deployment files
-        if: github.event.action != 'closed'
         run: |
           mkdir site-deploy
           cp -r build/* site-deploy
       - name: Print generated files
-        if: github.event.action != 'closed'
         run: ls -R site-deploy
       - name: Deploy Playground preview
         uses: rossjrw/pr-preview-action@v1
         with:
+          custom-url: modmark.org
           source-dir: ./playground/site-deploy/
           preview-branch: gh-pages
           umbrella-dir: pr-preview
-          action: auto
+          action: deploy
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Teardown Playground preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove


### PR DESCRIPTION
#66 aimed at adding preview deployment for pull request into the GitHub Pages Playground deployment. #67 implemented workflows responsible for that - then #69 added lots of `if` cases to ensure that the playground isn't actually built when the pull request is closed. This made the workflow less readable overall. This PR splits the DeployPreview workflow into two distinct jobs: `build-and-deploy` which deploys on new PRs/reopened PRs/synchronized PRs, and `teardown` which runs on closed PRs to remove the deployment. The `if` cases are only applied to the jobs overall and not within each job which improves readability. It also changes the default url (`modmark-org.github.io`) to our custom domain `modmark.org` for the automated message.

Resolves GH-66