### PR TITLE
GH-80: Fix memory leaks

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -205,9 +205,6 @@ impl Context {
                 body: _,
                 inline: _,
             } => {
-                // First, search for a package with transform to output format NATIVE
-                // If not found,
-
                 let Some((_, package)) =
                     self.transforms.get(name).and_then(|t|t.find_transform_to(output_format))
                      else {
@@ -217,12 +214,14 @@ impl Context {
                 match &package.implementation {
                     PackageImplementation::Wasm(wasm_module) => {
                         // note: cloning modules is cheap
-                        self.transform_from_wasm(&wasm_module.clone(), name, from, output_format)
+                        self.transform_from_wasm(&wasm_module, name, from, output_format)
                     }
-                    PackageImplementation::Native => {
-                        let aaa = package.info.name.clone();
-                        self.transform_from_native(&aaa, name, from, output_format)
-                    }
+                    PackageImplementation::Native => self.transform_from_native(
+                        &package.info.name.clone(),
+                        name,
+                        from,
+                        output_format,
+                    ),
                 }
             }
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ pub use element::Element;
 pub use error::CoreError;
 pub use package::{ArgInfo, Package, PackageInfo, Transform};
 
-use either::Either::{self, Left, Right};
+use either::Either::{Left, Right};
 
 mod context;
 mod element;


### PR DESCRIPTION
This PR resolves #80. 
Comparing the memory footprint of the playground of this branch (left) to main (right) after 50 rerenders of an empty document you notice that the new version is still around 7-8mb while our current implementation has grown to 66mb.  
![image](https://user-images.githubusercontent.com/11508459/220563720-0a209441-2ada-4e73-86ab-133a0230f293.png)




I got afraid that this issue would end up very hard to fix with proper web support without having to resort to recompiling all modules every time they are used. However, after a bit of digging in the `wasmer::js::module` I found that it seems like even though Wasmer requires the `Module::new` method to borrow a store it does not actually use it for anything. So we can create a dummy store when first compiling modules for web (and in the case of native platforms just use an Engine that we store in the context object) and then later create a new store each time we create a WebAssembly module instance.

I'm not entirely convinced that this is the way to go, and we will likely need to do a even bigger rewrite  
(and potentially store `Package`s in a JS context) to make chromium happy. But, we will deal with that issue another day.