### PR TITLE
GH-45: Fix problematic JS from GH-151

### DIFF
--- a/playground/static/compiler.js
+++ b/playground/static/compiler.js
@@ -28,9 +28,6 @@ onmessage = (event) => {
             case "transpile":
                 result = wasm_bindgen.transpile(event.data.source, event.data.format);
                 break;
-
-            case "package_info":
-                result = wasm_bindgen.package_info();
         }
         postMessage({ result: result, success: true, ...event.data });
     } catch (error) {

--- a/playground/static/main.js
+++ b/playground/static/main.js
@@ -11,7 +11,7 @@ compiler.onmessage = (event) => {
         return;
     }
 
-    if (event.data.seq != seq) return;
+    if (event.data.seq !== seq) return;
     if (event.data.success) {
         compiler_callback(event.data.result);
     } else {


### PR DESCRIPTION
This PR fixes two small problems introduced in #151:
- The worker JS has a switch with two branches on the same input where only one of them contains valid code; the invalid branch is removed
- Type coercion was enabled when comparing sequence numbers, this has now been removed