### PR TITLE
GH-116: Add math module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ members = [
     "package-tests"
 ]
 
-
-exclude = ["packages/table", "packages/html", "packages/latex", "packages/code", "playground/web_bindings"]
-
+exclude = ["packages/table", "packages/html", "packages/latex", "packages/code", "packages/math", "playground/web_bindings"]
 
 # We need to specifiy that we use the new resolver to
 # get wasmer to build correctly when using a workspace

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -13,7 +13,11 @@ use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Tra
 // package with a given name both is in a folder with that name, containing a cargo package with
 // that name. Otherwise, the module won't be found
 define_standard_package_loader! {
-    "table", "html", "latex", "code",
+    "table",
+    "html",
+    "latex",
+    "code",
+    "math",
 }
 
 // Here, all native packages are declared. The macro expands to two functions,

--- a/packages/math/Cargo.toml
+++ b/packages/math/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "math"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = "1.0.152"
+serde_json = "1.0.93"
+latex2mathml = "0.2.3"

--- a/packages/math/src/main.rs
+++ b/packages/math/src/main.rs
@@ -1,0 +1,147 @@
+use std::io::Read;
+use std::{env, io};
+
+use latex2mathml::{latex_to_mathml, DisplayStyle};
+use serde_json::{json, Value};
+
+macro_rules! raw {
+    ($expr:expr) => {
+        json!({
+            "name": "raw",
+            "data": $expr
+        })
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let action = &args[0];
+    match action.as_str() {
+        "manifest" => manifest(),
+        "transform" => transform(&args[1], &args[2]),
+        other => {
+            eprintln!("Invalid action {other}");
+        }
+    }
+}
+
+fn manifest() {
+    print!(
+        "{}",
+        serde_json::to_string(&json!(
+            {
+            "name": "math",
+            "version": "0.1",
+            "description": "This package provides inline and multiline [math] modules",
+            "transforms": [
+                {
+                    "from": "math",
+                    "to": ["html", "latex"],
+                    "arguments": [
+                        {
+                            "name": "import",
+                            "default": "false",
+                            "description": r#"If set to "true", a Mathjax import will be added to HTML outputs for maximum compatibility"#
+                        }
+                    ],
+                }
+            ]
+            }
+        ))
+        .unwrap()
+    );
+}
+
+fn transform(from: &str, to: &str) {
+    match from {
+        "math" => transform_math(to),
+        other => {
+            eprintln!("Package does not support transforming from {other}");
+        }
+    }
+}
+
+fn transform_math(to: &str) {
+    let json: Value = {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).unwrap();
+        serde_json::from_str(&buffer).unwrap()
+    };
+
+    match to {
+        "html" => math_to_html(&json),
+        "latex" => math_to_latex(&json),
+        other => {
+            eprintln!("Package does not support transforming math to {other}");
+        }
+    }
+}
+
+fn math_to_html(json: &Value) {
+    // This import is added as part of the output, but when we get variables up and running, we
+    // would stick it into the import variable
+    let import = r#"<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/mml-chtml.js"></script>"#;
+
+    let import_opt = json["arguments"]["import"]
+        .as_str()
+        .expect(r#""import" as string"#);
+    let do_import = !import_opt.eq_ignore_ascii_case("false");
+    if !import_opt.eq_ignore_ascii_case("true") && !import_opt.eq_ignore_ascii_case("false") {
+        eprintln!(
+            r#"Argument "import" expected to be "true" or "false", but was actually "{import_opt}""#
+        );
+    }
+
+    let body = json["data"].as_str().expect("Data as string");
+    let inline = json["inline"].as_bool().expect("Inline as bool");
+    let inline_hint = if inline {
+        DisplayStyle::Inline
+    } else {
+        DisplayStyle::Block
+    };
+    let result = latex_to_mathml(body, inline_hint);
+    match result {
+        Ok(mathml) => {
+            if do_import {
+                println!(
+                    "{}",
+                    json! {[
+                        raw!(import),
+                        raw!(mathml)
+                    ]}
+                );
+            } else {
+                println!(
+                    "{}",
+                    json! {[
+                        raw!(mathml)
+                    ]}
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to parse latex: {e}");
+        }
+    }
+}
+
+fn math_to_latex(json: &Value) {
+    let body = json["data"].as_str().expect("Data as string");
+    if json["inline"].as_bool().expect("Inline as bool") {
+        println!(
+            "{}",
+            json! {[
+                raw!(format!("${}$", body.replace('$', r"\$")))
+            ]}
+        );
+    } else {
+        println!(
+            "{}",
+            json! {[
+                raw!(r"\begin{equation}"),
+                raw!(body),
+                raw!(r"\end{equation}")
+            ]}
+        );
+    }
+}

--- a/packages/math/tests/test_import_html.json
+++ b/packages/math/tests/test_import_html.json
@@ -1,0 +1,19 @@
+{
+    "name": "math",
+    "arguments": {
+        "import": "true"
+    },
+    "data": "x^2",
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<script id=\"MathJax-script\" async src=\"https://cdn.jsdelivr.net/npm/mathjax@3/es5/mml-chtml.js\"></script>",
+            "name": "raw"
+        },
+        {
+            "data": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><msup><mi>x</mi><mn>2</mn></msup></math>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/math/tests/test_inline_html.json
+++ b/packages/math/tests/test_inline_html.json
@@ -1,0 +1,15 @@
+{
+    "name": "math",
+    "arguments": {
+        "import": "false"
+    },
+    "data": "x^2",
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><msup><mi>x</mi><mn>2</mn></msup></math>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/math/tests/test_inline_latex.json
+++ b/packages/math/tests/test_inline_latex.json
@@ -1,0 +1,15 @@
+{
+    "name": "math",
+    "arguments": {
+        "import": "false"
+    },
+    "data": "x^2",
+    "inline": true,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "$x^2$",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/math/tests/test_multiline_html.json
+++ b/packages/math/tests/test_multiline_html.json
@@ -1,0 +1,15 @@
+{
+    "name": "math",
+    "arguments": {
+        "import": "false"
+    },
+    "data": "x^2",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\"><msup><mi>x</mi><mn>2</mn></msup></math>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/math/tests/test_multiline_latex.json
+++ b/packages/math/tests/test_multiline_latex.json
@@ -1,0 +1,23 @@
+{
+    "name": "math",
+    "arguments": {
+        "import": "false"
+    },
+    "data": "x^2",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{equation}",
+            "name": "raw"
+        },
+        {
+            "data": "x^2",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{equation}",
+            "name": "raw"
+        }
+    ]
+}

--- a/playground/static/example.mdm
+++ b/playground/static/example.mdm
@@ -5,11 +5,12 @@ It allows for syntactical constructions similar to Markdown,
 such as **bold text**, //italic text//, ~~some ==crazy
 __combination__==~~, but the coolest feature of all are modules:
 
-Here, we invoke the table module, and print x, x^2 and x^3 for
-x between 1 and 4:
+Here, we invoke the table module, and print [math][x], [math][x^2] and
+[math][x^3] for [math][x] between [math][1] and [math][4]. The input to
+the table module contains some math modules, and that works just fine!
 
 [table]
-x^^^^|x^^2^^|x^^3^^
+[math][x]|[math][x^2]|[math][x^3]
 1|1|1
 2|4|8
 3|9|27
@@ -19,12 +20,12 @@ What is this //table// thing? It is a module. Modules live
 within packages, which are programs who reside outside language.
 They are simply .wasm-programs which gets the input of the
 module, in this case all the text in the paragraph starting
-with [raw][[table]], and can do anything it want with it. In
+with [__text][[table]], and can do anything it want with it. In
 this case, ModMark sends the text together with information such
 as that the target output format is HTML, to the package which
-houses the [raw][[table]] module. The module then generates the
-corresponding <table> and </table> tags, and the result appears
-here.
+houses the [__text][[table]] module. The module then generates
+the corresponding <table> and </table> tags, and the result
+appears here.
 
 So, modular you say? How modular? Well, a package is responsible
 for translating something to something else, like the table module


### PR DESCRIPTION
This PR implements a `[math]` module, usable both inline and multi-line, with both `HTML` and `LaTeX` as output formats.

For the HTML output format, [mathjax](https://www.mathjax.org/) is imported by adding a `<script async src=...>` tag just before the math content. This can be disabled by giving `false` as the `import` argument, such as `[math import=false]$x^2$`. mathjax allows displaying of MathML in browsers which lacks native support for that. [latex2mathml](https://crates.io/crates/latex2mathml) is used to convert LaTeX to MathML when the output format is HTML, and since that natively supports both inline-style and block-style math, the `inline` parameter is carried over.

For the LaTeX output format, `$...$` is used for inline math, making sure to escape any `$` in the input by replacing it with `\$`. For multiline math, `\begin{equation}....\end{equation}` is used.

The PR also includes tests with high branch coverage.

Resolves GH-116.