### PR TITLE
GH-87: Add specific deserialization error

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -319,7 +319,11 @@ impl Context {
 
     /// Deserialize a compound (i.e a list of `JsonEntries`) that are recived from a package
     pub fn deserialize_compound(input: &str) -> Result<Element, CoreError> {
-        let entries: Vec<JsonEntry> = serde_json::from_str(input)?;
+        let entries: Vec<JsonEntry> =
+            serde_json::from_str(input).map_err(|error| CoreError::DeserializationError {
+                string: input.to_string(),
+                error,
+            })?;
 
         // Convert the parsed entries into real Elements
         let elements: Vec<Element> = entries.into_iter().map(Self::entry_to_element).collect();

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -40,8 +40,13 @@ pub enum CoreError {
     MissingArgument(String, String),
     #[error("Argument '{0}' is not supported by the element '{1}'.")]
     InvalidArgument(String, String),
-    #[error("Failed to serialize json")]
+    #[error("Json error")]
     JsonError(#[from] serde_json::Error),
+    #[error("Failed to deserialize '{string}', got error '{error}'.")]
+    DeserializationError {
+        string: String,
+        error: serde_json::Error,
+    },
     #[error("Transform does not terminate")]
     NonTerminatingTransform,
     #[error("Parsing error: {0:#?}.")]

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -114,7 +114,10 @@ impl Package {
         let manifest = {
             let mut buffer = String::new();
             output.read_to_string(&mut buffer)?;
-            serde_json::from_str(&buffer).map_err(|e| e.into())
+            serde_json::from_str(&buffer).map_err(|error| CoreError::DeserializationError {
+                string: buffer.clone(),
+                error,
+            })
         };
 
         manifest


### PR DESCRIPTION
Resolves #87 by introducing a new deserialization error type. A downside is that if the question mark operator is used on serde_json::Error it will always give the generic json error but since all errors are the same in serde_json I don't see another way to do it.

Here is an example if you break a module (table in this case):
![image](https://user-images.githubusercontent.com/40837400/220853798-bc0a8b7d-1afc-47df-8135-ce4d30a13455.png)
