### PR TITLE
GH-91: Add support for disabling the bundling of standard packages

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parser = {version= "*", path = "../parser/"}
-core = {version= "*", path = "../core/"}
+parser = {version= "*", path = "../parser/" }
+core = {version= "*", path = "../core/", default-features = false, features = ["native"]}
 clap = { version = "4.1.4", features = ["derive"] }
 notify = "5.0.0"
 crossterm = "0.26.0"
 thiserror = "1.0.38"
 directories = "4.0.1"
+
+[features]
+default = ["core/bundle_std_packages"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ either = "1.8.1"
 # Use the "web" feature to support web builds with:
 [features]
 # `wasm-pack build --target web`
-default = ["native"]
+default = ["native", "bundle_std_packages"]
 native = ["wasmer/sys-default", "wasmer-wasi/sys-default"]
 web = ["wasmer/js-default", "wasmer-wasi/js"]
+bundle_std_packages = []

--- a/core/build.rs
+++ b/core/build.rs
@@ -5,10 +5,16 @@ use std::{
     process::Command,
 };
 
+fn main() {
+    // build packages if we want to bundle them
+    #[cfg(feature = "bundle_std_packages")]
+    build_packages()
+}
+
 // This build script will build all of the crates found in the top level "modules" directory
 // into wasm binary files which allows core to load them from the path
 // env!("OUT_DIR")/out/<name_of_module>/wasm32_wasi/release/<name_of_module>.wasm
-fn main() {
+fn build_packages() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let workspace_path = {

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -86,7 +86,8 @@ macro_rules! define_native_packages {
 /// that the standard package cargo name is the same as the containing folder name.
 macro_rules! define_standard_package_loader {
     ($($name:expr),* $(,)?) => {
-        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError>{
+        #[cfg(feature = "bundle_std_packages")]
+        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError> {
             $(
                 ctx.load_package_from_wasm(
                     include_bytes!(
@@ -103,7 +104,11 @@ macro_rules! define_standard_package_loader {
             )*
             Ok(())
         }
-    }
+        #[cfg(not(feature = "bundle_std_packages"))]
+        pub fn load_standard_packages(_: &mut Context) -> Result<(), CoreError> {
+            Ok(())
+        }
+    };
 }
 
 pub(crate) use define_native_packages;

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -11,13 +11,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 parser = { version = "*", path = "../../parser/" }
 thiserror = "1.0.38"
-core = { version = "*", path = "../../core/", default-features = false, features = ["web"] }
+core = { version = "*", path = "../../core/", default-features = false, features = ["web", "bundle_std_packages"] }
 wasm-bindgen = "0.2.63"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6" }
-
-[features]
-default = ["core/bundle_std_packages"]

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -9,12 +9,15 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parser = {version= "*", path = "../../parser/"}
+parser = { version = "*", path = "../../parser/" }
 thiserror = "1.0.38"
-core = {version= "*", path = "../../core/", default-features = false, features = ["web"]}
+core = { version = "*", path = "../../core/", default-features = false, features = ["web"] }
 wasm-bindgen = "0.2.63"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6" }
+
+[features]
+default = ["core/bundle_std_packages"]


### PR DESCRIPTION
This PR adds support for disabling bundling of standard packages. There is now a feature `bundle_std_packages` which is enabled by default, which makes sure the packages are built and bundled. If you build either `cli` or `playground` with `--no-default-features`, it will be disabled and the packages will not be bundled.

Resolves #91