### PR TITLE
GH-143: Clarify and enforce package conventions

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -119,13 +119,10 @@ mod tests {
     #[test]
     fn table_manifest_test() {
         let ctx = Context::default();
-        let info = ctx
-            .get_package_info("Standard table package")
-            .unwrap()
-            .clone();
+        let info = ctx.get_package_info("table").unwrap().clone();
 
         let foo = PackageInfo {
-            name: "Standard table package".to_string(),
+            name: "table".to_string(),
             version: "0.1".to_string(),
             description: "This package supports [table] modules".to_string(),
             transforms: vec![Transform {

--- a/package-tests/Cargo.toml
+++ b/package-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dev-dependencies]
 datatest-stable = "0.1.3"
-serde = "1.0.152"
+serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.93"
 diffy = "0.3.0"
 once_cell = "1.17.1"

--- a/package-tests/tests/package_tests.rs
+++ b/package-tests/tests/package_tests.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use diffy::create_patch;
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 // Unfortunately, if we run multiple tests at the very same time, some of them will sometimes
@@ -105,8 +106,205 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
+fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
+    // path is ../packages/package-name/Cargo.toml
+    let package_path = file
+        .parent()
+        .expect("Popping one component should give package path");
+
+    // We now need to synchronize so that we wait until other threads operating on the same package
+    // is done. Since we want multiple tests in parallel but only one per package, we have a map
+    // from package path to a mutex, which we need the lock for. The map lock can't be poisoned.
+    let mut map = LOCK.lock().unwrap();
+    let mutex = map.entry(package_path.to_path_buf()).or_default().clone();
+    // Drop the lock on the map now, so we let other threads test if they can proceed
+    drop(map);
+
+    let lock = {
+        match mutex.lock() {
+            Ok(lock) => lock,
+            Err(poison) => poison.into_inner(),
+        }
+    };
+
+    let manifest: Manifest = {
+        let cmd = Command::new(env!("CARGO"))
+            .arg("run")
+            .arg(format!("--manifest-path={}", file.to_string_lossy()))
+            .arg("--")
+            .arg("manifest")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Spawn `cargo run` process");
+
+        let result = String::from_utf8(cmd.wait_with_output().unwrap().stdout)
+            .expect("Expected result to be utf8");
+        serde_json::from_str(&result).expect("Not a valid package manifest")
+    };
+
+    let cargo_manifest: Value = {
+        let cmd = Command::new(env!("CARGO"))
+            .arg("read-manifest")
+            .arg(format!("--manifest-path={}", file.to_string_lossy()))
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Spawn `cargo read-manifest` process");
+
+        let result = String::from_utf8(cmd.wait_with_output().unwrap().stdout)
+            .expect("Expected result to be utf8");
+        serde_json::from_str(&result).expect("Cargo read-manifest not valid JSON")
+    };
+
+    // Make sure to explicitly drop the lock, so that we don't drop it earlier implicitly. It is ok
+    // to drop it now since we are done with the package itself.
+    // Even though the tests aren't done, we are done with running Cargo and thus don't need
+    // exclusive access to the directory anymore.
+    drop(lock);
+
+    // First, we want to check the cargo manifest validity
+    // Get the last component of the path, which is the folder name
+    let package_folder = package_path.components().next_back().unwrap().as_os_str();
+    // Get the project name from cargo manifest
+    let project_name = cargo_manifest["name"].as_str().unwrap();
+
+    assert_eq!(
+        project_name, package_folder,
+        "Cargo project name should have the same name as the folder the package is in"
+    );
+
+    // Loop though all cargo targets and find all "bin" targets
+    let bin_targets: Vec<&serde_json::Map<String, Value>> = cargo_manifest["targets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|target| {
+            let target = target.as_object().unwrap();
+            target["kind"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|t| t.as_str().unwrap() == "bin")
+                .then_some(target)
+        })
+        .collect();
+
+    assert_eq!(
+        bin_targets.len(),
+        1,
+        "Cargo project should have exactly one binary target"
+    );
+
+    assert_eq!(
+        bin_targets[0]["name"].as_str().unwrap(),
+        package_folder,
+        "Cargo project target should have the same name as the folder the package is in"
+    );
+
+    // Now, let's check the package manifest
+    // Check that the name is lowercase/digit/_/- and starts lowercase
+    let name = manifest.name;
+    let ok_name = name.starts_with(|c: char| c.is_ascii_lowercase())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-');
+
+    assert!(ok_name, "Package name must start with lowercase letter, and must only contain lowercase letters, digits, underscores and dashes");
+
+    // Check that it declares at least one transform
+    assert!(
+        !manifest.transforms.is_empty(),
+        "Package should declare at least one transform"
+    );
+
+    // Check all transform details (see check_transform)
+    manifest.transforms.iter().for_each(check_transform);
+
+    // See if the package has tests
+    let has_tests = package_path
+        .join("tests")
+        .read_dir()
+        .ok()
+        .and_then(|mut content| {
+            // Note: we can't use .path().ends_with(".json") since that checks one entire component,
+            // and not the end of the last component
+            content
+                .any(|f| f.unwrap().path().to_string_lossy().ends_with(".json"))
+                .then_some(())
+        })
+        .is_some();
+
+    if !has_tests {
+        let red = "\x1b[31m";
+        let reset = "\x1b[0m";
+        eprintln!("{red}WARNING{reset}: Package {project_name} has no tests. Place tests in the /tests folder");
+    }
+
+    Ok(())
+}
+
+fn check_transform(transform: &Transform) {
+    // Check "from"
+    assert!(
+        transform.from.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-' || c == '.'),
+        "Parent and module names should only contain lowercase letters, digits, dashes and dots (transform from {} failed)",
+        transform.from
+    );
+
+    // Check "to" exists
+    assert!(
+        !transform.to.is_empty(),
+        "Transform should have at least one output format (transform from {} failed)",
+        transform.from
+    );
+
+    // Check "to" values
+    assert!(
+        transform
+            .to
+            .iter()
+            .all(|to| to.chars().all(|c| c.is_ascii_lowercase())),
+        "Output format should only contain lowercase letters (transform from {} failed)",
+        transform.from
+    );
+
+    // Check "arguments"
+    assert!(
+        transform.arguments.iter().all(|arg|
+            arg.name.starts_with(|c: char| c.is_ascii_lowercase()) &&
+                arg.name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        ),
+        "Argument names should start with lowercase letter, and must only contain lowercase letters, digits and underscores (transform from {} failed)",
+        transform.from
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+struct Manifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub transforms: Vec<Transform>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+struct Transform {
+    pub from: String,
+    pub to: Vec<String>,
+    pub arguments: Vec<ArgInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+struct ArgInfo {
+    pub name: String,
+    pub default: Option<String>,
+    pub description: String,
+}
+
 datatest_stable::harness!(
     test_package_input,
     "../packages",
-    r"[^/\\]*[/\\]tests[/\\].*\.json$"
+    r"[^/\\]*[/\\]tests[/\\].*\.json$",
+    test_package_conventions,
+    "../packages",
+    r"[^/\\]*[/\\]Cargo.toml"
 );

--- a/package-tests/tests/package_tests.rs
+++ b/package-tests/tests/package_tests.rs
@@ -67,6 +67,7 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
             "--manifest-path={}",
             manifest_path.to_string_lossy()
         ))
+        .arg("-q")
         .arg("--")
         .arg("transform")
         .arg(from)
@@ -131,6 +132,7 @@ fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
         let cmd = Command::new(env!("CARGO"))
             .arg("run")
             .arg(format!("--manifest-path={}", file.to_string_lossy()))
+            .arg("-q")
             .arg("--")
             .arg("manifest")
             .stdout(Stdio::piped())
@@ -203,6 +205,13 @@ fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
     // Now, let's check the package manifest
     // Check that the name is lowercase/digit/_/- and starts lowercase
     let name = manifest.name;
+
+    assert_eq!(
+        name.as_str(),
+        package_folder,
+        "Package should have the same name as the enclosing folder"
+    );
+
     let ok_name = name.starts_with(|c: char| c.is_ascii_lowercase())
         && name
             .chars()

--- a/packages/README.md
+++ b/packages/README.md
@@ -58,6 +58,17 @@ You will be sent the element as json object via stdout, and you respond by sendi
 
 If you want to see some examples of what this json format looks like, you can check out the subdirectories or visit the online playground and select "JSON output".
 
+## Conventions
+
+There are some conventions when creating and naming packages.
+ * All packages in this directory should be cargo crates, where the crate name and only binary target name should match the directory name.
+ * All package names must start with a lowercase letter and may only contain lowercase letters, underscores and dashes.
+ * Each package must contain at least one transform (a package isn't very useful without one)
+ * Each transform must satisfy the following:
+   * Its `from` field (the parent or module name) must only contain lowercase letters, digits, dashes, underscores and dots
+   * Its `to` array must have at least one entry, and they all must be in all lowercase letters, since it is meant to match a format or file extension
+   * Its arguments should have names starting with a lowercase letter and may only contain lowercase letters, numbers and underscores
+
 ## Handling errors
 
 Errors occur in all pieces of code, including your packages. As a part of the sandbox we build to run your packages in, we have built in some error handling.

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -181,7 +181,7 @@ fn manifest() -> String {
     serde_json::to_string(&json!(
         {
             "version": "0.1",
-            "name": "HTML",
+            "name": "html",
             "description": "This packages provides HTML support for the basic Modmark features.",
             "transforms": [
                 {

--- a/packages/latex/src/main.rs
+++ b/packages/latex/src/main.rs
@@ -174,7 +174,7 @@ fn manifest() -> String {
     serde_json::to_string(&json!(
         {
             "version": "0.1",
-            "name": "Latex",
+            "name": "latex",
             "description": "This packages provides Latex support for the basic Modmark features.",
             "transforms": [
                 {

--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 fn manifest() {
     print!("{}", serde_json::to_string(&json!(
         {
-        "name": "Standard table package",
+        "name": "table",
         "version": "0.1",
         "description": "This package supports [table] modules",
         "transforms": [


### PR DESCRIPTION
See issue #143. This PR resolves that issue by adding the conventions discussed there into `packages/README.md` and adds a test in `package-tests` which checks that these conventions are being met. Additionally, the convention test gives a warning if a package doesn't have any tests in it (but it doesn't fail the test). This PR also changes the current packages to follow the convention.

Resolves #143