### PR TITLE
Add `config`uration module

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,7 +11,7 @@ use notify::{Config, Event, PollWatcher, RecommendedWatcher, RecursiveMode, Watc
 use once_cell::sync::Lazy;
 
 use error::CliError;
-use modmark_core::{context::CompilationState, CoreError, OutputFormat};
+use modmark_core::{context::CompilationState, OutputFormat};
 use modmark_core::{eval, Context};
 use parser::{parse, Ast};
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,13 +43,8 @@ struct Args {
     dev: bool,
 }
 
-static CTX: Lazy<Mutex<Context<PackageManager>>> = Lazy::new(|| {
-    Mutex::new({
-        let mut ctx = Context::new_with_resolver(PackageManager {});
-        ctx.load_default_packages().unwrap();
-        ctx
-    })
-});
+static CTX: Lazy<Mutex<Context<PackageManager>>> =
+    Lazy::new(|| Mutex::new(Context::new_with_resolver(PackageManager {}).unwrap()));
 
 // Infer the output format based on the file extension of the output format
 fn infer_output_format(output: &Path) -> Option<OutputFormat> {

--- a/cli/src/package.rs
+++ b/cli/src/package.rs
@@ -24,14 +24,13 @@ impl Resolve for PackageManager {
     fn resolve(&self, path: &str) -> Result<Vec<u8>, Self::Error> {
         RUNTIME.block_on(resolve_package(path))
     }
-    fn resolve_all(&self, paths: Vec<&str>) -> Vec<Result<Vec<u8>, Self::Error>> {
+    fn resolve_all(&self, paths: &[&str]) -> Vec<Result<Vec<u8>, Self::Error>> {
         RUNTIME.block_on(resolve_packages(paths))
     }
 }
 
-async fn resolve_packages(paths: Vec<&str>) -> Vec<Result<Vec<u8>, CliError>> {
-    let futures = paths.iter().map(|path| resolve_package(path));
-
+async fn resolve_packages(paths: &[&str]) -> Vec<Result<Vec<u8>, CliError>> {
+    let futures = paths.into_iter().map(|&path| resolve_package(path));
     return join_all(futures).await;
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -301,7 +301,13 @@ impl<T> Context<T> {
             )?;
         }
 
-        Ok(())
+        if config.0.is_empty() {
+            Ok(())
+        } else {
+            Err(CoreError::UnusedConfigs(
+                config.0.drain().map(|(k, _)| k).collect(),
+            ))
+        }
     }
 
     // This function was introduced to avoid repeated code. It takes a map and a package, and adds

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -735,6 +735,56 @@ enum JsonEntry {
     },
 }
 
+#[derive(Default)]
+#[repr(transparent)]
+struct ModuleImport(HashMap<String, ModuleImportConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ModuleImportConfig {
+    ImportAll,
+    Include(Vec<String>),
+    Exclude(Vec<String>),
+    HideAll,
+}
+
+impl From<HideConfig> for ModuleImportConfig {
+    fn from(value: HideConfig) -> Self {
+        match value {
+            HideConfig::HideAll => ModuleImportConfig::HideAll,
+        }
+    }
+}
+
+impl From<ImportConfig> for ModuleImportConfig {
+    fn from(value: ImportConfig) -> Self {
+        match value {
+            ImportConfig::ImportAll => Self::ImportAll,
+            ImportConfig::Include(vec) => Self::Include(vec),
+            ImportConfig::Exclude(vec) => Self::Exclude(vec),
+        }
+    }
+}
+
+impl From<Config> for ModuleImport {
+    fn from(value: Config) -> Self {
+        let Config {
+            imports,
+            hides,
+            sets,
+        } = value;
+        let map = imports
+            .into_iter()
+            .map(|import| (import.name, import.importing.into()))
+            .chain(
+                hides
+                    .into_iter()
+                    .map(|hide| (hide.name, hide.hiding.into())),
+            )
+            .collect();
+        ModuleImport(map)
+    }
+}
+
 /// This is just a helper to ensure that omitted "inline" fields
 /// default to true.
 fn default_inline() -> bool {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,4 +1,5 @@
 use std::collections::hash_map::Entry;
+use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Formatter;
 use std::iter::once;
@@ -8,7 +9,6 @@ use std::{
     fmt::Debug,
     io::{Read, Write},
 };
-use std::collections::HashSet;
 
 use either::{Either, Left};
 use serde::{Deserialize, Serialize};
@@ -778,7 +778,7 @@ impl<T> Context<T> {
         let mut given_args = args.clone();
 
         // Get info about what args this parent node
-        let args_info = self.get_args_info(parent_name, &output_format)?;
+        let args_info = self.get_args_info(parent_name, output_format)?;
 
         for arg_info in args_info {
             let ArgInfo {
@@ -822,7 +822,7 @@ impl<T> Context<T> {
         let mut collected_args = HashMap::new();
 
         // Get info about what args this parent node supports
-        let args_info = self.get_args_info(module_name, &output_format)?;
+        let args_info = self.get_args_info(module_name, output_format)?;
 
         for arg_info in args_info {
             let ArgInfo {
@@ -948,16 +948,14 @@ impl TryFrom<Config> for ModuleImport {
             .chain(
                 hides
                     .into_iter()
-                    .map(|hide| (hide.name, hide.hiding.into()))
+                    .map(|hide| (hide.name, hide.hiding.into())),
             )
-            .map(|(name, value)|
-                {
-                    if !found.insert(name.clone()) {
-                        duplicates.push(name.clone());
-                    }
-                    (name, value)
+            .map(|(name, value)| {
+                if !found.insert(name.clone()) {
+                    duplicates.push(name.clone());
                 }
-            )
+                (name, value)
+            })
             .collect();
 
         if !duplicates.is_empty() {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -956,11 +956,10 @@ impl TryFrom<Config> for ModuleImport {
                     .into_iter()
                     .map(|hide| (hide.name, hide.hiding.into())),
             )
-            .map(|(name, value)| {
+            .inspect(|(name, _)| {
                 if !found.insert(name.clone()) {
                     duplicates.push(name.clone());
                 }
-                (name, value)
             })
             .collect();
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,3 @@
-use parser::ParseError;
 use std::error::Error;
 use thiserror::Error;
 #[cfg(feature = "native")]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -54,7 +54,7 @@ pub enum CoreError {
     },
     #[error("Transform does not terminate")]
     NonTerminatingTransform,
-    #[error("Parsing error: {0:#?}.")]
+    #[error("Parsing error: {0}.")]
     Parsing(#[from] ParseError),
     #[error("Native call error: Non-module given to package {0} named {1}")]
     NonModuleToNative(String, String),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use parser::ParseError;
 use thiserror::Error;
 #[cfg(feature = "native")]
 #[allow(unused_imports)]
@@ -61,7 +63,11 @@ pub enum CoreError {
     #[error("Root element is not a parent, cannot remove __document for playground")]
     RootElementNotParent,
     #[error("DenyAllResolver is used; resolving of packages disallowed")]
-    DenyAllResolver
+    DenyAllResolver,
+    #[error("Error resolving {0}: {1:?}")]
+    Resolve(String, Box<dyn Error>),
+    #[error("An error occurred: '{0}'")]
+    Other(String)
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -61,7 +61,7 @@ pub enum CoreError {
     NonModuleToNative(String, String),
     #[error("Root element is not a parent, cannot remove __document for playground")]
     RootElementNotParent,
-    #[error("DenyAllResolver is used; resolving of packages disallowed")]
+    #[error("Importing external packages is not allowed")]
     DenyAllResolver,
     #[error("Error resolving {0}: {1:?}")]
     Resolve(String, Box<dyn Error>),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
 use parser::ParseError;
+use std::error::Error;
 use thiserror::Error;
 #[cfg(feature = "native")]
 #[allow(unused_imports)]
@@ -67,7 +67,7 @@ pub enum CoreError {
     #[error("Error resolving {0}: {1:?}")]
     Resolve(String, Box<dyn Error>),
     #[error("An error occurred: '{0}'")]
-    Other(String)
+    Other(String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -60,6 +60,8 @@ pub enum CoreError {
     NonModuleToNative(String, String),
     #[error("Root element is not a parent, cannot remove __document for playground")]
     RootElementNotParent,
+    #[error("DenyAllResolver is used; resolving of packages disallowed")]
+    DenyAllResolver
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -67,7 +67,7 @@ pub enum CoreError {
     #[error("Error resolving {0}: {1:?}")]
     Resolve(String, Box<dyn Error>),
     #[error("Duplicate configurations for packages: '{0:?}'")]
-    DuplicateConfigs(Vec<String>)
+    DuplicateConfigs(Vec<String>),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -66,8 +66,8 @@ pub enum CoreError {
     DenyAllResolver,
     #[error("Error resolving {0}: {1:?}")]
     Resolve(String, Box<dyn Error>),
-    #[error("An error occurred: '{0}'")]
-    Other(String),
+    #[error("Duplicate configurations for packages: '{0:?}'")]
+    DuplicateConfigs(Vec<String>)
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -68,6 +68,8 @@ pub enum CoreError {
     Resolve(String, Box<dyn Error>),
     #[error("Duplicate configurations for packages: '{0:?}'")]
     DuplicateConfigs(Vec<String>),
+    #[error("Unused configurations for packages: '{0:?}'")]
+    UnusedConfigs(Vec<String>),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,6 @@ pub use context::Context;
 pub use element::Element;
 pub use error::CoreError;
 pub use package::{ArgInfo, Package, PackageInfo, Transform};
-use parser::ParseError;
 
 use crate::context::CompilationState;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -77,7 +77,14 @@ pub fn eval(
     // TODO: Move this out so that we have a flag in the CLI and a switch in the playground to
     //   do verbose errors or "debug mode" or similar
     ctx.state.verbose_errors = true;
-    let document = parser::parse(source)?.try_into()?;
+    //let document = parser::parse(source)?.try_into()?;
+    let (doc_ast, config) = parser::parse_with_config(source)?;
+    let document = doc_ast.try_into()?;
+
+    if let Some(cfg) = config {
+        println!("Config: {:#?}", cfg);
+    }
+
     let res = eval_elem(document, ctx, format);
 
     res.map(|s| (s, ctx.take_state()))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,7 @@ compile_error!("feature \"native\" and feature \"web\" cannot be enabled at the 
 pub trait Resolve {
     type Error;
     fn resolve(&self, path: &str) -> Result<Vec<u8>, Self::Error>;
-    fn resolve_all(&self, paths: Vec<&str>) -> Vec<Result<Vec<u8>, Self::Error>>;
+    fn resolve_all(&self, paths: &[&str]) -> Vec<Result<Vec<u8>, Self::Error>>;
 }
 
 pub struct DenyAllResolver;
@@ -36,8 +36,11 @@ impl Resolve for DenyAllResolver {
         Err(CoreError::DenyAllResolver)
     }
 
-    fn resolve_all(&self, paths: Vec<&str>) -> Vec<Result<Vec<u8>, Self::Error>> {
-        paths.iter().map(|_| Err(CoreError::DenyAllResolver)).collect()
+    fn resolve_all(&self, paths: &[&str]) -> Vec<Result<Vec<u8>, Self::Error>> {
+        paths
+            .iter()
+            .map(|_| Err(CoreError::DenyAllResolver))
+            .collect()
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -90,7 +90,7 @@ pub fn eval<T>(
 ) -> Result<(String, CompilationState), CoreError>
 where
     T: Resolve,
-    <T as Resolve>::Error : Error + 'static,
+    <T as Resolve>::Error: Error + 'static,
 {
     // Note: this isn't actually needed, since take_state clears state, but it
     // is still called to ensure that it is cleared, if someone uses any context mutating functions
@@ -109,7 +109,7 @@ where
         ctx.import_missing_packages(cfg)?;
     }
     //Fixme: fix this stuff?????
-    ctx.expose_transforms2(config)?;
+    ctx.configure(config)?;
 
     let res = eval_elem(document, ctx, format);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -183,7 +183,8 @@ mod tests {
 
     #[test]
     fn table_manifest_test() {
-        let ctx = Context::default();
+        let mut ctx = Context::new_without_resolver();
+        ctx.load_default_packages().unwrap();
         let info = ctx.get_package_info("table").unwrap().clone();
 
         let foo = PackageInfo {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -182,8 +182,7 @@ mod tests {
 
     #[test]
     fn table_manifest_test() {
-        let mut ctx = Context::new_without_resolver();
-        ctx.load_default_packages().unwrap();
+        let ctx = Context::new_without_resolver().unwrap();
         let info = ctx.get_package_info("table").unwrap().clone();
 
         let foo = PackageInfo {

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -81,8 +81,8 @@ define_native_packages! {
 
 /// Returns a string containing the body of this invocation. This is the "leaf" call; no tree will
 /// be created as a result of this call
-pub fn native_raw(
-    _ctx: &mut Context,
+pub fn native_raw<T>(
+    _ctx: &mut Context<T>,
     body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
@@ -93,8 +93,8 @@ pub fn native_raw(
 
 /// Re-parses the content as block content (a paragraph with tags, modules etc) and
 /// returns the resulting compound element containing the contents of the paragraph
-pub fn native_inline_content(
-    _ctx: &mut Context,
+pub fn native_inline_content<T>(
+    _ctx: &mut Context<T>,
     body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
@@ -110,8 +110,8 @@ pub fn native_inline_content(
 
 /// Re-parses the content as block content (multiple paragraph or multiline module invocations) and
 /// returns the resulting compound element
-pub fn native_block_content(
-    _ctx: &mut Context,
+pub fn native_block_content<T>(
+    _ctx: &mut Context<T>,
     body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
@@ -126,8 +126,8 @@ pub fn native_block_content(
 }
 
 /// Example function for setting environment variables, currently unimplemented
-pub fn native_set_env(
-    _ctx: &mut Context,
+pub fn native_set_env<T>(
+    _ctx: &mut Context<T>,
     _body: &str,
     _args: HashMap<String, String>,
     _inline: bool,
@@ -136,8 +136,8 @@ pub fn native_set_env(
     unimplemented!("native_set_env")
 }
 
-pub fn native_warn(
-    ctx: &mut Context,
+pub fn native_warn<T>(
+    ctx: &mut Context<T>,
     body: &str,
     mut args: HashMap<String, String>,
     _inline: bool,
@@ -157,8 +157,8 @@ pub fn native_warn(
     Ok(Left(Element::Compound(vec![])))
 }
 
-pub fn native_err(
-    ctx: &mut Context,
+pub fn native_err<T>(
+    ctx: &mut Context<T>,
     body: &str,
     args: HashMap<String, String>,
     inline: bool,

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -46,8 +46,8 @@ macro_rules! define_native_packages {
             ]
         }
 
-        pub fn handle_native(
-            ctx: &mut Context,
+        pub fn handle_native<T>(
+            ctx: &mut Context<T>,
             package_name: &str,
             node_name: &str, // name of module or parent
             element: &Element,
@@ -88,7 +88,7 @@ macro_rules! define_native_packages {
 macro_rules! define_standard_package_loader {
     ($($name:expr),* $(,)?) => {
         #[cfg(all(feature = "bundle_std_packages", feature = "native", feature = "precompile_wasm"))]
-        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError> {
+        pub fn load_standard_packages<T>(ctx: &mut Context<T>) -> Result<(), CoreError> {
             $(
                 ctx.load_precompiled_package_from_wasm(
                     include_bytes!(
@@ -106,7 +106,7 @@ macro_rules! define_standard_package_loader {
             Ok(())
         }
         #[cfg(all(feature = "bundle_std_packages", not(all(feature = "native", feature = "precompile_wasm"))))]
-        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError> {
+        pub fn load_standard_packages<T>(ctx: &mut Context<T>) -> Result<(), CoreError> {
             $(
                 ctx.load_package_from_wasm(
                     include_bytes!(
@@ -124,7 +124,7 @@ macro_rules! define_standard_package_loader {
             Ok(())
         }
         #[cfg(not(feature = "bundle_std_packages"))]
-        pub fn load_standard_packages(_: &mut Context) -> Result<(), CoreError> {
+        pub fn load_standard_packages<T>(_: &mut Context<T>) -> Result<(), CoreError> {
             Ok(())
         }
     };

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -108,7 +108,7 @@ macro_rules! define_standard_package_loader {
         #[cfg(all(feature = "bundle_std_packages", not(all(feature = "native", feature = "precompile_wasm"))))]
         pub fn load_standard_packages<T>(ctx: &mut Context<T>) -> Result<(), CoreError> {
             $(
-                ctx.load_package_from_wasm(
+                ctx.load_standard_package(
                     include_bytes!(
                         concat!(
                             env!("OUT_DIR"),

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -130,7 +130,7 @@ fn import_config(input: &str) -> IResult<&str, ImportConfig, ConfigError> {
     map_res(
         opt(pair(
             delimited(space0, take_while1(|c: char| !c.is_whitespace()), space0),
-            separated_list0(pair(char(','), space0), alphanumeric1),
+            separated_list0(pair(char(','), space0), take_while1(|c: char| !c.is_whitespace() && c != ',')),
         )),
         |res: Option<(&str, Vec<&str>)>| {
             if let Some((option, imports)) = res {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -152,39 +152,39 @@ fn import_config(input: &str) -> IResult<&str, ImportConfig, ConfigError> {
     )(input)
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Hash)]
 pub struct Config {
     pub imports: Vec<Import>,
     pub hides: Vec<Hide>,
     pub sets: Vec<Set>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Import {
     pub name: String,
     pub importing: ImportConfig,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum ImportConfig {
     ImportAll,
     Include(Vec<String>),
     Exclude(Vec<String>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Hide {
     pub name: String,
     pub hiding: HideConfig,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Set {
     pub key: String,
     pub value: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum HideConfig {
     HideAll,
 }

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -1,0 +1,269 @@
+use nom::bytes::complete::{is_not, take_while, take_while1};
+use nom::character::complete::{alphanumeric1, char, line_ending, space0};
+use nom::combinator::{all_consuming, cut, eof, map, map_res, opt, peek, verify};
+use nom::error::{ErrorKind, FromExternalError, ParseError};
+use nom::multi::{separated_list0, separated_list1};
+use nom::sequence::{delimited, pair, separated_pair, terminated};
+use nom::{IResult, Parser};
+use thiserror::Error;
+
+use crate::config::ConfigError::*;
+use crate::module::parse_multiline_module;
+
+/// This function optionally parses a `[config]` module, and if a `[config]` module is detected,
+/// it will forcefully be parsed. If parsing fails, this parser fails with an appropriate
+/// `ConfigError`
+pub fn parse_config_module(input: &str) -> IResult<&str, Option<Config>, ConfigError> {
+    // Okay, this is kind of complicated since we want our result to have the same lifetime
+    // as the input, even though we have an IR of Module which doesn't have a lifetime
+    // First: try to parse the "config" module
+    let module = verify(parse_multiline_module, |module| {
+        module.name.to_ascii_lowercase().as_str() == "config"
+    })(input);
+
+    // Check if it was successful
+    match module {
+        // If we have no config module, return None and keep all our input
+        Err(_) => Ok((input, None)),
+        // If we do have a config module, "rest" is going to contain the rest of our input file to
+        // be parsed, and "module" is our parsed module
+        Ok((rest, module)) => {
+            // Let's cut our config body (make sure it actually parses and otherwise fail the parse
+            // altogether), and on successful parse, return our "rest" to be continued at parsing
+            all_consuming(map(cut(parse_config_body), Some))(&module.body)
+                .map(|(_, cfg)| (rest, cfg))
+        }
+    }
+}
+
+fn parse_config_body(input: &str) -> IResult<&str, Config, ConfigError> {
+    // FIXME: The best way to do this is probably by just running .lines(), I think, and maybe
+    //   regex? This is kinda complicated and doesn't provide good diagnostics
+
+    // Our config body contains of newline-separated import statements
+    map_res(
+        separated_list1(line_ending, cut(terminated(config_statement, space0))),
+        |imports| {
+            imports
+                .into_iter()
+                .flatten()
+                .try_fold(Config::default(), Config::try_append)
+        },
+    )(input)
+}
+
+fn config_statement(input: &str) -> IResult<&str, Option<ConfigAppendable>, ConfigError> {
+    // Check if it is empty, and in that case, return it
+    let empty_result = map(pair(space0, peek(line_ending.or(eof))), |_| None)(input);
+    if empty_result.is_ok() {
+        return empty_result;
+    }
+
+    // Get the first keyword
+    let (rest, keyword) = delimited(space0, is_not(" \n\r"), space0)(input)
+        .map_err(|e| e.map(|_e: nom::error::Error<&str>| InvalidConfigStatement))?;
+    match keyword {
+        "import" => map(import_statement, Into::into)(rest),
+        "hide" => map(hide_statement, Into::into)(rest),
+        "set" => map(set_statement, Into::into)(rest),
+        _ => Err(nom::Err::Error(InvalidConfigKeyword(keyword.to_string()))),
+    }
+    .map(|(a, b)| (a, Some(b)))
+}
+
+fn set_statement(input: &str) -> IResult<&str, Set, ConfigError> {
+    map(
+        separated_pair(
+            take_while(|c: char| !c.is_whitespace()),
+            space0,
+            is_not("\n\r"),
+        ),
+        |(key, value): (&str, &str)| {
+            if value.starts_with('"') && value.ends_with('"') {
+                let sub_value = &value[1..value.len() - 1];
+                Set {
+                    key: key.to_string(),
+                    value: sub_value.to_string(),
+                }
+            } else {
+                Set {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                }
+            }
+        },
+    )(input)
+    .map_err(|e| {
+        e.map(|_e: nom::error::Error<&str>| {
+            InvalidSetStatement(
+                input
+                    .lines()
+                    .next()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            )
+        })
+    })
+}
+
+fn hide_statement(input: &str) -> IResult<&str, Hide, ConfigError> {
+    map(take_while(|c: char| !c.is_whitespace()), |name: &str| {
+        Hide {
+            name: name.to_string(),
+            hiding: HideConfig::HideAll,
+        }
+    })(input)
+}
+
+fn import_statement(input: &str) -> IResult<&str, Import, ConfigError> {
+    map(
+        pair(take_while(|c: char| !c.is_whitespace()), import_config),
+        |(name, config)| Import {
+            name: name.to_string(),
+            importing: config,
+        },
+    )(input)
+}
+
+fn import_config(input: &str) -> IResult<&str, ImportConfig, ConfigError> {
+    // three cases: either we have "using abc, def...", or "hiding abc, def...", or nothing
+    map_res(
+        opt(pair(
+            delimited(space0, take_while1(|c: char| !c.is_whitespace()), space0),
+            separated_list0(pair(char(','), space0), alphanumeric1),
+        )),
+        |res: Option<(&str, Vec<&str>)>| {
+            if let Some((option, imports)) = res {
+                if imports.is_empty() {
+                    return Err(NoExclusionsSpecified(option.to_string()));
+                }
+
+                let map = imports.into_iter().map(&str::to_string).collect();
+                let lowercase = option.to_lowercase();
+                match lowercase.as_str() {
+                    "using" => Ok(ImportConfig::Include(map)),
+                    "hiding" => Ok(ImportConfig::Exclude(map)),
+                    x => Err(InvalidImportSpecifier(x.to_string())),
+                }
+            } else {
+                Ok(ImportConfig::ImportAll)
+            }
+        },
+    )(input)
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    pub imports: Vec<Import>,
+    pub hides: Vec<Hide>,
+    pub sets: Vec<Set>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Import {
+    pub name: String,
+    pub importing: ImportConfig,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImportConfig {
+    ImportAll,
+    Include(Vec<String>),
+    Exclude(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Hide {
+    pub name: String,
+    pub hiding: HideConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct Set {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum HideConfig {
+    HideAll,
+}
+
+enum ConfigAppendable {
+    Import(Import),
+    Hide(Hide),
+    Set(Set),
+}
+
+impl Config {
+    fn try_append(mut self, other: ConfigAppendable) -> Result<Self, ConfigError> {
+        // Fixme: Check that there are no collisions here
+        match other {
+            ConfigAppendable::Import(i) => {
+                self.imports.push(i);
+            }
+            ConfigAppendable::Hide(h) => {
+                self.hides.push(h);
+            }
+            ConfigAppendable::Set(s) => {
+                self.sets.push(s);
+            }
+        }
+        Ok(self)
+    }
+}
+
+impl From<Import> for ConfigAppendable {
+    fn from(value: Import) -> Self {
+        ConfigAppendable::Import(value)
+    }
+}
+
+impl From<Hide> for ConfigAppendable {
+    fn from(value: Hide) -> Self {
+        ConfigAppendable::Hide(value)
+    }
+}
+
+impl From<Set> for ConfigAppendable {
+    fn from(value: Set) -> Self {
+        ConfigAppendable::Set(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum ConfigError {
+    #[error("Invalid configuration statement: start with a keyword and then give options, like 'import foo'")]
+    InvalidConfigStatement,
+    // If we get an invalid keyword (the first word of a config line)
+    #[error("Invalid configuration keyword '{0}', expected 'import', 'hide' or 'set'")]
+    InvalidConfigKeyword(String),
+    #[error("Invalid import statement '{0}', expected 'import package_name'")]
+    InvalidImportStatement(String),
+    #[error("Invalid import specifier '{0}', expected 'using' or 'hiding'")]
+    InvalidImportSpecifier(String),
+    #[error("Invalid set statement, expected 'set key value', got '{0}'")]
+    InvalidSetStatement(String),
+    #[error("'{0}' specified for an import but no transformations named")]
+    NoExclusionsSpecified(String),
+    #[error("Accumulation error")]
+    AccumulationError,
+    #[error("Unknown nom error when parsing config: '{0}', kind: '{1:?}'")]
+    UnknownNomError(String, ErrorKind),
+}
+
+impl ParseError<&str> for ConfigError {
+    fn from_error_kind(input: &str, kind: ErrorKind) -> Self {
+        UnknownNomError(input.to_string(), kind)
+    }
+
+    fn append(_input: &str, _kind: ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+
+impl FromExternalError<&str, ConfigError> for ConfigError {
+    fn from_external_error(_input: &str, _kind: ErrorKind, e: ConfigError) -> Self {
+        e
+    }
+}

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::{is_not, take_while, take_while1};
-use nom::character::complete::{alphanumeric1, char, line_ending, space0};
+use nom::character::complete::{char, line_ending, space0};
 use nom::combinator::{all_consuming, cut, eof, map, map_res, opt, peek, verify};
 use nom::error::{ErrorKind, FromExternalError, ParseError};
 use nom::multi::{separated_list0, separated_list1};
@@ -127,7 +127,10 @@ fn import_config(input: &str) -> IResult<&str, ImportConfig, ConfigError> {
     map_res(
         opt(pair(
             delimited(space0, take_while1(|c: char| !c.is_whitespace()), space0),
-            separated_list0(pair(char(','), space0), take_while1(|c: char| !c.is_whitespace() && c != ',')),
+            separated_list0(
+                pair(char(','), space0),
+                take_while1(|c: char| !c.is_whitespace() && c != ','),
+            ),
         )),
         |res: Option<(&str, Vec<&str>)>| {
             if let Some((option, imports)) = res {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -37,9 +37,6 @@ pub fn parse_config_module(input: &str) -> IResult<&str, Option<Config>, ConfigE
 }
 
 fn parse_config_body(input: &str) -> IResult<&str, Config, ConfigError> {
-    // FIXME: The best way to do this is probably by just running .lines(), I think, and maybe
-    //   regex? This is kinda complicated and doesn't provide good diagnostics
-
     // Our config body contains of newline-separated import statements
     map_res(
         separated_list1(line_ending, cut(terminated(config_statement, space0))),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -18,7 +18,7 @@ use crate::punct::smart_punctuate;
 use crate::tag::CompoundAST;
 use crate::Ast::Text;
 
-mod config;
+pub mod config;
 mod module;
 mod or;
 mod punct;

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,17 +1,13 @@
-use modmark_core::{eval, eval_no_document, Context, CoreError, OutputFormat, DenyAllResolver};
 use std::cell::RefCell;
 
+use modmark_core::{eval, eval_no_document, Context, CoreError, DenyAllResolver, OutputFormat};
 use parser::ParseError;
 use serde::Serialize;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 thread_local! {
-    static CONTEXT: RefCell<Context<DenyAllResolver>> = RefCell::new({
-        let mut ctx = Context::new_without_resolver();
-        ctx.load_default_packages().unwrap();
-        ctx
-    });
+    static CONTEXT: RefCell<Context<DenyAllResolver>> = RefCell::new(Context::new_without_resolver().unwrap())
 }
 
 #[derive(Error, Debug)]

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,4 +1,4 @@
-use modmark_core::{eval, eval_no_document, Context, CoreError, OutputFormat};
+use modmark_core::{eval, eval_no_document, Context, CoreError, OutputFormat, DenyAllResolver};
 use std::cell::RefCell;
 
 use parser::ParseError;
@@ -7,7 +7,11 @@ use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 thread_local! {
-    static CONTEXT: RefCell<Context> = RefCell::new(Context::default());
+    static CONTEXT: RefCell<Context<DenyAllResolver>> = RefCell::new({
+        let mut ctx = Context::new_without_resolver();
+        ctx.load_default_packages().unwrap();
+        ctx
+    });
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This PR adds the `[config]` module. This isn't a native module nor an external module, it is a parser module which is handled at the parsing step immediately. Currently, there is support for `import`, `hide` and `set` statements.

# Syntax:
To use the config module, put a multiline `[config]` module at the very top of the document. `[config]` modules are not allowed anywhere else. Thereafter, each line of the module body is a config statement. There are three types of statements described below, and here is an example of a config module expression:
```
[config]
hide table
import bettertable
set bettertable_colours gray white gray black
```

## Import statements:
Import statements come in three flavours:
```
import foo
import bar using a, b, c
import baz hiding x, y, z
```
They import the given package, possibly only importing some transforms (`using`) or possibly skipping some transforms (`hiding`).

## Hide statements:
You can hide a built-in package by doing `hide html`. This has the same behaviour as doing `import html using <none>` or `import html hiding *` (none of which is allowed).

## Set statements
You may do `set key value` to set the variable `key` to the value `value`. `value` may contain spaces (so `set a abc def` works), but it strips its initial spaces; quotes can be used to include initial whitespace

# State of this PR
~~This is currently a draft PR. To make this merge-ready, it needs to have better support in Core, to actually do something with errors rather than just printing them to the console, and hook it up to the package manager (for the CLI) which will hopefully be merged in GH-126.~~

I think this PR is ready for merging. Note that these config statements are not supposed to be the only ones which exists but I think it might be good to have a foundation to build upon on main. More statements may be added as part of future issues/PRs.

*Note that this PR doesn't add package resolving to the Playground; if you want to test it out, you may use the CLI*