### PR TITLE
Playground: Add chromium support

### DIFF
--- a/playground/build-playground.sh
+++ b/playground/build-playground.sh
@@ -1,4 +1,4 @@
 rm -r build
 mkdir build
 cp -r static/* build
-wasm-pack build ./web_bindings --target web --out-dir ../build/pkg
+wasm-pack build ./web_bindings --target no-modules --out-dir ../build/pkg

--- a/playground/static/compiler.js
+++ b/playground/static/compiler.js
@@ -1,0 +1,40 @@
+// FIXME: Replace with a normal ES module import once Firefox adds support for js modules in web workers
+importScripts("./pkg/web_bindings.js");
+
+let loaded = false;
+wasm_bindgen("./pkg/web_bindings_bg.wasm").then(() => {
+    loaded = true;
+    postMessage({ type: "init" });
+});
+
+onmessage = (event) => {
+    if (!loaded) return;
+
+    try {
+        let result;
+        switch (event.data.type) {
+            case "ast":
+                result = wasm_bindgen.ast(event.data.source);
+                break;
+            case "ast_debug":
+                result = wasm_bindgen.ast_debug(event.data.source);
+                break;
+            case "json_output":
+                result = wasm_bindgen.json_output(event.data.source);
+                break;
+            case "package_info":
+                result = wasm_bindgen.package_info(event.data.source);
+                break;
+            case "transpile":
+                result = wasm_bindgen.transpile(event.data.source, event.data.format);
+                break;
+
+            case "package_info":
+                result = wasm_bindgen.package_info();
+        }
+        postMessage({ result: result, success: true, ...event.data });
+    } catch (error) {
+        console.log(error);
+        postMessage({ error: error, success: false, ...event.data })
+    }
+};


### PR DESCRIPTION
Resolves GH-45. This PR adds support for the playground in Chromium browsers. This is done by instantiating the WASM module that contains the compiler inside of a web worker instead of the main thread.