### PR TITLE
GH-94: Improve table package

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -127,12 +127,30 @@ mod tests {
             description: "This package supports [table] modules".to_string(),
             transforms: vec![Transform {
                 from: "table".to_string(),
-                to: vec![OutputFormat::new("html")],
-                arguments: vec![ArgInfo {
-                    name: "col_delimiter".to_string(),
-                    default: Some("|".to_string()),
-                    description: "The string delimiter for columns".to_string(),
-                }],
+                to: vec![OutputFormat::new("html"), OutputFormat::new("latex")],
+                arguments: vec![
+                    ArgInfo {
+                        name: "header".to_string(),
+                        default: Some("none".to_string()),
+                        description: "Style to apply to heading, none/bold".to_string(),
+                    }, ArgInfo {
+                        name: "alignment".to_string(),
+                        default: Some("left".to_string()),
+                        description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
+                    }, ArgInfo {
+                        name: "borders".to_string(),
+                        default: Some("all".to_string()),
+                        description: "Which borders to draw, all/horizontal/vertical/outer/none".to_string(),
+                    }, ArgInfo {
+                        name: "delimiter".to_string(),
+                        default: Some("|".to_string()),
+                        description: "The delimiter between cells".to_string(),
+                    }, ArgInfo {
+                        name: "strip_whitespace".to_string(),
+                        default: Some("true".to_string()),
+                        description: "true/false to strip/don't strip whitespace in cells".to_string(),
+                    },
+                ],
             }],
         };
 

--- a/packages/table/src/example.json
+++ b/packages/table/src/example.json
@@ -1,6 +1,0 @@
-{
-  "name": "table",
-  "arguments": {},
-  "data": "10 | **bold text** | silly \n second | row | here \n",
-  "inline": false
-}

--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -1,8 +1,29 @@
+use std::convert::TryInto;
 use std::env;
 use std::fmt::Write;
 use std::io::{self, Read};
+use std::iter::repeat;
+use std::process::exit;
 
 use serde_json::{json, Value};
+
+macro_rules! raw {
+    ($expr:expr) => {
+        json!({
+            "name": "raw",
+            "data": $expr
+        })
+    }
+}
+
+macro_rules! inline_content {
+    ($expr:expr) => {
+        json!({
+            "name": "inline_content",
+            "data": $expr
+        })
+    }
+}
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -25,9 +46,13 @@ fn manifest() {
         "transforms": [
             {
                 "from": "table",
-                "to": ["html"],
+                "to": ["html", "latex"],
                 "arguments": [
-                    {"name": "col_delimiter", "default": "|", "description": "The string delimiter for columns"}
+                    {"name": "header", "default": "none", "description": "Style to apply to heading, none/bold"},
+                    {"name": "alignment", "default": "left", "description": "Horizontal alignment in cells, left/center/right or l/c/r for each column"},
+                    {"name": "borders", "default": "all", "description": "Which borders to draw, all/horizontal/vertical/outer/none"},
+                    {"name": "delimiter", "default": "|", "description": "The delimiter between cells"},
+                    {"name": "strip_whitespace", "default": "true", "description": "true/false to strip/don't strip whitespace in cells"}
                 ],
             }
         ]
@@ -46,46 +71,410 @@ fn transform(from: &String, to: &String) {
     }
 }
 
