### PR TITLE
Unify structure for external, native and built-in packages

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ wasmer-wasi = { version = "3.1.1", default-features = false }
 thiserror = "1.0.38"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
+either = "1.8.1"
 
 
 # Use the "web" feature to support web builds with:

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -3,6 +3,7 @@ use std::{
     io::{Read, Write},
 };
 
+use either::Either::{self, Left, Right};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use wasmer::Cranelift;
@@ -496,50 +497,6 @@ impl Context {
             ));
         }
         Ok(collected_args)
-    }
-}
-
-/// An enum containing one of two data types. Note that this is similar to `Result`, minus the
-/// convention that the right value is an error type.
-#[derive(Debug, Clone)]
-pub enum Either<L, R> {
-    Left(L),
-    Right(R),
-}
-
-impl<L, R> Either<L, R> {
-    /// Extracts the left value of this `Either` as an `Option`
-    pub fn get_left(self) -> Option<L> {
-        match self {
-            Either::Left(l) => Some(l),
-            Either::Right(_) => None,
-        }
-    }
-
-    /// Extracts the right value of this `Either` as an `Option`
-    pub fn get_right(self) -> Option<R> {
-        match self {
-            Either::Left(_) => None,
-            Either::Right(r) => Some(r),
-        }
-    }
-
-    /// Extracts the values of this `Either` as a tuple of `Option`s
-    pub fn get_tuple(self) -> (Option<L>, Option<R>) {
-        match self {
-            Either::Left(l) => (Some(l), None),
-            Either::Right(r) => (None, Some(r)),
-        }
-    }
-
-    /// Turns a reference to this `Either` to an `Either` of references to the value contained.
-    /// This is similar to `Option::as_ref`. Chaining this with `get_left` will get a reference to
-    /// the left value.
-    pub fn as_ref(&self) -> Either<&L, &R> {
-        match self {
-            Either::Left(l) => Either::Left(l),
-            Either::Right(r) => Either::Right(r),
-        }
     }
 }
 

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -37,7 +37,7 @@ impl TryFrom<Ast> for Element {
                 children: doc
                     .elements
                     .into_iter()
-                    .map(|e| e.try_into())
+                    .map(TryInto::try_into)
                     .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Paragraph(paragraph) => Ok(Element::Parent {
@@ -46,7 +46,7 @@ impl TryFrom<Ast> for Element {
                 children: paragraph
                     .elements
                     .into_iter()
-                    .map(|e| e.try_into())
+                    .map(TryInto::try_into)
                     .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Tag(tag) => Ok(Element::Parent {
@@ -55,7 +55,7 @@ impl TryFrom<Ast> for Element {
                 children: tag
                     .elements
                     .into_iter()
-                    .map(|e| e.try_into())
+                    .map(TryInto::try_into)
                     .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
             Ast::Module(module) => match module.args {
@@ -77,7 +77,7 @@ impl TryFrom<Ast> for Element {
                 children: heading
                     .elements
                     .into_iter()
-                    .map(|e| e.try_into())
+                    .map(TryInto::try_into)
                     .collect::<Result<Vec<Element>, ParseError>>()?,
             }),
         }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -44,6 +44,8 @@ pub enum CoreError {
     NonTerminatingTransform,
     #[error("Parsing error: {0:#?}.")]
     Parsing(#[from] ParseError),
+    #[error("Native call error: Non-module given to package {0} named {1}")]
+    NonModuleToNative(String, String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -13,6 +13,8 @@ pub enum CoreError {
         "Could not load package '{2}'. There is another package that transforms '{0}' to '{1}'."
     )]
     OccupiedTransform(String, String, String),
+    #[error("Could not load package '{1}'. There is another native transform from '{0}'.")]
+    OccupiedNativeTransform(String, String),
     #[cfg(feature = "native")]
     #[error("Compiler error")]
     WasmerCompiler(Box<CompileError>),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,6 @@ mod element;
 mod error;
 mod package;
 mod std_packages;
-#[macro_use]
 mod std_packages_macros;
 
 #[cfg(all(feature = "web", feature = "native"))]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,16 +1,22 @@
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
-mod context;
-mod element;
-mod error;
-mod package;
+use serde::Deserialize;
 
 pub use context::Context;
 pub use element::Element;
 pub use error::CoreError;
 pub use package::{ArgInfo, Package, PackageInfo, Transform};
-use serde::Deserialize;
-use std::hash::{Hash, Hasher};
+
+use crate::context::Either;
+
+mod context;
+mod element;
+mod error;
+mod package;
+mod std_packages;
+#[macro_use]
+mod std_packages_macros;
 
 #[cfg(all(feature = "web", feature = "native"))]
 compile_error!("feature \"native\" and feature \"web\" cannot be enabled at the same time");
@@ -69,8 +75,13 @@ pub fn eval_elem(
             args: _,
             children: _,
         } => {
-            let compound = ctx.transform(&root, format)?;
-            eval_elem(compound, ctx, format)
+            /*let compound = ctx.transform(&root, format)?;
+            eval_elem(compound, ctx, format)*/
+            let either = ctx.transform(&root, format)?;
+            match either {
+                Either::Left(elem) => eval_elem(elem, ctx, format),
+                Either::Right(res) => Ok(res),
+            }
         }
         Compound(children) => {
             let mut raw_content = String::new();
@@ -87,7 +98,7 @@ pub fn eval_elem(
             inline: _,
         } => {
             // Base case, if its just raw content, stop.
-            if name == "raw" {
+            /*if name == "raw" {
                 return Ok(body.clone());
             }
 
@@ -107,10 +118,17 @@ pub fn eval_elem(
                     .collect::<Result<Vec<Element>, _>>()?;
 
                 return Ok(eval_elem(Element::Compound(elements), ctx, format)?);
-            }
+            }*/
 
+            /*
             let compound = ctx.transform(&root, format)?;
             eval_elem(compound, ctx, format)
+             */
+            let either = ctx.transform(&root, format)?;
+            match either {
+                Either::Left(elem) => eval_elem(elem, ctx, format),
+                Either::Right(res) => Ok(res),
+            }
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ pub use element::Element;
 pub use error::CoreError;
 pub use package::{ArgInfo, Package, PackageInfo, Transform};
 
-use crate::context::Either;
+use either::Either::{self, Left, Right};
 
 mod context;
 mod element;
@@ -90,8 +90,8 @@ pub fn eval_elem(
         } => {
             let either = ctx.transform(&root, format)?;
             match either {
-                Either::Left(elem) => eval_elem(elem, ctx, format),
-                Either::Right(res) => Ok(res),
+                Left(elem) => eval_elem(elem, ctx, format),
+                Right(res) => Ok(res),
             }
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,21 +68,8 @@ pub fn eval_elem(
     ctx: &mut Context,
     format: &OutputFormat,
 ) -> Result<String, CoreError> {
-    use Element::*;
+    use Element::{Compound, Module, Parent};
     match root {
-        Parent {
-            name: _,
-            args: _,
-            children: _,
-        } => {
-            /*let compound = ctx.transform(&root, format)?;
-            eval_elem(compound, ctx, format)*/
-            let either = ctx.transform(&root, format)?;
-            match either {
-                Either::Left(elem) => eval_elem(elem, ctx, format),
-                Either::Right(res) => Ok(res),
-            }
-        }
         Compound(children) => {
             let mut raw_content = String::new();
 
@@ -92,38 +79,16 @@ pub fn eval_elem(
             Ok(raw_content)
         }
         Module {
-            ref name,
+            name: _,
             args: _,
-            ref body,
+            body: _,
             inline: _,
+        }
+        | Parent {
+            name: _,
+            args: _,
+            children: _,
         } => {
-            // Base case, if its just raw content, stop.
-            /*if name == "raw" {
-                return Ok(body.clone());
-            }
-
-            if name == "inline_content" {
-                let elements = parser::parse_inline(body)?
-                    .into_iter()
-                    .map(|ast| ast.try_into())
-                    .collect::<Result<Vec<Element>, _>>()?;
-
-                return Ok(eval_elem(Element::Compound(elements), ctx, format)?);
-            }
-
-            if name == "block_content" {
-                let elements = parser::parse_blocks(body)?
-                    .into_iter()
-                    .map(|ast| ast.try_into())
-                    .collect::<Result<Vec<Element>, _>>()?;
-
-                return Ok(eval_elem(Element::Compound(elements), ctx, format)?);
-            }*/
-
-            /*
-            let compound = ctx.transform(&root, format)?;
-            eval_elem(compound, ctx, format)
-             */
             let either = ctx.transform(&root, format)?;
             match either {
                 Either::Left(elem) => eval_elem(elem, ctx, format),

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -1,5 +1,5 @@
 use crate::package::PackageImplementation::Native;
-use crate::{error::CoreError, Context, Element, OutputFormat};
+use crate::{error::CoreError, OutputFormat};
 use serde::Deserialize;
 use std::{io::Read, sync::Arc};
 use wasmer::{Instance, Module, Store};

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -40,6 +40,20 @@ pub enum PackageImplementation {
     Native,
 }
 
+/// Implements PartialEq for PackageImplementation in a way where two
+/// `PackageImplementation::Native` gives `true` but any other combination gives `false`
+impl PartialEq for PackageImplementation {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Native => match other {
+                Native => true,
+                PackageImplementation::Wasm(_) => false,
+            },
+            PackageImplementation::Wasm(_) => false,
+        }
+    }
+}
+
 impl Package {
     /// Read the binary data from a `.wasm` file and create a Package
     /// containing info about the package as well as the compiled wasm source module.

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+
+use crate::context::Either;
+use crate::context::Either::Right;
+use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
+use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
+
+pub struct StandardPackages {}
+
+define_native_packages! {
+    StandardPackages;
+    "core" => {
+        "raw", vec![] => native_raw,
+    };
+    "reparse" => {
+        "inline_content", vec![] => native_inline_content,
+        "block_content", vec![] => native_block_content,
+    };
+    "env" => {
+        "set-env", vec![
+            ArgInfo {
+                name: "key".to_string(),
+                default: None,
+                description: "The key to set".to_string()
+            }
+        ] => native_inline_content,
+    };
+}
+
+define_standard_package_loader! {
+    StandardPackages;
+    "table", "html",
+}
+
+/*pub fn handle_native_invocation(
+    ctx: &mut Context,
+    package_name: &String,
+    node_name: &String, // name of module or parent
+    element: &Element,
+    args: HashMap<String, String>,
+) -> Result<Element, CoreError> {
+    match package_name.into() {
+        "parser" => match node_name.into() {
+            "parse_inline" => match element {
+                Element::Module {
+                    name,
+                    args: _,
+                    body,
+                    inline,
+                } => native_inline_content(ctx, body, args, *inline),
+                _ => unimplemented!(),
+            },
+            _ => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    }
+    unimplemented!()
+}*/
+
+pub fn native_raw(
+    ctx: &mut Context,
+    body: &String,
+    args: HashMap<String, String>,
+    inline: bool,
+    output_format: &OutputFormat,
+) -> Result<Either<Element, String>, CoreError> {
+    Ok(Right(body.clone()))
+}
+
+pub fn native_inline_content(
+    ctx: &mut Context,
+    body: &String,
+    args: HashMap<String, String>,
+    inline: bool,
+    output_format: &OutputFormat,
+) -> Result<Either<Element, String>, CoreError> {
+    let elements = parser::parse_inline(body)?
+        .into_iter()
+        .map(|ast| ast.try_into())
+        .collect::<Result<Vec<Element>, _>>()?;
+
+    return Ok(Right(crate::eval_elem(
+        Element::Compound(elements),
+        ctx,
+        output_format,
+    )?));
+}
+
+pub fn native_block_content(
+    ctx: &mut Context,
+    body: &String,
+    args: HashMap<String, String>,
+    inline: bool,
+    output_format: &OutputFormat,
+) -> Result<Either<Element, String>, CoreError> {
+    let elements = parser::parse_blocks(body)?
+        .into_iter()
+        .map(|ast| ast.try_into())
+        .collect::<Result<Vec<Element>, _>>()?;
+
+    Ok(Right(crate::eval_elem(
+        Element::Compound(elements),
+        ctx,
+        output_format,
+    )?))
+}
+
+pub fn native_set_env(
+    ctx: &mut Context,
+    body: &String,
+    args: HashMap<String, String>,
+    inline: bool,
+    output_format: &OutputFormat,
+) -> Result<Either<Element, String>, CoreError> {
+    unimplemented!("native_set_env")
+}

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
 
-use crate::context::Either;
-use crate::context::Either::{Left, Right};
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
 use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
+use either::Either::{self, Left, Right};
+
+// Here, all standard packages are declared. The macro expands to one function
+// which takes a &mut Context and loads it with the given standard package. It is important that the
+// package with a given name both is in a folder with that name, containing a cargo package with
+// that name. Otherwise, the module won't be found
+define_standard_package_loader! {
+    "table", "html",
+}
 
 // Here, all native packages are declared. The macro expands to two functions,
 // one being a function returning the manifests for those packages, and the other
@@ -25,14 +32,6 @@ define_native_packages! {
             }
         ] => native_set_env,
     };
-}
-
-// Here, all standard packages are declared. The macro expands to one function
-// which takes a &mut Context and loads it with the given standard package. It is important that the
-// package with a given name both is in a folder with that name, containing a cargo package with
-// that name. Otherwise, the module won't be found
-define_standard_package_loader! {
-    "table", "html",
 }
 
 /// Returns a string containing the body of this invocation. This is the "leaf" call; no tree will

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use crate::context::Either;
-use crate::context::Either::Right;
+use crate::context::Either::{Left, Right};
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
 use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
 
 // Here, all native packages are declared. The macro expands to two functions,
 // one being a function returning the manifests for those packages, and the other
-// being the entry point to run these packages
+// being the entry point to run these packages.
 define_native_packages! {
     "core" => {
         "raw", vec![] => native_raw,
@@ -35,15 +35,8 @@ define_standard_package_loader! {
     "table", "html",
 }
 
-/*pub fn handle_native_invocation(
-    ctx: &mut Context,
-    package_name: &String,
-    node_name: &String, // name of module or parent
-    element: &Element,
-    args: HashMap<String, String>,
-) -> Result<Element, CoreError> {
-}*/
-
+/// Returns a string containing the body of this invocation. This is the "leaf" call; no tree will
+/// be created as a result of this call
 pub fn native_raw(
     _ctx: &mut Context,
     body: &str,
@@ -54,44 +47,41 @@ pub fn native_raw(
     Ok(Right(body.to_owned()))
 }
 
+/// Re-parses the content as block content (a paragraph with tags, modules etc) and
+/// returns the resulting compound element containing the contents of the paragraph
 pub fn native_inline_content(
-    ctx: &mut Context,
+    _ctx: &mut Context,
     body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
-    output_format: &OutputFormat,
+    _output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_inline(body)?
         .into_iter()
         .map(TryInto::try_into)
         .collect::<Result<Vec<Element>, _>>()?;
 
-    Ok(Right(crate::eval_elem(
-        Element::Compound(elements),
-        ctx,
-        output_format,
-    )?))
+    Ok(Left(Element::Compound(elements)))
 }
 
+/// Re-parses the content as block content (multiple paragraph or multiline module invocations) and
+/// returns the resulting compound element
 pub fn native_block_content(
-    ctx: &mut Context,
+    _ctx: &mut Context,
     body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
-    output_format: &OutputFormat,
+    _output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_blocks(body)?
         .into_iter()
         .map(TryInto::try_into)
         .collect::<Result<Vec<Element>, _>>()?;
 
-    Ok(Right(crate::eval_elem(
-        Element::Compound(elements),
-        ctx,
-        output_format,
-    )?))
+    Ok(Left(Element::Compound(elements)))
 }
 
+/// Example function for setting environment variables, currently unimplemented
 pub fn native_set_env(
     _ctx: &mut Context,
     _body: &str,

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -58,44 +58,44 @@ define_standard_package_loader! {
 }*/
 
 pub fn native_raw(
-    ctx: &mut Context,
-    body: &String,
-    args: HashMap<String, String>,
-    inline: bool,
-    output_format: &OutputFormat,
+    _ctx: &mut Context,
+    body: &str,
+    _args: HashMap<String, String>,
+    _inline: bool,
+    _output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
-    Ok(Right(body.clone()))
+    Ok(Right(body.to_owned()))
 }
 
 pub fn native_inline_content(
     ctx: &mut Context,
-    body: &String,
-    args: HashMap<String, String>,
-    inline: bool,
+    body: &str,
+    _args: HashMap<String, String>,
+    _inline: bool,
     output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_inline(body)?
         .into_iter()
-        .map(|ast| ast.try_into())
+        .map(TryInto::try_into)
         .collect::<Result<Vec<Element>, _>>()?;
 
-    return Ok(Right(crate::eval_elem(
+    Ok(Right(crate::eval_elem(
         Element::Compound(elements),
         ctx,
         output_format,
-    )?));
+    )?))
 }
 
 pub fn native_block_content(
     ctx: &mut Context,
-    body: &String,
-    args: HashMap<String, String>,
-    inline: bool,
+    body: &str,
+    _args: HashMap<String, String>,
+    _inline: bool,
     output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_blocks(body)?
         .into_iter()
-        .map(|ast| ast.try_into())
+        .map(TryInto::try_into)
         .collect::<Result<Vec<Element>, _>>()?;
 
     Ok(Right(crate::eval_elem(
@@ -106,11 +106,11 @@ pub fn native_block_content(
 }
 
 pub fn native_set_env(
-    ctx: &mut Context,
-    body: &String,
-    args: HashMap<String, String>,
-    inline: bool,
-    output_format: &OutputFormat,
+    _ctx: &mut Context,
+    _body: &str,
+    _args: HashMap<String, String>,
+    _inline: bool,
+    _output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
     unimplemented!("native_set_env")
 }

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -5,10 +5,10 @@ use crate::context::Either::Right;
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
 use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
 
-pub struct StandardPackages {}
-
+// Here, all native packages are declared. The macro expands to two functions,
+// one being a function returning the manifests for those packages, and the other
+// being the entry point to run these packages
 define_native_packages! {
-    StandardPackages;
     "core" => {
         "raw", vec![] => native_raw,
     };
@@ -23,12 +23,15 @@ define_native_packages! {
                 default: None,
                 description: "The key to set".to_string()
             }
-        ] => native_inline_content,
+        ] => native_set_env,
     };
 }
 
+// Here, all standard packages are declared. The macro expands to one function
+// which takes a &mut Context and loads it with the given standard package. It is important that the
+// package with a given name both is in a folder with that name, containing a cargo package with
+// that name. Otherwise, the module won't be found
 define_standard_package_loader! {
-    StandardPackages;
     "table", "html",
 }
 
@@ -39,22 +42,6 @@ define_standard_package_loader! {
     element: &Element,
     args: HashMap<String, String>,
 ) -> Result<Element, CoreError> {
-    match package_name.into() {
-        "parser" => match node_name.into() {
-            "parse_inline" => match element {
-                Element::Module {
-                    name,
-                    args: _,
-                    body,
-                    inline,
-                } => native_inline_content(ctx, body, args, *inline),
-                _ => unimplemented!(),
-            },
-            _ => unimplemented!(),
-        },
-        _ => unimplemented!(),
-    }
-    unimplemented!()
 }*/
 
 pub fn native_raw(

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -33,11 +33,11 @@ macro_rules! define_native_packages {
                         description: "A native package supporting native modules".to_string(),
                         transforms: vec![
                             $(
-                            (Transform {
-                                from: $transform.to_string(),
-                                to: vec![],
-                                arguments: $arg_info
-                            }),
+                                (Transform {
+                                    from: $transform.to_string(),
+                                    to: vec![],
+                                    arguments: $arg_info
+                                }),
                             )*
                         ]
                     }),

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -1,84 +1,80 @@
 macro_rules! define_native_packages {
-    ($ns:ident; $($name:expr => { $($transform:expr, $arg_info:expr => $handler:ident,)* };)*) => {
-        impl $ns {
-            pub fn native_package_list() -> Vec<PackageInfo> {
-                vec![
-                    $(
-                        (PackageInfo {
-                            name: $name.to_string(),
-                            version: "1".to_string(),
-                            description: "A native package supporting native modules".to_string(),
-                            transforms: vec![
-                                $(
-                                (Transform {
-                                    from: $transform.to_string(),
-                                    to: vec![OutputFormat("NATIVE".to_string())],
-                                    arguments: $arg_info
-                                }),
-                                )*
-                            ]
-                        }),
-                    )*
-                ]
-            }
-
-            pub fn handle_native(
-                ctx: &mut Context,
-                package_name: &str,
-                node_name: &str, // name of module or parent
-                element: &Element,
-                args: HashMap<String, String>,
-                output_format: &OutputFormat
-            ) -> Result<Either<Element, String>, CoreError> {
-                match package_name {
-                    $(
-                        $name => match node_name {
+    ($($name:expr => { $($transform:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
+        pub fn native_package_list() -> Vec<PackageInfo> {
+            vec![
+                $(
+                    (PackageInfo {
+                        name: $name.to_string(),
+                        version: "1".to_string(),
+                        description: "A native package supporting native modules".to_string(),
+                        transforms: vec![
                             $(
-                                $transform => match element {
-                                    Element::Module {
-                                        name: _,
-                                        args: _,
-                                        body,
-                                        inline,
-                                    } => $handler(ctx, body, args, *inline, output_format),
-                                    _ => Err(
-                                        CoreError::NonModuleToNative(
-                                            package_name.to_string(),
-                                            node_name.to_string()
-                                        )
-                                    )
-                                },
+                            (Transform {
+                                from: $transform.to_string(),
+                                to: vec![],
+                                arguments: $arg_info
+                            }),
                             )*
-                            _ => unreachable!("Native: Wrong node name")
-                        },
-                    )*
-                    _ => unreachable!("Native: Wrong package name")
-                }
+                        ]
+                    }),
+                )*
+            ]
+        }
+
+        pub fn handle_native(
+            ctx: &mut Context,
+            package_name: &str,
+            node_name: &str, // name of module or parent
+            element: &Element,
+            args: HashMap<String, String>,
+            output_format: &OutputFormat
+        ) -> Result<Either<Element, String>, CoreError> {
+            match package_name {
+                $(
+                    $name => match node_name {
+                        $(
+                            $transform => match element {
+                                Element::Module {
+                                    name: _,
+                                    args: _,
+                                    body,
+                                    inline,
+                                } => $handler(ctx, body, args, *inline, output_format),
+                                _ => Err(
+                                    CoreError::NonModuleToNative(
+                                        package_name.to_string(),
+                                        node_name.to_string()
+                                    )
+                                )
+                            },
+                        )*
+                        _ => unreachable!("Native: Wrong node name")
+                    },
+                )*
+                _ => unreachable!("Native: Wrong package name")
             }
         }
     }
 }
 
 macro_rules! define_standard_package_loader {
-    ($ns:ident; $($name:expr,)*) => {
-        impl $ns {
-            pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError>{
-                $(
-                    ctx.load_package_from_wasm(
-                        include_bytes!(
-                            concat!(
-                                env!("OUT_DIR"),
-                                "/",
-                                $name,
-                                "/wasm32-wasi/release/",
-                                $name,
-                                ".wasm"
-                            )
+    ($($name:expr),* $(,)?) => {
+        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError>{
+            $(
+                ctx.load_package_from_wasm(
+                    include_bytes!(
+                        concat!(
+                            env!("OUT_DIR"),
+                            "/",
+                            $name,
+                            "/wasm32-wasi/release/",
+                            $name,
+                            ".wasm"
                         )
-                    )?;
-                )*
-                Ok(())
-            }
+                    )
+                )?;
+            )*
+            Ok(())
         }
     }
 }

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -1,0 +1,87 @@
+macro_rules! define_native_packages {
+    ($ns:ident; $($name:expr => { $($transform:expr, $arg_info:expr => $handler:ident,)* };)*) => {
+        impl $ns {
+            pub fn native_package_list() -> Vec<PackageInfo> {
+                vec![
+                    $(
+                        (PackageInfo {
+                            name: $name.to_string(),
+                            version: "1".to_string(),
+                            description: "A native package supporting native modules".to_string(),
+                            transforms: vec![
+                                $(
+                                (Transform {
+                                    from: $transform.to_string(),
+                                    to: vec![OutputFormat("NATIVE".to_string())],
+                                    arguments: $arg_info
+                                }),
+                                )*
+                            ]
+                        }),
+                    )*
+                ]
+            }
+
+            pub fn handle_native(
+                ctx: &mut Context,
+                package_name: &String,
+                node_name: &String, // name of module or parent
+                element: &Element,
+                args: HashMap<String, String>,
+                output_format: &OutputFormat
+            ) -> Result<Either<Element, String>, CoreError> {
+                match package_name.as_str() {
+                    $(
+                        $name => match node_name.as_str() {
+                            $(
+                                $transform => match element {
+                                    Element::Module {
+                                        name: _,
+                                        args: _,
+                                        body,
+                                        inline,
+                                    } => $handler(ctx, body, args, *inline, output_format),
+                                    _ => Err(
+                                        CoreError::NonModuleToNative(
+                                            package_name.to_string(),
+                                            node_name.to_string()
+                                        )
+                                    )
+                                },
+                            )*
+                            _ => unreachable!("Native: Wrong node name")
+                        },
+                    )*
+                    _ => unreachable!("Native: Wrong package name")
+                }
+            }
+        }
+    }
+}
+
+macro_rules! define_standard_package_loader {
+    ($ns:ident; $($name:expr,)*) => {
+        impl $ns {
+            pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError>{
+                $(
+                    ctx.load_package_from_wasm(
+                        include_bytes!(
+                            concat!(
+                                env!("OUT_DIR"),
+                                "/",
+                                $name,
+                                "/wasm32-wasi/release/",
+                                $name,
+                                ".wasm"
+                            )
+                        )
+                    )?;
+                )*
+                Ok(())
+            }
+        }
+    }
+}
+
+pub(crate) use define_native_packages;
+pub(crate) use define_standard_package_loader;

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -1,3 +1,27 @@
+/// This macro defines takes a declaration of native packages, and generates two functions,
+/// `pub fn native_package_list() -> Vec<PackageInfo>` returning a list of PackageInfos for the
+/// packages, and `pub fn handle_native(...) -> Result<Either<Element, String>, CoreError>` which
+/// takes a call to a native module and calls it by the handle given in the declaration.
+///
+/// The native module handlers should have the signature:
+/// `pub fn fn_name(ctx: &mut Context, body: &str, args: HashMap<String, String>,
+///     inline: bool, output_format: &OutputFormat) -> Result<Either<Element, String>, CoreError>;`
+///
+/// Example usage:
+/// ```rust,ignore
+/// define_native_packages! {
+///     "package_name_1" => {
+///         "module_name_1", vec![ //a vec containing the `ArgInfo`s
+///             ArgInfo {
+///                 name: "key".to_string(),
+///                 default: None,
+///                 description: "The key to set".to_string()
+///             }
+///         ] => handle_module_1,
+///         "module_name_2", vec![] => handle_module_2
+///     }
+/// }
+/// ```
 macro_rules! define_native_packages {
     ($($name:expr => { $($transform:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
@@ -57,6 +81,9 @@ macro_rules! define_native_packages {
     }
 }
 
+/// This macro takes a list of standard package names and includes them from the
+/// `OUT_DIR/pkg_name/wasm32-wasi/release/pkg_name.wasm` wasm file. It is important
+/// that the standard package cargo name is the same as the containing folder name.
 macro_rules! define_standard_package_loader {
     ($($name:expr),* $(,)?) => {
         pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError>{

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -24,15 +24,15 @@ macro_rules! define_native_packages {
 
             pub fn handle_native(
                 ctx: &mut Context,
-                package_name: &String,
-                node_name: &String, // name of module or parent
+                package_name: &str,
+                node_name: &str, // name of module or parent
                 element: &Element,
                 args: HashMap<String, String>,
                 output_format: &OutputFormat
             ) -> Result<Either<Element, String>, CoreError> {
-                match package_name.as_str() {
+                match package_name {
                     $(
-                        $name => match node_name.as_str() {
+                        $name => match node_name {
                             $(
                                 $transform => match element {
                                     Element::Module {


### PR DESCRIPTION
This PR aims to restructure the native packages, those which are written in rust in the source code to Modmark, to use the same interface as external packages loaded from wasm. This is done mainly by changing `wasm_module: Module` in the `Package` struct to an enum holding two options, either the wasm module or a flag telling the core that the package is implemented natively.

Some work has already been done, and now all packages are under the same interface. We no longer have lots of `if name == "raw" {...}; if name == "parse_inline" {...} ...`, the native packages are in the same list as the normal packages and are searched for in the same way. Some macros has also been added to simplify the declaration of such native packages.

There is still some work to be done:

- [x] Change `(from, NATIVE)` to something better (currently, native modules encode their transform to go from the target module to the output format `NATIVE`)
- [x] ~~Maybe move native modules to another list, since they don't have an output format, just a source format~~ They are in the same map but with two different cases for the value
- [x] ~~Maybe split the different `Element` types to wrap opaque structs, so pattern matching isn't needed as much~~ Since we are still unsure if we may support native parents, this is skipped for now. It may be changed later if we decide to only allow modules, but if not this may be unnecessary
- [x] ~~Come to a decision on how/if args are allowed for native Parent nodes~~ See above, skipped for now
- [x] General clean-up

Resolves #82