### PR TITLE
Add error handling for modules

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,7 @@ fn compile_file(args: &Args) -> Result<Ast, CliError> {
         return Err(CliError::UnknownOutputFormat);
     };
 
-    let output = eval(&source, &mut CTX.lock().unwrap(), &format)?;
+    let output = eval(&source, &mut CTX.lock().unwrap(), &format)?.0;
 
     let mut output_file = File::create(&args.output)?;
     output_file.write_all(output.as_bytes())?;

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -44,7 +44,7 @@ impl Debug for Context {
 /// transformed natively (in one way), or externally (possibly in different ways, depending on the
 /// output format)
 #[derive(Debug)]
-enum TransformVariant {
+pub enum TransformVariant {
     Native((Transform, Package)),
     External(HashMap<OutputFormat, (Transform, Package)>),
 }
@@ -53,7 +53,7 @@ impl TransformVariant {
     /// This function finds the transform to an output format. If the transform is a native
     /// transform, that is returned regardless of the output format, but if it is external, the
     /// map is searched to find the appropriate transform
-    fn find_transform_to(&self, format: &OutputFormat) -> Option<&(Transform, Package)> {
+    pub(crate) fn find_transform_to(&self, format: &OutputFormat) -> Option<&(Transform, Package)> {
         match self {
             TransformVariant::Native(t) => Some(t),
             TransformVariant::External(map) => map.get(format),
@@ -62,7 +62,7 @@ impl TransformVariant {
 
     /// This function `.insert`s an entry to the map if this is of the `External` variant. If it
     /// is of the `Native` variant, this call does nothing.
-    fn insert_into_external(&mut self, format: OutputFormat, entry: (Transform, Package)) {
+    pub(crate) fn insert_into_external(&mut self, format: OutputFormat, entry: (Transform, Package)) {
         match self {
             TransformVariant::Native(_) => {}
             TransformVariant::External(map) => {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -310,7 +310,7 @@ impl Context {
         if let Err(e) = fn_res {
             // An error occurred when executing Wasm module =>
             // it probably crashed, so just insert an error node
-            Ok(Left(Element::Module {
+            return Ok(Left(Element::Module {
                 name: "error".to_string(),
                 args: ModuleArguments {
                     positioned: Some(vec![name.to_string(), output_format.0.to_string()]),
@@ -318,7 +318,7 @@ impl Context {
                 },
                 body: format!("Runtime error: {e}"),
                 inline: false,
-            }))
+            }));
         }
 
         // Read the output of the package from stdout

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,6 +1,8 @@
+use std::fmt::Formatter;
 use std::iter::once;
 use std::{
     collections::HashMap,
+    fmt,
     fmt::Debug,
     io::{Read, Write},
 };
@@ -37,6 +39,16 @@ pub struct Issue {
     pub source: String,
     pub target: String,
     pub description: String,
+}
+
+impl fmt::Display for Issue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} -> {}: {}",
+            self.source, self.target, self.description
+        )
+    }
 }
 
 impl CompilationState {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -655,7 +655,6 @@ impl Default for Context {
     fn default() -> Self {
         let mut ctx = Self::new();
         ctx.load_default_packages().unwrap();
-        ctx.state.verbose_errors = true;
         ctx
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -22,6 +22,13 @@ pub struct Context {
     transforms: HashMap<String, TransformVariant>,
     #[cfg(feature = "native")]
     engine: Engine,
+    state: CompilationState
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct CompilationState {
+    warnings: Vec<(String, String)>,
+    errors: Vec<(String, String)>
 }
 
 impl Debug for Context {
@@ -72,6 +79,7 @@ impl Context {
             transforms: HashMap::new(),
             #[cfg(feature = "native")]
             engine: EngineBuilder::new(Cranelift::new()).engine(),
+            state: CompilationState::default()
         }
     }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -28,8 +28,8 @@ pub struct Context {
 
 #[derive(Default, Clone, Debug)]
 pub struct CompilationState {
-    pub(crate) warnings: Vec<(String, String)>,
-    pub(crate) errors: Vec<(String, String)>,
+    pub warnings: Vec<(String, String)>,
+    pub errors: Vec<(String, String)>,
 }
 
 impl CompilationState {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -18,17 +18,17 @@ use crate::{std_packages, Element};
 use crate::{ArgInfo, CoreError, OutputFormat, Package, PackageInfo, Transform};
 
 pub struct Context {
-    pub packages: HashMap<String, Package>,
-    pub transforms: HashMap<String, TransformVariant>,
+    pub(crate) packages: HashMap<String, Package>,
+    pub(crate) transforms: HashMap<String, TransformVariant>,
     #[cfg(feature = "native")]
     engine: Engine,
-    pub state: CompilationState
+    pub(crate) state: CompilationState
 }
 
 #[derive(Default, Clone, Debug)]
 pub struct CompilationState {
-    pub warnings: Vec<(String, String)>,
-    pub errors: Vec<(String, String)>
+    pub(crate) warnings: Vec<(String, String)>,
+    pub(crate) errors: Vec<(String, String)>
 }
 
 impl Debug for Context {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -188,8 +188,7 @@ impl Context {
                     if self
                         .transforms
                         .get(from)
-                        .map(|t| t.find_transform_to(output_format))
-                        .flatten()
+                        .and_then(|t| t.find_transform_to(output_format))
                         .is_some()
                     {
                         return Err(CoreError::OccupiedTransform(
@@ -274,7 +273,7 @@ impl Context {
                 match &package.implementation {
                     PackageImplementation::Wasm(wasm_module) => {
                         // note: cloning modules is cheap
-                        self.transform_from_wasm(&wasm_module, name, from, output_format)
+                        self.transform_from_wasm(wasm_module, name, from, output_format)
                     }
                     PackageImplementation::Native => self.transform_from_native(
                         &package.info.name.clone(),

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -88,6 +88,11 @@ impl Context {
         }
     }
 
+    /// Clears the internal `CompilationState` of this Context.
+    pub fn clear_state(&mut self) {
+        self.state = CompilationState::default()
+    }
+
     /// This function loads the default packages to the Context. First, it loads all native
     /// packages, retrieved from `std_packages::native_package_list()`, and then it loads all
     /// standard packages by passing this Context to `std_packages::load_standard_packages()`

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -32,6 +32,13 @@ pub struct CompilationState {
     pub(crate) errors: Vec<(String, String)>,
 }
 
+impl CompilationState {
+    fn clear(&mut self) {
+        self.warnings.clear();
+        self.errors.clear();
+    }
+}
+
 impl Debug for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Context")
@@ -90,7 +97,13 @@ impl Context {
 
     /// Clears the internal `CompilationState` of this Context.
     pub fn clear_state(&mut self) {
-        self.state = CompilationState::default()
+        self.state.clear();
+    }
+
+    /// Takes the internal `CompilationState` of this Context, and replacing it with
+    /// a cleared out `CompilationState`
+    pub fn take_state(&mut self) -> CompilationState {
+        std::mem::take(&mut self.state)
     }
 
     /// This function loads the default packages to the Context. First, it loads all native

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -18,17 +18,17 @@ use crate::{std_packages, Element};
 use crate::{ArgInfo, CoreError, OutputFormat, Package, PackageInfo, Transform};
 
 pub struct Context {
-    packages: HashMap<String, Package>,
-    transforms: HashMap<String, TransformVariant>,
+    pub packages: HashMap<String, Package>,
+    pub transforms: HashMap<String, TransformVariant>,
     #[cfg(feature = "native")]
     engine: Engine,
-    state: CompilationState
+    pub state: CompilationState
 }
 
 #[derive(Default, Clone, Debug)]
 pub struct CompilationState {
-    warnings: Vec<(String, String)>,
-    errors: Vec<(String, String)>
+    pub warnings: Vec<(String, String)>,
+    pub errors: Vec<(String, String)>
 }
 
 impl Debug for Context {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -28,8 +28,15 @@ pub struct Context {
 
 #[derive(Default, Clone, Debug)]
 pub struct CompilationState {
-    pub warnings: Vec<(String, String)>,
-    pub errors: Vec<(String, String)>,
+    pub warnings: Vec<Issue>,
+    pub errors: Vec<Issue>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Issue {
+    pub source: String,
+    pub target: String,
+    pub description: String,
 }
 
 impl CompilationState {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -66,7 +66,7 @@ pub fn eval(source: &str, ctx: &mut Context, format: &OutputFormat) -> Result<St
         println!("{}: {}", source, text);
     }
 
-    println!("ERRORS:");
+    println!("\nERRORS:");
     for (source, text) in &ctx.state.errors {
         println!("{}: {}", source, text);
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,6 +58,7 @@ impl FromStr for OutputFormat {
 
 /// Evaluates a document using the given context
 pub fn eval(source: &str, ctx: &mut Context, format: &OutputFormat) -> Result<String, CoreError> {
+    ctx.clear_state();
     let document = parser::parse(source)?.try_into()?;
     let res = eval_elem(document, ctx, format);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,7 +59,19 @@ impl FromStr for OutputFormat {
 /// Evaluates a document using the given context
 pub fn eval(source: &str, ctx: &mut Context, format: &OutputFormat) -> Result<String, CoreError> {
     let document = parser::parse(source)?.try_into()?;
-    eval_elem(document, ctx, format)
+    let res = eval_elem(document, ctx, format);
+
+    println!("WARNINGS:");
+    for (source, text) in &ctx.state.warnings {
+        println!("{}: {}", source, text);
+    }
+
+    println!("ERRORS:");
+    for (source, text) in &ctx.state.errors {
+        println!("{}: {}", source, text);
+    }
+
+    res
 }
 
 pub fn eval_elem(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,18 +69,12 @@ pub fn eval(
 
     println!("\nWARNINGS:");
     for warning in &ctx.state.warnings {
-        println!(
-            "{} -> {}: {}",
-            warning.source, warning.target, warning.description
-        );
+        println!("{warning}");
     }
 
     println!("\nERRORS:");
     for error in &ctx.state.errors {
-        println!(
-            "{} -> {}: {}",
-            error.source, error.target, error.description
-        );
+        println!("{error}");
     }
 
     res.map(|s| (s, ctx.take_state()))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -63,7 +63,13 @@ pub fn eval(
     ctx: &mut Context,
     format: &OutputFormat,
 ) -> Result<(String, CompilationState), CoreError> {
-    ctx.clear_state(); // Note: this isn't actually needed, since take_state clears state
+    // Note: this isn't actually needed, since take_state clears state, but it
+    // is still called to ensure that it is cleared, if someone uses any context mutating functions
+    // outside of here which doesn't take state afterwards
+    ctx.clear_state();
+
+    // TODO: Move this out so that we have a flag in the CLI and a switch in the playground to
+    //   do verbose errors or "debug mode" or similar
     ctx.state.verbose_errors = true;
     let document = parser::parse(source)?.try_into()?;
     let res = eval_elem(document, ctx, format);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ pub use package::{ArgInfo, Package, PackageInfo, Transform};
 
 use crate::context::CompilationState;
 
-pub mod context;
+mod context;
 mod element;
 mod error;
 mod package;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ pub use package::{ArgInfo, Package, PackageInfo, Transform};
 
 use crate::context::CompilationState;
 
-mod context;
+pub mod context;
 mod element;
 mod error;
 mod package;
@@ -67,14 +67,20 @@ pub fn eval(
     let document = parser::parse(source)?.try_into()?;
     let res = eval_elem(document, ctx, format);
 
-    println!("WARNINGS:");
-    for (source, text) in &ctx.state.warnings {
-        println!("{}: {}", source, text);
+    println!("\nWARNINGS:");
+    for warning in &ctx.state.warnings {
+        println!(
+            "{} -> {}: {}",
+            warning.source, warning.target, warning.description
+        );
     }
 
     println!("\nERRORS:");
-    for (source, text) in &ctx.state.errors {
-        println!("{}: {}", source, text);
+    for error in &ctx.state.errors {
+        println!(
+            "{} -> {}: {}",
+            error.source, error.target, error.description
+        );
     }
 
     res.map(|s| (s, ctx.take_state()))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ pub use package::{ArgInfo, Package, PackageInfo, Transform};
 
 use crate::context::CompilationState;
 
-mod context;
+pub mod context;
 mod element;
 mod error;
 mod package;
@@ -67,16 +67,6 @@ pub fn eval(
     ctx.state.verbose_errors = true;
     let document = parser::parse(source)?.try_into()?;
     let res = eval_elem(document, ctx, format);
-
-    println!("\nWARNINGS:");
-    for warning in &ctx.state.warnings {
-        println!("{warning}");
-    }
-
-    println!("\nERRORS:");
-    for error in &ctx.state.errors {
-        println!("{error}");
-    }
 
     res.map(|s| (s, ctx.take_state()))
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -63,7 +63,8 @@ pub fn eval(
     ctx: &mut Context,
     format: &OutputFormat,
 ) -> Result<(String, CompilationState), CoreError> {
-    ctx.clear_state();
+    ctx.clear_state(); // Note: this isn't actually needed, since take_state clears state
+    ctx.state.verbose_errors = true;
     let document = parser::parse(source)?.try_into()?;
     let res = eval_elem(document, ctx, format);
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -1,11 +1,13 @@
-use crate::package::PackageImplementation::Native;
-use crate::{error::CoreError, OutputFormat};
-use serde::Deserialize;
 use std::{io::Read, sync::Arc};
+
+use serde::Deserialize;
 #[cfg(feature = "native")]
 use wasmer::Engine;
 use wasmer::{Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
+
+use crate::package::PackageImplementation::Native;
+use crate::{error::CoreError, OutputFormat};
 
 /// Transform from a node into another node
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
@@ -99,8 +101,8 @@ impl Package {
             .arg("manifest")
             .finalize(store)?;
 
-        let import_object = wasi_env.import_object(store, &module)?;
-        let instance = Instance::new(store, &module, &import_object)?;
+        let import_object = wasi_env.import_object(store, module)?;
+        let instance = Instance::new(store, module, &import_object)?;
 
         // Attach the memory export
         let memory = instance.exports.get_memory("memory")?;

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -145,9 +145,13 @@ pub fn native_err(
         .push((source.to_string(), body.to_string()));
 
     // Check if we have an __error transform
-    if !ctx.transforms.get("__error")
+    if !ctx
+        .transforms
+        .get("__error")
         .and_then(|t| t.find_transform_to(output_format))
-        .is_some() || source == "__error" {
+        .is_some()
+        || source == "__error"
+    {
         // If we don't have, don't add an __error parent since that would yield an CoreError
         // Also if the error did originate from an error module itself, don't generate more and
         // crash

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -26,14 +26,24 @@ define_native_packages! {
                 name: "source".to_string(),
                 default: Some("<unknown>".to_string()),
                 description: "The source module/parent responsible for the warning".to_string()
-            }
+            },
+            ArgInfo {
+                name: "target".to_string(),
+                default: Some("<unknown>".to_string()),
+                description: "The target output format when the warning was generated".to_string()
+            },
         ] => native_warn,
         "error", vec![
             ArgInfo {
                 name: "source".to_string(),
                 default: Some("<unknown>".to_string()),
                 description: "The source module/parent responsible for the error".to_string()
-            }
+            },
+            ArgInfo {
+                name: "target".to_string(),
+                default: Some("<unknown>".to_string()),
+                description: "The target output format when the error was generated".to_string()
+            },
         ] => native_err
     };
     "reparse" => {

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -143,7 +143,7 @@ pub fn native_warn(
         description: body.to_string(),
         input: args
             .remove("input")
-            .and_then(|s| (s != "<unknown>").then(|| s)),
+            .and_then(|s| (s != "<unknown>").then_some(s)),
     });
 
     // Return no new nodes
@@ -161,7 +161,7 @@ pub fn native_err(
     let target = args.get("target").unwrap();
     let input: Option<&String> = args
         .get("input")
-        .and_then(|s| (s != "<unknown>").then(|| s));
+        .and_then(|s| (s != "<unknown>").then_some(s));
 
     // Push the issue to errors
     ctx.state.errors.push(Issue {
@@ -172,11 +172,11 @@ pub fn native_err(
     });
 
     // Check if we have an __error transform
-    if !ctx
+    if ctx
         .transforms
         .get("__error")
         .and_then(|t| t.find_transform_to(output_format))
-        .is_some()
+        .is_none()
         || source == "__error"
     {
         // If we don't have, don't add an __error parent since that would yield an CoreError

--- a/modules/README.md
+++ b/modules/README.md
@@ -2,44 +2,59 @@
 
 Hey there!
 
-In this folder, you can find a bunch of useful packages that come with the compiler. But, what are packages, you ask? Well, they are programs that add support for transforming **module elements** (like `[math]` and `[table]`) as well as **parent elements** (like `**bold text**` and the document template) into a output format.
+In this folder, you can find a bunch of useful packages that come with the compiler. But, what are packages, you ask? Well, they are programs that add support for transforming
+**module elements** (like `[math]` and `[table]`) as well as **parent elements
+** (like `**bold text**` and the document template) into an output format.
 
-Packages work similarly to command-line programs: they receive a part of theto document in json format through stdin, modify it, and send the result back via stdout. Packages are loaded as `.wasm` files, which means they can be written in any programming language that supports WebAssembly (WASM) and the WebAssembly System Interface (WASI).
+Packages work similarly to command-line programs: they receive a part of the document in json format through stdin, modify it, and send the result back via stdout. Packages are loaded as `.wasm` files, which means they can be written in any programming language that supports WebAssembly (WASM) and the WebAssembly System Interface (WASI).
 
 For example, if you want to create your own package in Rust, compile it to `--target wasm32-wasi`.
 
-
 # Writing a package of your own
+
 If you wish to write your own package you need to handle two types of request that are specified as command-line arguments to your program.
 
 ## Manifest
-When your program is called with the arguments `$ ./my_program manifest` it expects to recieve a json object (sent via stdout) that explains how your package works and what transforms it supports. A manifest might look something like this:
+
+When your program is called with the arguments `$ ./my_program manifest` it expects to receive a json object (sent via stdout) that explains how your package works and what transforms it supports. A manifest might look something like this:
+
 ```json
 {
     "name": "Name of your package",
     "version": "0.1",
     "description": "A short description that explains the function of your package",
     "transforms": [
-            {
-                "from": "foo",
-                "to": ["html", "tex"],
-                "arguments": [
-                    {"name": "a_argument", "description": "This is the description for the argument 'a_argument'"},
-                    {"name": "another_argument", "default": "hello", "description": "..."}
-                ],
-            },
-            {
-                "from": "bar",
-                "arguments": [],
-            }
+        {
+            "from": "foo",
+            "to": [
+                "html",
+                "tex"
+            ],
+            "arguments": [
+                {
+                    "name": "a_argument",
+                    "description": "This is the description for the argument 'a_argument'"
+                },
+                {
+                    "name": "another_argument",
+                    "default": "hello",
+                    "description": "..."
+                }
+            ]
+        },
+        {
+            "from": "bar",
+            "arguments": []
+        }
     ]
 }
 ```
 
 ## Transforming an element
-When the program is called with `$ ./my_program transform <element_name> <output_format>` you will need to transform an element into the youdesired output format.
 
-You will be sent the element as json object via stdout and you respond by sending a json list of objects representing elements back.
+When the program is called with `$ ./my_program transform <element_name> <output_format>` you will need to transform an element into the desired output format.
+
+You will be sent the element as json object via stdout, and you respond by sending a json list of objects representing elements back.
 
 If you want to see some examples of what this json format looks like, you can check out the subdirectories or visit the online playground and select "JSON output".
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -42,3 +42,27 @@ When the program is called with `$ ./my_program transform <element_name> <output
 You will be sent the element as json object via stdout and you respond by sending a json list of objects representing elements back.
 
 If you want to see some examples of what this json format looks like, you can check out the subdirectories or visit the online playground and select "JSON output".
+
+## Handling errors
+
+Errors occur in all pieces of code, including your packages. As a part of the sandbox we build to run your packages in, we have built in some error handling.
+
+Here are the main ideas:
+
+* There are both **warnings** and **errors**, which are collected throughout the lifecycle of the compilation.
+* **Warnings** are treated as just warnings, and will take the output of your package and try to use it, assuming that the document generation may still proceed.
+* **Errors** are treated like errors, and the result of your package is ignored. If the output format has support for it, your module will be replaced by an error message that shows up in the document, at the place it occurred.
+* After document compilation, the warnings and errors should somehow be displayed for you to see, separately from the document, since you may have a couple of warnings but still have a valid document.
+
+We have tried to make it as simple as possible to generate **warnings**/**errors** if need be. As a part of `wasi` you have access to `stderr`, and the easiest and best way to generate **warnings**/**errors** is through that. Your code may also crash, and that will also be caught by our sandbox, but that should **never** be intentional.
+
+* If you want to generate an **error**, you should print the error text to `stderr` and then exit early **without printing anything valid to `stdout`**. Printing nothing is considered invalid.
+* If the sandbox sees that there is output in `stderr` and no valid output in `stdout`, it will treat **each line** in `stderr` as a separate error.
+* If you want to generate a **warning**, you should print the warning text to `stderr` and then proceed to executing your code as normal, returning the normal output.
+* If the sandbox sees that there is output in `stderr` but still a valid tree structure in `stdout`, it will treat **each line** in `stderr` as a separate warning
+* If your module does crash, it will clearly be treated as an error but depending on the language you write in, the error text may not be as customizable as you could have hoped. It is
+  ***not allowed to intentionally crash your module to emit errors***.
+
+Under the hood, for each error an `[error]` module is created, and for each warning, a `[warning]` module is created. A native package takes care of them and takes the appropriate action. To have some sort of traceback, the modules take a `source` parameter, which is the name of the module that was invoked which caused the error, `target`, which is the target output format when the error occurred, and `input` which is the input that the module received when the error occurred. It is strongly advised to generate errors by `stderr` since these fields will be filled automatically, but if you want you may use these `[error]`/`[warning]` modules. When evaluated, `[warning]` modules do disappear, while `[error]` modules will check if there is a transform from `[__error]` to the desired output format. If there is, it will create such an `[__error]` module, copying the arguments, to allow the language package to show errors in-line.
+
+If you are implementing the `[__error]` transform itself, it is very important that **it doesn't delegate to any other module which errors**. If an error occurs within the `[__error]` module, it will create an `[error]` module with `[__error]` as source, and the `[error]` module figures out that it shouldn't generate any more `[__error]` modules. But if the `[__error]` module generated some other module that crashed, the source of that error won't be `[__error]` and another `[__error]` will be created, possibly leading to infinite recursion. ***Only have simple behaviours within your `[__error]` handler to avoid infinite recursion. It is strongly suggested to not create any other nodes that may fail within the `[__error]` handler***

--- a/modules/html/src/example.json
+++ b/modules/html/src/example.json
@@ -1,12 +1,5 @@
 {
-    "name": "__bold",
-    "arguments": {},
-    "children": [
-        {
-            "name": "__text",
-            "data": "Hello, world",
-            "arguments": {},
-            "inline": true
-        }
-    ]
+    "name": "__error",
+    "arguments": {"source": "blabla"},
+    "data": "SOME ERROR OCCURED haha"
 }

--- a/modules/html/src/example.json
+++ b/modules/html/src/example.json
@@ -1,5 +1,12 @@
 {
-    "name": "__error",
-    "arguments": {"source": "blabla"},
-    "data": "SOME ERROR OCCURED haha"
+    "name": "__bold",
+    "arguments": {},
+    "children": [
+        {
+            "name": "__text",
+            "data": "Hello, world",
+            "arguments": {},
+            "inline": true
+        }
+    ]
 }

--- a/modules/html/src/main.rs
+++ b/modules/html/src/main.rs
@@ -118,18 +118,10 @@ fn transform_error(error: Value) -> String {
     )
     .unwrap();
 
-    write!(
-        result,
-        r#"{{"name": "raw", "data": "ERROR! Originating from {source}<br />Error: {err}"}},"#,
-    )
-    .unwrap();
+    let data = escape(format!("Error originating from {source}: {err}").as_str());
+    write!(result, r#"{{"name": "raw", "data": "{data}"}},"#,).unwrap();
 
-    write!(
-        result,
-        r#"{{"name": "raw", "data": "</span>"}}"#,
-    )
-        .unwrap();
-
+    write!(result, r#"{{"name": "raw", "data": "</span>"}}"#,).unwrap();
 
     result.push(']');
 
@@ -138,18 +130,21 @@ fn transform_error(error: Value) -> String {
 
 fn escape_text(module: Value) -> String {
     if let Value::String(s) = &module["data"] {
-        let s = s
-            .replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;")
-            .replace('"', "&quot;")
-            .replace('\'', "&#39;")
-            .replace("\r\n", "\\n")
-            .replace('\n', "\\n");
+        let s = escape(s);
         format!(r#"[{{"name": "raw", "data": "{s}"}}]"#)
     } else {
         panic!("Malformed text module");
     }
+}
+
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace("\r\n", "\\n")
+        .replace('\n', "\\n")
 }
 
 fn transform_tag(node: Value, html_tag: &str) -> String {

--- a/modules/html/src/main.rs
+++ b/modules/html/src/main.rs
@@ -108,6 +108,9 @@ fn transform_error(error: Value) -> String {
     let Value::String(source) = &error["arguments"]["source"] else {
         panic!();
     };
+    let Value::String(input) = &error["arguments"]["input"] else {
+        panic!();
+    };
     let Value::String(err) = &error["data"] else {
         panic!();
     };
@@ -118,10 +121,18 @@ fn transform_error(error: Value) -> String {
     )
     .unwrap();
 
-    let data = escape(format!("Error originating from {source}: {err}").as_str());
-    write!(result, r#"{{"name": "raw", "data": "{data}"}},"#,).unwrap();
+    let data = escape(format!("Error originating from {source}: {err} on input {input}").as_str());
+    write!(
+        result,
+        "{}",
+        json!({
+            "name":"raw", "data":data
+        })
+        .to_string()
+    )
+    .unwrap();
 
-    write!(result, r#"{{"name": "raw", "data": "</span>"}}"#,).unwrap();
+    write!(result, r#",{{"name": "raw", "data": "</span>"}}"#,).unwrap();
 
     result.push(']');
 
@@ -229,6 +240,11 @@ fn manifest() -> String {
                     {
                         "name":"target",
                         "description":"Target for the error",
+                        "default":"<unknown>"
+                    },
+                    {
+                        "name":"input",
+                        "description":"Input for the error",
                         "default":"<unknown>"
                     },
                 ],

--- a/modules/html/src/main.rs
+++ b/modules/html/src/main.rs
@@ -69,7 +69,8 @@ fn transform_document(doc: Value) -> String {
 
     write!(
         result,
-        r#"{{"name": "raw", "data": "<html><head><title>Document</title></head><body>"}},"#
+        "{},",
+        raw!("<html><head><title>Document</title></head><body>")
     )
     .unwrap();
 
@@ -80,7 +81,7 @@ fn transform_document(doc: Value) -> String {
         }
     }
 
-    write!(result, r#"{{"name": "raw", "data": "</body></html>"}}"#).unwrap();
+    write!(result, "{}", raw!("</body></html>")).unwrap();
     result.push(']');
 
     result
@@ -95,7 +96,7 @@ fn transform_heading(heading: Value) -> String {
     };
     let level = s.parse::<u8>().unwrap().clamp(1, 6);
 
-    write!(result, r#"{{"name": "raw", "data": "<h{level}>"}},"#,).unwrap();
+    write!(result, "{},", raw!(format!("<h{level}>"))).unwrap();
 
     if let Value::Array(children) = &heading["children"] {
         for child in children {
@@ -104,7 +105,7 @@ fn transform_heading(heading: Value) -> String {
         }
     }
 
-    write!(result, r#"{{"name": "raw", "data": "</h{level}>"}}"#,).unwrap();
+    write!(result, "{},", raw!(format!("</h{level}>"))).unwrap();
     result.push(']');
 
     result
@@ -139,7 +140,7 @@ fn transform_error(error: Value) -> String {
 fn escape_text(module: Value) -> String {
     if let Value::String(s) = &module["data"] {
         let s = escape(s);
-        format!(r#"[{{"name": "raw", "data": "{s}"}}]"#)
+        format!("[{}]", raw!(s).to_string())
     } else {
         panic!("Malformed text module");
     }
@@ -151,8 +152,6 @@ fn escape(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
-        .replace("\r\n", "\\n")
-        .replace('\n', "\\n")
 }
 
 fn transform_tag(node: Value, html_tag: &str) -> String {

--- a/modules/html/src/main.rs
+++ b/modules/html/src/main.rs
@@ -125,6 +125,10 @@ fn transform_error(error: Value) -> String {
         panic!();
     };
 
+    // TODO: Maybe make these errors look better. Be careful though, see notes in API, don't use
+    //   calls to other modules that may fail. I have taken care to not use __text but rather just
+    //   entered the text myself, because if I used __text and that failed, it would lead to
+    //   infinite recursion, which is bad
     write!(result, "{},", raw!(r#"<span style="background:#FF0000">"#)).unwrap();
 
     let data = escape(format!("Error originating from {source}: {err} on input {input}").as_str());
@@ -157,7 +161,8 @@ fn escape(text: &str) -> String {
 fn transform_tag(node: Value, html_tag: &str) -> String {
     let mut result = String::new();
     result.push('[');
-    write!(result, r#"{{"name": "raw", "data": "<{html_tag}>" }},"#).unwrap();
+
+    write!(result, "{},", raw!(format!("<{html_tag}>"))).unwrap();
 
     if let Value::Array(children) = &node["children"] {
         for child in children {
@@ -166,7 +171,7 @@ fn transform_tag(node: Value, html_tag: &str) -> String {
         }
     }
 
-    write!(result, r#"{{"name": "raw", "data": "</{html_tag}>" }}"#).unwrap();
+    write!(result, "{}", raw!(format!("</{html_tag}>"))).unwrap();
     result.push(']');
 
     result

--- a/modules/html/src/main.rs
+++ b/modules/html/src/main.rs
@@ -6,6 +6,15 @@ use std::{
 
 use serde_json::{from_str, json, Value};
 
+macro_rules! raw {
+    ($expr:expr) => {
+        json!({
+            "name": "raw",
+            "data": $expr
+        })
+    }
+}
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
@@ -115,24 +124,12 @@ fn transform_error(error: Value) -> String {
         panic!();
     };
 
-    write!(
-        result,
-        r#"{{"name": "raw", "data": "<span style=\"background:#FF0000\">"}},"#,
-    )
-    .unwrap();
+    write!(result, "{},", raw!(r#"<span style="background:#FF0000">"#)).unwrap();
 
     let data = escape(format!("Error originating from {source}: {err} on input {input}").as_str());
-    write!(
-        result,
-        "{}",
-        json!({
-            "name":"raw", "data":data
-        })
-        .to_string()
-    )
-    .unwrap();
+    write!(result, "{},", raw!(data)).unwrap();
 
-    write!(result, r#",{{"name": "raw", "data": "</span>"}}"#,).unwrap();
+    write!(result, "{}", raw!("</span>")).unwrap();
 
     result.push(']');
 

--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -121,58 +121,72 @@
 </head>
 
 <body>
-    <div class="menu">
-        <div class="menu-items">
-            <div class="left-menu" id="left-menu">
-                <h1>Modmark playground</h1>
-                <select name="selector" id="selector">
-                    <option value="ast">Abstract syntax tree</option>
-                    <option value="ast-debug">Debug AST</option>
-                    <option value="json-output">JSON output</option>
-                    <option value="transpile">HTML output</option>
-                    <option value="render">Rendered HTML</option>
-                </select>
-                <button id="view-toggle">
+<div class="menu">
+    <div class="menu-items">
+        <div class="left-menu" id="left-menu">
+            <h1>Modmark playground</h1>
+            <select name="selector" id="selector">
+                <option value="ast">Abstract syntax tree</option>
+                <option value="ast-debug">Debug AST</option>
+                <option value="json-output">JSON output</option>
+                <option value="transpile">HTML output</option>
+                <option value="render">Rendered HTML</option>
+            </select>
+            <button id="view-toggle">
                     <span class="material-symbols-outlined">
                         widgets
                     </span>
-                    View packages
-                </button>
-            </div>
-            <a href="https://github.com/modmark-org/modmark">
+                View packages
+            </button>
+        </div>
+        <a href="https://github.com/modmark-org/modmark">
                 <span class="material-symbols-outlined">
                     info
                 </span>
-                GitHub
-            </a>
-        </div>
+            GitHub
+        </a>
     </div>
-    <main id="wrapper">
-        <div id="editor-view">
-            <textarea id="editor"></textarea>
-            <div id="preview">
-                <div id="output"></div>
-                <div id="error-prompt">
+</div>
+<main id="wrapper">
+    <div id="editor-view">
+        <textarea id="editor"></textarea>
+        <div id="preview">
+            <div id="output"></div>
+            <div id="error-prompt">
                     <span class="material-symbols-outlined">
                         report
                     </span>
-                    <strong>Error</strong>
-                    <div id="error-log"></div>
+                <strong>Error</strong>
+                <div id="error-log"></div>
+            </div>
+            <div id="problem-box">
+                <div id="warnings" class="problem-inner-box">
+                    <div id="warnings-text">
+                        <span>Here is a warning</span>
+                        <br>
+                        <span>Here is another warning</span>
+                    </div>
                 </div>
-
+                <div id="errors" class="problem-inner-box">
+                    <div id="errors-text">
+                        HERE IS AN ERROR<br>
+                        HERE IS ANOTHER ERROR
+                    </div>
+                </div>
             </div>
         </div>
-        <div id="package-view">
-            <div id="packages">
-                <h2>Packages</h2>
-                <div class="note">Note: this will be made a lot easier to use once we
-                    have a more stable package API.
-                </div>
-                <pre id="package-content">
+    </div>
+    <div id="package-view">
+        <div id="packages">
+            <h2>Packages</h2>
+            <div class="note">Note: this will be made a lot easier to use once we
+                have a more stable package API.
+            </div>
+            <pre id="package-content">
                 </pre>
-            </div>
         </div>
-    </main>
+    </div>
+</main>
 </body>
 
 </html>

--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -7,13 +7,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap" rel="stylesheet">
     <title>Modmark Playground</title>
     <link rel="stylesheet" href="style.css">
     <script type="module">
-        import init, { ast, ast_debug, inspect_context, transpile, json_output } from "./pkg/web_bindings.js";
+        import init, {ast, ast_debug, inspect_context, json_output, transpile} from "./pkg/web_bindings.js";
 
         let view = "editor";
 
@@ -27,6 +27,9 @@
         const editorView = document.getElementById("editor-view");
         const viewToggle = document.getElementById("view-toggle");
         const leftMenu = document.getElementById("left-menu");
+        const problemBox = document.getElementById("problem-box");
+        const warningsBox = document.getElementById("warnings-text");
+        const errorsBox = document.getElementById("errors-text");
 
 
         function buttonContent(text, icon) {
@@ -70,6 +73,7 @@
             // Clear the errors
             errorLog.innerText = "";
             errorPrompt.style.display = "none";
+            problemBox.style.display = "none";
 
             let pre = document.createElement("pre")
             try {
@@ -80,14 +84,45 @@
                     case "ast-debug":
                         pre.innerText = ast_debug(input);
                         break;
+                    case "render":
                     case "transpile":
-                        pre.innerHTML = transpile(input);
+                        let res = JSON.parse(transpile(input));
+
+                        let hasProblems = false;
+                        const warnings = res.warnings.length;
+                        if (warnings !== 0) {
+                            let warningsText = `<strong>${warnings} warning${warnings === 1 ? "" : "s"}</strong>`;
+                            for (const warning of res.warnings) {
+                                warningsText += `<br>${warning}`
+                            }
+                            warningsBox.innerHTML = warningsText;
+                            hasProblems = true
+                        } else {
+                            warningsBox.innerHTML = "<strong>No warnings</strong>";
+                        }
+
+                        const errors = res.errors.length;
+                        if (errors !== 0) {
+                            let errorsText = `<strong>${errors} error${errors === 1 ? "" : "s"}</strong>`;
+                            for (const error of res.errors) {
+                                errorsText += `<br>${error}`
+                            }
+                            errorsBox.innerHTML = errorsText;
+                            hasProblems = true
+                        } else {
+                            errorsBox.innerHTML = "<strong>No errors</strong>";
+                        }
+
+                        if (hasProblems) problemBox.style.display = "block";
+
+                        if (selector.value === "render") {
+                            output.innerHTML = res.content;
+                        } else {
+                            pre.innerHTML = res.content;
+                        }
                         break;
                     case "json-output":
                         pre.innerHTML = json_output(input);
-                        break;
-                    case "render":
-                        output.innerHTML = transpile(input);
                         break;
                 }
             } catch (error) {
@@ -99,7 +134,6 @@
                 output.innerHTML = pre.outerHTML;
             }
         }
-
 
 
         init().then(() => {
@@ -161,17 +195,10 @@
             </div>
             <div id="problem-box">
                 <div id="warnings" class="problem-inner-box">
-                    <div id="warnings-text">
-                        <span>Here is a warning</span>
-                        <br>
-                        <span>Here is another warning</span>
-                    </div>
+                    <div id="warnings-text"></div>
                 </div>
                 <div id="errors" class="problem-inner-box">
-                    <div id="errors-text">
-                        HERE IS AN ERROR<br>
-                        HERE IS ANOTHER ERROR
-                    </div>
+                    <div id="errors-text"></div>
                 </div>
             </div>
         </div>

--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -113,7 +113,7 @@
                             errorsBox.innerHTML = "<strong>No errors</strong>";
                         }
 
-                        if (hasProblems) problemBox.style.display = "block";
+                        if (hasProblems) problemBox.style.display = "flex";
 
                         if (selector.value === "render") {
                             output.innerHTML = res.content;

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -116,6 +116,7 @@ select:hover {
 
 #preview {
     background: rgb(242, 242, 242);
+    position: relative;
 }
 
 #error-prompt {
@@ -129,6 +130,34 @@ select:hover {
 #error-log pre {
     overflow: scroll;
     opacity: 0.4;
+}
+
+#problem-box {
+    position: absolute;
+    bottom: 2rem;
+}
+
+.problem-inner-box {
+    width:48%;
+    display: inline-block;
+    border-radius: 0.3rem;
+}
+
+#warnings {
+    background: #e6e600;
+}
+
+#errors {
+    background: #dc0000;
+}
+
+#warnings-text {
+    margin: 1rem;
+    font-size: 12px;
+}
+
+#errors-text {
+    margin: 1rem;
 }
 
 #error-prompt strong {

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -133,6 +133,7 @@ select:hover {
 }
 
 #problem-box {
+    display: none;
     position: absolute;
     bottom: 2rem;
 }

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -6,11 +6,10 @@ body {
 
 .material-symbols-outlined {
     position: relative;
-    font-variation-settings:
-        'FILL' 0,
-        'wght' 400,
-        'GRAD' 0,
-        'opsz' 48;
+    font-variation-settings: 'FILL' 0,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 48;
     font-size: 1rem;
     top: 1px;
 }
@@ -117,6 +116,8 @@ select:hover {
 #preview {
     background: rgb(242, 242, 242);
     position: relative;
+    display: flex;
+    flex-direction: column;
 }
 
 #error-prompt {
@@ -134,12 +135,14 @@ select:hover {
 
 #problem-box {
     display: none;
-    position: absolute;
-    bottom: 2rem;
+    margin-top: auto;
+    font-size: 12px;
 }
 
 .problem-inner-box {
-    width:48%;
+    width: 50%;
+    margin-right: 0.4rem;
+    margin-left: 0.4rem;
     display: inline-block;
     border-radius: 0.3rem;
 }
@@ -154,7 +157,6 @@ select:hover {
 
 #warnings-text {
     margin: 1rem;
-    font-size: 12px;
 }
 
 #errors-text {
@@ -203,7 +205,7 @@ select:hover {
     #editor,
     #output {
         height: auto;
-        height: calc((100vh - 4rem)/2);
+        height: calc((100vh - 4rem) / 2);
         width: 100%;
     }
 

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -18,3 +18,5 @@ wasm-bindgen = "0.2.63"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6" }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -48,8 +48,7 @@ pub fn transpile(source: &str) -> Result<String, PlaygroundError> {
         let mut ctx = ctx.borrow_mut();
         eval(source, &mut ctx, &OutputFormat::new("html"))
     })?;
-
-    Ok(result)
+    result.0
 }
 
 #[wasm_bindgen]

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,4 +1,4 @@
-use core::{eval, Context, CoreError, OutputFormat};
+use core::{context::Issue, eval, Context, CoreError, OutputFormat};
 use std::cell::RefCell;
 
 use parser::ParseError;
@@ -62,13 +62,13 @@ pub fn transpile(source: &str) -> Result<String, PlaygroundError> {
         .1
         .warnings
         .iter()
-        .map(|(source, text)| escape(format!("{source}: {text}")))
+        .map(|issue| escape(issue.to_string()))
         .collect();
     let errors = result
         .1
         .errors
         .iter()
-        .map(|(source, text)| escape(format!("{source}: {text}")))
+        .map(|issue| escape(issue.to_string()))
         .collect();
     let transpile = Transpile {
         content: result.0,
@@ -79,8 +79,7 @@ pub fn transpile(source: &str) -> Result<String, PlaygroundError> {
 }
 
 fn escape(text: String) -> String {
-    text
-        .replace('&', "&amp;")
+    text.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,4 +1,4 @@
-use core::{context::Issue, eval, Context, CoreError, OutputFormat};
+use core::{eval, Context, CoreError, OutputFormat};
 use std::cell::RefCell;
 
 use parser::ParseError;

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -62,13 +62,13 @@ pub fn transpile(source: &str) -> Result<String, PlaygroundError> {
         .1
         .warnings
         .iter()
-        .map(|(source, text)| format!("{source}: {text}"))
+        .map(|(source, text)| escape(format!("{source}: {text}")))
         .collect();
     let errors = result
         .1
         .errors
         .iter()
-        .map(|(source, text)| format!("{source}: {text}"))
+        .map(|(source, text)| escape(format!("{source}: {text}")))
         .collect();
     let transpile = Transpile {
         content: result.0,
@@ -76,6 +76,17 @@ pub fn transpile(source: &str) -> Result<String, PlaygroundError> {
         errors,
     };
     Ok(serde_json::to_string(&transpile).unwrap())
+}
+
+fn escape(text: String) -> String {
+    text
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace("\r\n", "\\n")
+        .replace('\n', "\\n")
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
This PR aims at adding error handling for modules. A module may fail for multiple reasons, and the default behaviour shouldn't be that no part of the document can be evaluated just because one module fails. It may not be obvious why a module failed, especially if one module invokes other modules etc.

This implementation of error handling works on this fundamental concept:
* The `Context` has a `CompilationState`, which keeps the state of the document compilation, including what errors and warnings have occurred

To facilitate error reporting, these native modules have been added:
* `[error]` which adds an error to the current context, and takes optional arguments `source` and `target`
* `[warning]` which adds an warning to the current context, and takes optional arguments `source` and `target`

Additionally, the `[error]` module will check if there is a package (usually the language package) handling `[__error]` modules, and will then generate such a module. This makes it possible to make the errors appear when they occur, at the place they occur, in the output document (for example, as red text describing the error), in addition to being collected. If no such `[__error]` transform exists, or if it itself is responsible for the error, no such module will be given.

Since wasi-modules have access to `stdout` and `stderr`, `stderr` was leveraged to allow for even easier warning/error reporting for developers:
* If a line is printed to `stderr`, it will become either a warning or an error (one warning/error per line)
* If `stdout` contains text, the lines in `stderr` are treated as warnings, and otherwise as errors. If `stdout` contains text (and the `stderr` lines thus are treated as warnings), the result will still be parsed as an `Element` and put into the tree. This is assuming that a warning occurred that didn't have to stop evaluation of the module (for example, an invalid language specified for a `code` module, but the text can still be displayed unformatted).

Additionally, calls to modules in wasmer results in a `Result`. If that fails, it is assumed that the module crashed (`panic`ed or similar), and its output won't be trusted to contain correct and uncorrupted data. Thus, it will generate an error and its output won't be used.

In addition to these things, this PR includes some basic error formatting for the HTML module as well as displaying the collected errors in the playground.

***Note:*** This PR is still a draft. It isn't finished yet, and several aspects and specifications described above are subject to change.

Todo before finished:
- [x] Determine if it is appropriate to save the input text to a module when an error occurred.
- [x] Change `(String, String)` (`(Source, Text)`) for a custom `Issue` type, possibly containing more data.
- [x] ~~Improving error display in HTML.~~ I think I'll leave that to the people working on the modules, but I have a placeholder implementation which works, and improvements can be made upon that.
- [x] Improving the `transform` function when it comes to error handling; there is some repeated code there at the moment, and a lot of boiler-plate that may be abstracted away.
- [x] Determine the necessity for the `target` field, and the necessity for adding additional fields.
- [x] General clean-up.

Resolves #85