### PR TITLE
GH-93: Allow modules in headings

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -204,29 +204,18 @@ fn parse_document_blocks(input: &str) -> IResult<&str, Vec<Ast>> {
 ///
 /// returns: The heading node, if a successful parse occurs, otherwise the parse error
 fn parse_heading(input: &str) -> IResult<&str, Heading> {
-    let res = map(
+    map(
         pair(
             verify(take_while1(|c| c == '#'), |s: &str| {
                 s.len() <= u8::MAX as usize
             }),
-            preceded(space0, parse_heading_text),
+            preceded(space0, parse_heading_text).and_then(parse_paragraph_elements),
         ),
-        |(start, body)| (start, body),
-    )(input);
-
-    return match res {
-        Ok((str, (start, body))) => {
-            let (_, elements) = parse_paragraph_elements(body).unwrap();
-            Ok((
-                str,
-                Heading {
-                    level: start.len() as u8,
-                    elements,
-                },
-            ))
-        }
-        Err(e) => Err(e),
-    };
+        |(start, elements)| Heading {
+            level: start.len() as u8,
+            elements,
+        },
+    )(input)
 }
 
 /// Parses the text for a heading, consuming until a line ending is found.

--- a/parser/tests/compilation_tests/headings_with_tags.mdmtest
+++ b/parser/tests/compilation_tests/headings_with_tags.mdmtest
@@ -78,7 +78,13 @@ text //
         {
             "name": "Heading1",
             "children": [
-                "title [math]{x^2}"
+                "title ",
+                {
+                    "name": "math",
+                    "args": {},
+                    "body": "x^2",
+                    "one_line": true
+                }
             ]
         }
     ]


### PR DESCRIPTION
Resolves: #93 

This PR extends the functionality of headings to allow modules. This is done by using ``parse_paragraph_elements`` inside ``parse_heading``.

Example: ``# This heading has a cool equation: [math]x^2=4``

