### PR TITLE
GH-152: Use ES-module import syntax

### DIFF
--- a/playground/build-playground.sh
+++ b/playground/build-playground.sh
@@ -1,4 +1,4 @@
 rm -r build
 mkdir build
 cp -r static/* build
-wasm-pack build ./web_bindings --target no-modules --out-dir ../build/pkg
+wasm-pack build ./web_bindings --target web --out-dir ../build/pkg

--- a/playground/static/compiler.js
+++ b/playground/static/compiler.js
@@ -1,11 +1,11 @@
-// FIXME: Replace with a normal ES module import once Firefox adds support for js modules in web workers
-importScripts("./pkg/web_bindings.js");
+// noinspection JSFileReferences
+import init, {ast, ast_debug, json_output, package_info, transpile} from "./pkg/web_bindings.js";
 
 let loaded = false;
-wasm_bindgen("./pkg/web_bindings_bg.wasm").then(() => {
+init().then(() => {
     loaded = true;
-    postMessage({ type: "init" });
-});
+    postMessage({type: "init"});
+})
 
 onmessage = (event) => {
     if (!loaded) return;
@@ -14,23 +14,20 @@ onmessage = (event) => {
         let result;
         switch (event.data.type) {
             case "ast":
-                result = wasm_bindgen.ast(event.data.source);
+                result = ast(event.data.source);
                 break;
             case "ast_debug":
-                result = wasm_bindgen.ast_debug(event.data.source);
+                result = ast_debug(event.data.source);
                 break;
             case "json_output":
-                result = wasm_bindgen.json_output(event.data.source);
+                result = json_output(event.data.source);
                 break;
             case "package_info":
-                result = wasm_bindgen.package_info(event.data.source);
+                result = package_info(event.data.source);
                 break;
             case "transpile":
-                result = wasm_bindgen.transpile(event.data.source, event.data.format);
+                result = transpile(event.data.source, event.data.format);
                 break;
-
-            case "package_info":
-                result = wasm_bindgen.package_info();
         }
         postMessage({ result: result, success: true, ...event.data });
     } catch (error) {

--- a/playground/static/index.html
+++ b/playground/static/index.html
@@ -13,7 +13,7 @@
     <script src="ace/ace.js" type="text/javascript" charset="utf-8"></script>
     <title>ModMark Playground</title>
     <link rel="stylesheet" href="style.css">
-    <script type="module" defer src="main.js"></script>
+    <script type="module" defer src="main.mjs"></script>
 </head>
 
 <body>

--- a/playground/static/main.mjs
+++ b/playground/static/main.mjs
@@ -1,7 +1,7 @@
 let seq = 0;
 let compiler_callback;
 let compiler_failure;
-let compiler = new Worker("./compiler.js");
+let compiler = new Worker("./compiler.js", {type: "module"});
 
 compiler.onmessage = (event) => {
     // Render the document once the wasm module containing the
@@ -11,7 +11,7 @@ compiler.onmessage = (event) => {
         return;
     }
 
-    if (event.data.seq != seq) return;
+    if (event.data.seq !== seq) return;
     if (event.data.success) {
         compiler_callback(event.data.result);
     } else {


### PR DESCRIPTION
This PR changes the `compiler.js` to import the bindings using the more modern ES-module syntax. This is supported by all major browsers but Firefox, which will get it in version 111, released [March 14th](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/111). After we confirm that this works, we should thus merge this PR.

It also changes `main.js` to have the extension `mjs` for JavaScript module, needed for support in MacOS.

Resolves GH-152