-fn transform_table(to: &String) {
-    match to.as_str() {
-        "html" => {
-            let input: Value = {
-                let mut buffer = String::new();
-                io::stdin().read_to_string(&mut buffer).unwrap();
-                serde_json::from_str(&buffer).unwrap()
-            };
+#[derive(PartialEq, Debug)]
+enum Target {
+    HTML,
+    LaTeX,
+}
 
-            let Value::String(delimiter) = &input["arguments"]["col_delimiter"] else {
-                panic!("No col_delimiter argument was provided");
-            };
+impl TryFrom<&str> for Target {
+    type Error = ();
+    fn try_from(str: &str) -> Result<Self, Self::Error> {
+        let str = str.to_ascii_lowercase();
+        if &str == "html" {
+            Ok(Target::HTML)
+        } else if &str == "latex" {
+            Ok(Target::LaTeX)
+        } else {
+            Err(())
+        }
+    }
+}
 
-            let rows: Vec<Vec<&str>> = input["data"]
-                .as_str()
-                .unwrap()
-                .lines()
-                .map(|row| row.split(delimiter).collect())
-                .collect();
+#[derive(PartialEq, Eq, Debug)]
+enum Alignment {
+    All(ColumnAlignment),
+    Columns(Vec<ColumnAlignment>),
+}
 
-            let mut output = String::new();
-            output.push('[');
-            output.push_str(r#"{"name": "raw", "data": "<table>"},"#);
-            for row in rows {
-                output.push_str(r#"{"name": "raw", "data": "<tr>"},"#);
-                for col in row {
-                    output.push_str(r#"{"name": "raw", "data": "<td>"},"#);
-                    write!(output, r#"{{"name": "inline_content", "data": "{col}"}},"#).unwrap();
-                    output.push_str(r#"{"name": "raw", "data": "</td>"},"#);
+impl Alignment {
+    fn latex_str(&self, width: usize, border: bool) -> String {
+        match self {
+            Alignment::All(alignment) => {
+                if border {
+                    "|".to_string()
+                        + (alignment.latex_char().to_string() + "|")
+                            .repeat(width)
+                            .as_str()
+                } else {
+                    alignment.latex_char().to_string().repeat(width)
                 }
-                output.push_str(r#"{"name": "raw", "data": "</tr>"},"#);
             }
-            output.push_str(r#"{"name": "raw", "data": "</table>"}"#);
-            output.push(']');
+            Alignment::Columns(vec) => {
+                if border {
+                    format!(
+                        "|{}",
+                        vec.iter()
+                            .map(|a| format!("{}|", a.latex_char()))
+                            .collect::<String>()
+                    )
+                } else {
+                    vec.iter().map(|a| a.latex_char()).collect()
+                }
+            }
+        }
+    }
 
-            print!("{output}");
+    fn for_column(&self, idx: usize) -> &ColumnAlignment {
+        match self {
+            Alignment::All(c) => c,
+            Alignment::Columns(c) => &c[idx],
         }
-        other => {
-            eprintln!("Cannot convert table to {other}");
-            return;
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum ColumnAlignment {
+    Left,
+    Center,
+    Right,
+}
+
+impl ColumnAlignment {
+    fn latex_char(&self) -> char {
+        match self {
+            ColumnAlignment::Left => 'l',
+            ColumnAlignment::Center => 'c',
+            ColumnAlignment::Right => 'r',
         }
+    }
+
+    fn html_style(&self) -> &str {
+        match self {
+            ColumnAlignment::Left => "text-align: left;",
+            ColumnAlignment::Center => "text-align: center;",
+            ColumnAlignment::Right => "text-align: right;",
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum Borders {
+    All,
+    Horizontal,
+    Vertical,
+    Outer,
+    None,
+}
+
+impl TryFrom<&str> for Borders {
+    type Error = ();
+    fn try_from(str: &str) -> Result<Self, Self::Error> {
+        use Borders::*;
+
+        match str.to_ascii_lowercase().as_str() {
+            "all" => Ok(All),
+            "horizontal" => Ok(Horizontal),
+            "vertical" => Ok(Vertical),
+            "outer" => Ok(Outer),
+            "none" => Ok(None),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Alignment {
+    fn width(&self) -> Option<usize> {
+        if let Alignment::Columns(vec) = self {
+            Some(vec.len())
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<&str> for Alignment {
+    type Error = ();
+    fn try_from(str: &str) -> Result<Self, Self::Error> {
+        use Alignment::*;
+        use ColumnAlignment::*;
+
+        match str.to_ascii_lowercase().as_str() {
+            "left" => Ok(All(Left)),
+            "center" => Ok(All(Center)),
+            "right" => Ok(All(Right)),
+            s => s
+                .chars()
+                .map(|c| match c.to_ascii_lowercase() {
+                    'l' => Ok(Left),
+                    'c' => Ok(Center),
+                    'r' => Ok(Right),
+                    _ => Err(()),
+                })
+                .collect::<Result<Vec<ColumnAlignment>, ()>>()
+                .map(|v| Columns(v)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Table<'a> {
+    width: usize,
+    height: usize,
+    content: Vec<Vec<&'a str>>,
+    alignment: Alignment,
+    borders: Borders,
+    header: bool,
+}
+
+impl Table<'_> {
+    fn to_latex(&self) -> Vec<Value> {
+        let mut vec: Vec<Value> = vec![];
+
+        let col_key = if self.borders == Borders::All || self.borders == Borders::Vertical {
+            self.alignment.latex_str(self.width, true)
+        } else if self.borders == Borders::None {
+            self.alignment.latex_str(self.width, false)
+        } else {
+            format!("|{}|", self.alignment.latex_str(self.width, false))
+        };
+
+        vec.push(raw!("\\begin{center}\n"));
+        vec.push(raw!(format!("\\begin{{tabular}} {{ {} }}\n", col_key)));
+
+        if self.borders != Borders::None {
+            vec.push(raw!("\\hline\n"));
+        }
+
+        for (idx, row) in self.content.iter().enumerate() {
+            let values = if idx == 0 && self.header {
+                row.iter()
+                    .map(|c| format!("**{c}**"))
+                    .map(|c| inline_content!(c))
+                    .collect::<Vec<Value>>()
+            } else {
+                row.iter()
+                    .map(|c| inline_content!(c))
+                    .collect::<Vec<Value>>()
+            };
+
+            for (idx, val) in values.into_iter().enumerate() {
+                if idx != 0 {
+                    vec.push(raw!(" & "));
+                }
+                vec.push(val);
+            }
+            vec.push(raw!(" \\\\\n"));
+
+            if self.borders == Borders::All || self.borders == Borders::Horizontal {
+                vec.push(raw!("\\hline\n"));
+            }
+        }
+
+        if self.borders == Borders::Outer {
+            vec.push(raw!(r"\hline"))
+        }
+        vec.push(raw!("\\end{tabular}\n"));
+        vec.push(raw!(r"\end{center}"));
+        vec
+    }
+
+    fn to_html(&self) -> Vec<Value> {
+        let mut vec: Vec<Value> = vec![];
+        if self.borders == Borders::None {
+            vec.push(raw!("<table>"));
+        } else {
+            vec.push(raw!(
+                r#"<table style="border: 1px solid black; border-collapse: collapse;""#
+            ));
+        }
+
+        let inside_border_style = if self.borders == Borders::All {
+            "border: 1px solid black; border-collapse: collapse;"
+        } else if self.borders == Borders::Vertical {
+            "border-left: 1px solid black; border-right: 1px solid black; border-collapse: collapse;"
+        } else if self.borders == Borders::Horizontal {
+            "border-top: 1px solid black; border-bottom: 1px solid black; border-collapse: collapse;"
+        } else {
+            ""
+        };
+
+        let ths = format!("<th{inside_border_style}>");
+        let tds = format!("<td{inside_border_style}>");
+
+        for (idx, row) in self.content.iter().enumerate() {
+            vec.push(raw!("<tr>"));
+
+            if idx == 0 && self.header {
+                for (idx, elem) in row.iter().enumerate() {
+                    let alignment = self.alignment.for_column(idx).html_style();
+                    vec.push(raw!(format!(r#"<th style="{alignment}{inside_border_style}">"#)));
+                    vec.push(inline_content!(elem));
+                    vec.push(raw!("</th>"));
+                }
+            } else {
+                for (idx, elem) in row.iter().enumerate() {
+                    let alignment = self.alignment.for_column(idx).html_style();
+                    vec.push(raw!(format!(r#"<td style="{alignment}{inside_border_style}">"#)));
+                    vec.push(inline_content!(elem));
+                    vec.push(raw!("</td>"));
+                }
+            }
+
+            vec.push(raw!("</tr>"));
+        }
+
+        vec.push(raw!("</table>"));
+        vec
+    }
+}
+
+fn parse_table(input: &Value) -> Option<Table> {
+    let delimiter = input["arguments"]["delimiter"].as_str().unwrap();
+    if delimiter.contains('\\') {
+        eprintln!("The delimiter may not contain backslashes");
+        return None;
+    }
+
+    let borders = match input["arguments"]["borders"].as_str().unwrap().try_into() {
+        Ok(border) => border,
+        Err(()) => {
+            eprintln!("Invalid 'borders' arg, choose one of all/horizontal/vertical/outer/none");
+            Borders::All
+        }
+    };
+
+    let alignment = match input["arguments"]["alignment"].as_str().unwrap().try_into() {
+        Ok(alignment) => alignment,
+        Err(()) => {
+            eprintln!(
+                "Invalid 'alignment' arg, choose one of left/center/right or l/c/r for each column"
+            );
+            Alignment::All(ColumnAlignment::Left)
+        }
+    };
+
+    let strip_whitespace = match input["arguments"]["strip_whitespace"]
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "false" => false,
+        s => {
+            if s != "true" {
+                eprintln!("Invalid 'strip_whitespace' arg, choose one of true/false");
+            }
+            true
+        }
+    };
+
+    let header = match input["arguments"]["header"]
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "none" => false,
+        s => {
+            if s != "bold" {
+                eprintln!("Invalid 'header' arg, choose one of none/bold");
+            }
+            true
+        }
+    };
+
+    let body = input["data"].as_str().unwrap();
+    let mut content = parse_content(body, delimiter, strip_whitespace);
+    let height = content.len();
+    //TODO: Fix special case where height = 0
+    let width = content.iter().map(|r| r.len()).max().unwrap();
+    if content.iter().any(|r| r.len() != width) {
+        eprintln!("The table is jagged; some rows are wider than others.");
+        content.iter_mut().for_each(|r| r.resize(width, ""))
+    }
+
+    if let Some(w) = alignment.width() {
+        if w != width {
+            eprintln!("Alignment given for {} columns but {} exist", w, width);
+            return None;
+        }
+    }
+
+    Some(Table {
+        width,
+        height,
+        content,
+        alignment,
+        borders,
+        header,
+    })
+}
+
+fn parse_content<'a>(input: &'a str, delimiter: &'a str, trim: bool) -> Vec<Vec<&'a str>> {
+    input
+        .lines()
+        .map(|row| split_by_delimiter(row, delimiter, trim))
+        .collect()
+}
+
+fn split_by_delimiter<'a>(input: &'a str, delimiter: &'a str, trim: bool) -> Vec<&'a str> {
+    let mut res = vec![];
+    let mut escaped = false;
+    let mut start_idx = 0;
+
+    for (idx, c) in input.char_indices() {
+        if escaped || idx < start_idx {
+            escaped = false;
+            continue;
+        }
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+        if input[idx..].starts_with(delimiter) {
+            let str = if trim {
+                &input[start_idx..idx].trim()
+            } else {
+                &input[start_idx..idx]
+            };
+
+            res.push(str);
+            start_idx = idx + delimiter.len();
+        }
+    }
+
+    if start_idx != input.as_bytes().len() {
+        let str = if trim {
+            &input[start_idx..].trim()
+        } else {
+            &input[start_idx..]
+        };
+
+        res.push(str)
+    }
+    res
+}
+
+fn transform_table(to: &str) {
+    let Ok(format): Result<Target, _> = to.try_into() else {
+        eprintln!("Unsupported format {to}, only HTML and LaTeX are supported!");
+        return;
+    };
+
+    let input: Value = {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).unwrap();
+        serde_json::from_str(&buffer).unwrap()
+    };
+
+    let Some(table) = parse_table(&input) else {
+        return;
+    };
+
+    if format == Target::LaTeX {
+        println!("{}", json! {table.to_latex()});
+    } else if format == Target::HTML {
+        println!("{}", json! {table.to_html()});
     }
 }

--- a/packages/table/tests/test_all_border_html.json
+++ b/packages/table/tests/test_all_border_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "all",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table style=\"border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_all_border_latex.json
+++ b/packages/table/tests/test_all_border_latex.json
@@ -1,0 +1,75 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "all",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { |l|l| }\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_heading_html.json
+++ b/packages/table/tests/test_heading_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "bold",
+        "alignment": "left",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<th style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</th>",
+            "name": "raw"
+        },
+        {
+            "data": "<th style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</th>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_heading_latex.json
+++ b/packages/table/tests/test_heading_latex.json
@@ -1,0 +1,63 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "bold",
+        "alignment": "left",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { ll }\n",
+            "name": "raw"
+        },
+        {
+            "data": "**a**",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "**b**",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_horizontal_border_html.json
+++ b/packages/table/tests/test_horizontal_border_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "horizontal",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table style=\"border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-top: 1px solid black; border-bottom: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-top: 1px solid black; border-bottom: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-top: 1px solid black; border-bottom: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-top: 1px solid black; border-bottom: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_horizontal_border_latex.json
+++ b/packages/table/tests/test_horizontal_border_latex.json
@@ -1,0 +1,75 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "horizontal",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { |ll| }\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_mixed_alignment_html.json
+++ b/packages/table/tests/test_mixed_alignment_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "rc",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: center;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: center;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_mixed_alignment_latex.json
+++ b/packages/table/tests/test_mixed_alignment_latex.json
@@ -1,0 +1,63 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "rc",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { rc }\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_no_strip.json
+++ b/packages/table/tests/test_no_strip.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "none",
+        "strip_whitespace": "false"
+    },
+    "data": "a | b  \nc|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a ",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": " b  ",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_outer_border_html.json
+++ b/packages/table/tests/test_outer_border_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "outer",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table style=\"border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_outer_border_latex.json
+++ b/packages/table/tests/test_outer_border_latex.json
@@ -1,0 +1,71 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "outer",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { |ll| }\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_right_alignment_html.json
+++ b/packages/table/tests/test_right_alignment_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "right",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: right;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_right_alignment_latex.json
+++ b/packages/table/tests/test_right_alignment_latex.json
@@ -1,0 +1,63 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "right",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { rr }\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_strip.json
+++ b/packages/table/tests/test_strip.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "none",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_vertical_border_html.json
+++ b/packages/table/tests/test_vertical_border_html.json
@@ -1,0 +1,87 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "vertical",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table style=\"border: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-left: 1px solid black; border-right: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-left: 1px solid black; border-right: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-left: 1px solid black; border-right: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left; border-left: 1px solid black; border-right: 1px solid black; border-collapse: collapse;\">",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}

--- a/packages/table/tests/test_vertical_border_latex.json
+++ b/packages/table/tests/test_vertical_border_latex.json
@@ -1,0 +1,71 @@
+{
+    "name": "table",
+    "arguments": {
+        "delimiter": "|",
+        "header": "none",
+        "alignment": "left",
+        "borders": "vertical",
+        "strip_whitespace": "true"
+    },
+    "data": "a |   b      \n c|d",
+    "inline": false,
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "data": "\\begin{center}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\begin{tabular} { |l|l| }\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "a",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "b",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "c",
+            "name": "inline_content"
+        },
+        {
+            "data": " & ",
+            "name": "raw"
+        },
+        {
+            "data": "d",
+            "name": "inline_content"
+        },
+        {
+            "data": " \\\\\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\hline\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{tabular}\n",
+            "name": "raw"
+        },
+        {
+            "data": "\\end{center}",
+            "name": "raw"
+        }
+    ]
+}


### PR DESCRIPTION
This PR aims to resolve GH-94 by adding wanted improvements to the Table package. Here are the points listed, with my comments:

- [x] Fix quote and backslash support
        - *Works as expected, one backslash escapes the delimiter, two doesn't, three does etc*
- [x] Arguments for alignment
        - *There is an `alignment` argument which you can set to left/center/right or some combination of l/c/r, one character for each column, like ccr which would center the two first columns and right-align the third.*
- [x] Arguments for borders
        - *Argument `borders` can be `all`/`horizontal`/`vertical`/`outer`/`none`. The options are self-explanatory. All but `none` implies `outer`*
- [x] Option for first row to be headers
        - *Argument `header` can be `none` which has no special treatment or `bold` which is `th` in html and `textbf` in latex*
- [x] Strip whitespace
        - *Argument `strip_whitespace` (true/false) controls stripping of whitespace*

~~This is a draft PR for now, and these are the things that needs to be fixed before promoting to a "real" PR:~~

- [x] Commenting code
- [x] Adding tests
- [x] Make sure it works for empty tables (for LaTeX, we insert `|l|` as the alignment for empty tables since it errors without an alignment. Also, we give an warning)
- [x] Possibly functional decomposition, the code doesn't look fantastic right now (I did that somewhat, think it got somewhat better)
- [x] General clean-up

Since the above-mentioned tasks are fixed, this PR is ready for review!

- Resolves GH-94
- Resolves GH-112