### PR TITLE
GH-120: Add -webkit-appearance: none;

### DIFF
--- a/playground/static/expand_more.svg
+++ b/playground/static/expand_more.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="M480 711 240 471l43-43 197 198 197-197 43 43-240 239Z"/></svg>

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -44,8 +44,8 @@ code {
 }
 
 button,
-select,
-input {
+input,
+select {
     display: flex;
     align-items: center;
     gap: 0.2rem;
@@ -53,10 +53,21 @@ input {
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.501);
     border-radius: 0.3rem;
     padding: 0.5rem 1rem 0.5rem 1rem;
-    background: rgb(231, 231, 231);
-    transition: 0.2s background;
+    background-color: rgb(231, 231, 231);
+    transition: 0.2s background-color;
     color: black;
+}
+
+select {
     -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border: none;
+    background-image: url("expand_more.svg");
+    background-size: 10%;
+    background-position: right center;
+    background-repeat: no-repeat;
+    padding-right: 1.5rem;
 }
 
 button {
@@ -65,7 +76,7 @@ button {
 
 button:hover,
 select:hover {
-    background: rgb(222, 222, 222);
+    background-color: rgb(222, 222, 222);
 }
 
 .menu {

--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -7,9 +7,9 @@ body {
 .material-symbols-outlined {
     position: relative;
     font-variation-settings: 'FILL' 0,
-        'wght' 400,
-        'GRAD' 0,
-        'opsz' 48;
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 48;
     font-size: 1rem;
 }
 
@@ -56,6 +56,7 @@ input {
     background: rgb(231, 231, 231);
     transition: 0.2s background;
     color: black;
+    -webkit-appearance: none;
 }
 
 button {
@@ -221,8 +222,6 @@ select:hover {
 }
 
 
-
-
 #package-view {
     width: 0;
     overflow-x: hidden;
@@ -264,11 +263,11 @@ select:hover {
     font-size: 1.2rem;
 }
 
-#package-content .container>.version {
+#package-content .container > .version {
     opacity: 0.6;
 }
 
-#package-content .container>.name {
+#package-content .container > .name {
     font-size: 1.6rem;
     display: inline;
 }
@@ -283,7 +282,6 @@ select:hover {
 }
 
 
-
 @media only screen and (max-width: 800px) {
     #editor-view {
         height: auto;
@@ -292,7 +290,6 @@ select:hover {
 
     #editor,
     #preview {
-        height: auto;
         height: calc((100vh - 4rem) / 2);
         width: 100%;
     }


### PR DESCRIPTION
This PR adds `-webkit-appearance: none;` to the `<option>` in the playground, which makes it look better on Safari on Mac. I think this is a simple improvement that is worth merging. See #120 for screenshots and more details. It also reformats the CSS file and removes a duplicate key `height` under the `#editor, #preview` selector. The duplicate key doesn't do anything and can thus be removed.

Resolves #120