### PR TITLE
GH-153: Add default html styling

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -53,6 +53,8 @@ pub enum CoreError {
     Parsing(#[from] ParseError),
     #[error("Native call error: Non-module given to package {0} named {1}")]
     NonModuleToNative(String, String),
+    #[error("Root element is not a parent, cannot remove __document for playground")]
+    RootElementNotParent,
 }
 
 impl From<WasiError> for CoreError {

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -67,12 +67,11 @@ fn transform_document(doc: Value) -> String {
     let mut result = String::new();
     result.push('[');
 
-    write!(
-        result,
-        "{},",
-        raw!("<html><head><title>Document</title></head><body>")
-    )
-    .unwrap();
+    write!(result, "{},", raw!("<html><head><title>Document</title>")).unwrap();
+
+    write!(result, "{},", raw!("<style>")).unwrap();
+    write!(result, "{},", raw!(include_str!("templates/html.css"))).unwrap();
+    write!(result, "{},", raw!("</style></head><body>")).unwrap();
 
     if let Value::Array(children) = &doc["children"] {
         for child in children {

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -67,6 +67,7 @@ fn transform_document(doc: Value) -> String {
     let mut result = String::new();
     result.push('[');
 
+    write!(result, "{},", raw!("<!DOCTYPE html>")).unwrap();
     write!(result, "{},", raw!("<html><head><title>Document</title>")).unwrap();
 
     write!(result, "{},", raw!("<style>")).unwrap();

--- a/packages/html/src/templates/html.css
+++ b/packages/html/src/templates/html.css
@@ -12,7 +12,6 @@
 h1,
 h2,
 h3 {
-  font-family: Inter, sans-serif;
   font-weight: 800;
   line-height: 1.1;
 }

--- a/packages/html/src/templates/html.css
+++ b/packages/html/src/templates/html.css
@@ -1,0 +1,179 @@
+:root {
+  --color-dark: #252525;
+  --color-light: #efefef;
+  --color-primary: #1a8fe3;
+  --size-step-0: clamp(1rem, calc(0.96rem + 0.22vw), 1.13rem);
+  --size-step-1: clamp(1.25rem, calc(1.16rem + 0.43vw), 1.5rem);
+  --size-step-2: clamp(1.56rem, calc(1.41rem + 0.76vw), 2rem);
+  --size-step-3: clamp(1.95rem, calc(1.71rem + 1.24vw), 2.66rem);
+  --size-step-4: clamp(2.44rem, calc(2.05rem + 1.93vw), 3.55rem);
+}
+
+h1,
+h2,
+h3 {
+  font-family: Inter, sans-serif;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+a {
+  color: currentColor;
+  text-decoration-color: var(--color-primary);
+  text-decoration-thickness: 0.3ex;
+  text-underline-offset: 0.3ex;
+}
+
+.lede {
+  font-size: var(--size-step-1);
+  max-width: 50ch;
+  font-style: italic;
+}
+
+
+blockquote {
+  max-width: 50ch;
+}
+
+h1 {
+  max-width: 20ch;
+}
+
+h2,
+h3 {
+  max-width: 28ch;
+}
+
+body {
+  background: var(--color-light);
+  color: var(--color-dark);
+  padding: 2em;
+  font-family: Georgia, serif;
+  font-size: var(--size-step-0);
+  line-height: 1.7;
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  padding: 2rem 10rem;
+}
+
+
+:is(h1, h2, h3, blockquote) {
+  --flow-space: 1.5em;
+}
+
+.lede {
+  font-size: var(--size-step-1);
+  font-style: italic;
+  max-width: 50ch;
+}
+
+.lede+* {
+  --flow-space: 2em;
+}
+
+:is(h1, h2, h3)+* {
+  --flow-space: 0.5em;
+}
+
+.flow>*+* {
+  margin-block-start: var(--flow-space, 1em);
+}
+
+blockquote {
+  padding-inline-start: 1em;
+  border-inline-start: 0.3em solid;
+  font-style: italic;
+  font-size: var(--size-step-1);
+}
+
+h1 {
+  font-size: var(--size-step-4);
+}
+
+h2 {
+  font-size: var(--size-step-3);
+}
+
+h3 {
+  font-size: var(--size-step-2);
+}
+
+ul,
+ol {
+  padding-inline-start: 1em;
+}
+
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+ul[role='list'],
+ol[role='list'] {
+  list-style: none;
+}
+
+/* Set core root defaults */
+html:focus-within {
+  scroll-behavior: smooth;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+article>* {
+  max-width: 65ch;
+  margin-inline: auto;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+}
+
+tbody tr:nth-child(even) {
+  background: #ccc;
+}

--- a/packages/html/src/templates/latex.css
+++ b/packages/html/src/templates/latex.css
@@ -1,0 +1,578 @@
+/*!
+ * LaTeX.css (https://latex.now.sh/)
+ *
+ * Source: https://github.com/vincentdoerig/latex-css
+ * Licensed under MIT (https://github.com/vincentdoerig/latex-css/blob/master/LICENSE)
+*/
+
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --body-color: hsl(0, 5%, 10%);
+  --body-bg-color: hsl(210, 20%, 98%);
+  --link-visited: hsl(0, 100%, 33%);
+  --link-focus-outline: hsl(220, 90%, 52%);
+  --pre-bg-color: hsl(210, 28%, 93%);
+  --kbd-bg-color: hsl(210, 5%, 100%);
+  --kbd-border-color: hsl(210, 5%, 70%);
+  --table-border-color: black;
+  --sidenote-target-border-color: hsl(55, 55%, 70%);
+  --footnotes-border-color: hsl(0, 0%, 39%);
+  --text-indent-size: 1.463rem;
+  /* In 12pt [Latin Modern font] LaTeX article
+  \parindent =~ 17.625pt; taking also into account the ratio
+  1pt[LaTeX] = (72 / 72.27) * 1pt[HTML], with default 12pt/1rem LaTeX.css font
+  size, the identation value in rem CSS units is: 
+  \parindent =~ 17.625 * (72 / 72.27) / 12 = 1.463rem. */
+}
+
+.latex-dark {
+  --body-color: hsl(0, 0%, 86%);
+  --body-bg-color: hsl(0, 0%, 16%);
+  --link-visited: hsl(196 80% 77%);
+  --link-focus-outline: hsl(215, 63%, 73%);
+  --pre-bg-color: hsl(0, 1%, 25%);
+  --kbd-bg-color: hsl(0, 0%, 16%);
+  --kbd-border-color: hsl(210, 5%, 70%);
+  --table-border-color: white;
+  --sidenote-target-border-color: hsl(0, 0%, 59%);
+  --footnotes-border-color: hsl(0, 0%, 59%);
+  --proof-symbol-filter: invert(80%);
+}
+
+@media (prefers-color-scheme: dark) {
+  .latex-dark-auto {
+    --body-color: hsl(0, 0%, 86%);
+    --body-bg-color: hsl(0, 0%, 16%);
+    --link-visited: hsl(196 80% 77%);
+    --link-focus-outline: hsl(215, 63%, 73%);
+    --pre-bg-color: hsl(0, 1%, 25%);
+    --kbd-bg-color: hsl(0, 0%, 16%);
+    --kbd-border-color: hsl(210, 5%, 70%);
+    --table-border-color: white;
+    --sidenote-target-border-color: hsl(0, 0%, 59%);
+    --footnotes-border-color: hsl(0, 0%, 59%);
+    --proof-symbol-filter: invert(80%);
+  }
+}
+
+/* Remove default margin */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+ul[class],
+ol[class],
+li,
+figure,
+figcaption,
+dl,
+dd {
+  margin: 0;
+}
+
+/* Make default font-size 1rem and add smooth scrolling to anchors */
+html {
+  font-size: 1rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+body {
+  font-family: 'Latin Modern', Georgia, Cambria, 'Times New Roman', Times, serif;
+  line-height: 1.8;
+
+  max-width: 80ch;
+  min-height: 100vh;
+  overflow-x: hidden;
+  margin: 0 auto;
+  padding: 2rem 1.25rem;
+
+  counter-reset: theorem definition sidenote-counter;
+
+  color: var(--body-color);
+  background-color: var(--body-bg-color);
+
+  text-rendering: optimizeLegibility;
+}
+
+/* Justify and hyphenate all paragraphs */
+p {
+  text-align: justify;
+  hyphens: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  margin-top: 1rem;
+}
+
+/* Indents paragraphs like in LaTeX documents*/
+.indent-pars p {
+  text-indent: var(--text-indent-size);
+}
+
+.indent-pars p.no-indent,
+p.no-indent {
+  text-indent: 0;
+}
+
+.indent-pars ol p,
+.indent-pars ul p {
+  text-indent: 0;
+}
+
+.indent-pars h2+p,
+.indent-pars h3+p,
+.indent-pars h4+p {
+  text-indent: 0;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+}
+
+/* Make links red */
+a,
+a:visited {
+  color: var(--link-visited);
+}
+
+a:focus {
+  outline-offset: 2px;
+  outline: 2px solid var(--link-focus-outline);
+}
+
+/* Make images easier to work with */
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Prevent textarea from overflowing */
+textarea {
+  width: 100%;
+}
+
+/* Natural flow and rhythm in articles by default */
+article>*+* {
+  margin-top: 1em;
+}
+
+/* Styles for inline code or code snippets */
+code,
+pre,
+kbd {
+  font-size: 85%;
+}
+
+pre {
+  padding: 1rem 1.4rem;
+  max-width: 100%;
+  overflow: auto;
+  border-radius: 4px;
+  background: var(--pre-bg-color);
+}
+
+pre code {
+  font-size: 95%;
+  position: relative;
+}
+
+kbd {
+  background: var(--kbd-bg-color);
+  border: 1px solid var(--kbd-border-color);
+  border-radius: 2px;
+  padding: 2px 4px;
+  font-size: 75%;
+}
+
+/* Better tables */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: auto;
+  max-width: 100%;
+  border-top: 2.27px solid var(--table-border-color);
+  border-bottom: 2.27px solid var(--table-border-color);
+  /* display: block; */
+  overflow-x: auto;
+  /* does not work because element is not block */
+  /* white-space: nowrap; */
+  counter-increment: caption;
+}
+
+/* add bottom border on column table headings  */
+table tr>th[scope='col'] {
+  border-bottom: 1.36px solid var(--table-border-color);
+}
+
+/* add right border on row table headings  */
+table tr>th[scope='row'] {
+  border-right: 1.36px solid var(--table-border-color);
+}
+
+table>tbody>tr:first-child>td,
+table>tbody>tr:first-child>th {
+  border-top: 1.36px solid var(--table-border-color);
+}
+
+table>tbody>tr:last-child>td,
+table>tbody>tr:last-child>th {
+  border-bottom: 1.36px solid var(--table-border-color);
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.5rem;
+  line-height: 1.1;
+}
+
+/* Table caption */
+caption {
+  text-align: left;
+  font-size: 0.923em;
+  /* border-bottom: 2pt solid #000; */
+  padding: 0 0.25em 0.25em;
+  width: 100%;
+  margin-left: 0;
+}
+
+caption::before {
+  content: 'Table 'counter(caption) '. ';
+  font-weight: bold;
+}
+
+/* allow scroll on the x-axis */
+.scroll-wrapper {
+  overflow-x: auto;
+}
+
+/* if a table is wrapped in a scroll wrapper,
+  the table cells shouldn't wrap */
+.scroll-wrapper>table td {
+  white-space: nowrap;
+}
+
+/* Center align the title */
+h1:first-child {
+  text-align: center;
+}
+
+/* Nested ordered list for ToC */
+nav ol {
+  counter-reset: item;
+  padding-left: 2rem;
+}
+
+nav li {
+  display: block;
+}
+
+nav li:before {
+  content: counters(item, '.') ' ';
+  counter-increment: item;
+  padding-right: 0.85rem;
+}
+
+/* Center definitions (most useful for display equations) */
+dl dd {
+  text-align: center;
+}
+
+/* Theorem */
+.theorem {
+  counter-increment: theorem;
+  display: block;
+  margin: 12px 0;
+  font-style: italic;
+}
+
+.theorem::before {
+  content: 'Theorem 'counter(theorem) '. ';
+  font-weight: bold;
+  font-style: normal;
+}
+
+/* Lemma */
+.lemma {
+  counter-increment: theorem;
+  display: block;
+  margin: 12px 0;
+  font-style: italic;
+}
+
+.lemma::before {
+  content: 'Lemma 'counter(theorem) '. ';
+  font-weight: bold;
+  font-style: normal;
+}
+
+/* Proof */
+.proof {
+  display: block;
+  margin: 12px 0;
+  font-style: normal;
+  position: relative;
+}
+
+.proof::before {
+  content: 'Proof. 'attr(title);
+  font-style: italic;
+}
+
+.proof:after {
+  content: '◾️';
+  filter: var(--proof-symbol-filter);
+  position: absolute;
+  right: -12px;
+  bottom: -2px;
+}
+
+/* Definition */
+.definition {
+  counter-increment: definition;
+  display: block;
+  margin: 12px 0;
+  font-style: normal;
+}
+
+.definition::before {
+  content: 'Definition 'counter(definition) '. ';
+  font-weight: bold;
+  font-style: normal;
+}
+
+/* Center align author name, use small caps and add vertical spacing  */
+.author {
+  margin: 0.85rem 0;
+  font-variant-caps: small-caps;
+  text-align: center;
+}
+
+/* Sidenotes */
+
+.sidenote {
+  font-size: 0.8rem;
+  float: right;
+  clear: right;
+  width: 18vw;
+  margin-right: -20vw;
+  margin-bottom: 1em;
+  text-indent: 0;
+}
+
+.sidenote.left {
+  float: left;
+  margin-left: -20vw;
+  margin-bottom: 1em;
+  text-indent: 0;
+}
+
+/* (WIP) add border when a sidenote is clicked on */
+.sidenote:target {
+  border: var(--sidenote-target-border-color) 1.5px solid;
+  padding: 0 .5rem;
+  scroll-margin-block-start: 10rem;
+}
+
+/* sidenote counter */
+.sidenote-number {
+  counter-increment: sidenote-counter;
+}
+
+.sidenote-number::after,
+.sidenote::before {
+  position: relative;
+  vertical-align: baseline;
+}
+
+/* add number in main content */
+.sidenote-number::after {
+  content: counter(sidenote-counter);
+  font-size: 0.7rem;
+  top: -0.5rem;
+  left: 0.1rem;
+}
+
+/* add number in front of the sidenote */
+.sidenote-number~.sidenote::before {
+  content: counter(sidenote-counter) ' ';
+  font-size: 0.7rem;
+  top: -0.5rem;
+}
+
+label.sidenote-toggle:not(.sidenote-number) {
+  display: none;
+}
+
+/* sidenotes inside blockquotes are indented more */
+blockquote .sidenote {
+  margin-right: -24vw;
+  width: 18vw;
+}
+
+
+label.sidenote-toggle {
+  display: inline;
+  cursor: pointer;
+}
+
+input.sidenote-toggle {
+  display: none;
+}
+
+@media (max-width: 1050px) {
+  label.sidenote-toggle:not(.sidenote-number) {
+    display: inline;
+  }
+
+  .sidenote {
+    display: none;
+  }
+
+  .sidenote-toggle:checked+.sidenote {
+    display: block;
+    margin: 0.5rem 1.25rem 1rem 0.5rem;
+    float: left;
+    left: 1rem;
+    clear: both;
+    width: 95%;
+  }
+
+  /* tweak indentation of sidenote inside a blockquote */
+  blockquote .sidenote {
+    margin-right: -25vw;
+    width: 16vw;
+  }
+}
+
+/* Make footnote text smaller and left align it (looks bad with long URLs) */
+.footnotes p {
+  text-align: left;
+  line-height: 1.5;
+  font-size: 85%;
+  margin-bottom: 0.4rem;
+}
+
+.footnotes {
+  border-top: 1px solid var(--footnotes-border-color);
+}
+
+/* Center title and paragraph */
+.abstract,
+.abstract p {
+  text-align: center;
+  margin-top: 0;
+}
+
+.abstract {
+  margin: 2.25rem 0;
+}
+
+.abstract>h2 {
+  font-size: 1rem;
+  margin-bottom: -0.2rem;
+}
+
+/* Format the LaTeX symbol correctly (a higher up, e lower) */
+.latex span:nth-child(1) {
+  text-transform: uppercase;
+  font-size: 0.75em;
+  vertical-align: 0.28em;
+  margin-left: -0.48em;
+  margin-right: -0.15em;
+  line-height: 1ex;
+}
+
+.latex span:nth-child(2) {
+  text-transform: uppercase;
+  vertical-align: -0.5ex;
+  margin-left: -0.1667em;
+  margin-right: -0.125em;
+  line-height: 1ex;
+}
+
+/* Heading typography */
+h1 {
+  font-size: 2.5rem;
+  line-height: 3.25rem;
+  margin-bottom: 1.625rem;
+}
+
+h2 {
+  font-size: 1.7rem;
+  line-height: 2rem;
+  margin-top: 3rem;
+}
+
+h3 {
+  font-size: 1.4rem;
+  margin-top: 2.5rem;
+}
+
+h4 {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+}
+
+h5 {
+  font-size: 1rem;
+  margin-top: 1.8rem;
+}
+
+h6 {
+  font-size: 1rem;
+  font-style: italic;
+  font-weight: normal;
+  margin-top: 2.5rem;
+}
+
+h3,
+h4,
+h5,
+h6 {
+  line-height: 1.625rem;
+}
+
+h1+h2 {
+  margin-top: 1.625rem;
+}
+
+h2+h3,
+h3+h4,
+h4+h5 {
+  margin-top: 0.8rem;
+}
+
+h5+h6 {
+  margin-top: -0.8rem;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 0.8rem;
+}

--- a/packages/html/tests/test_document.json
+++ b/packages/html/tests/test_document.json
@@ -1,53 +1,69 @@
 {
-    "name": "__document",
-    "arguments": {},
-    "children": [
+  "name": "__document",
+  "arguments": {},
+  "children": [
+    {
+      "name": "raw",
+      "data": "Raw stuff",
+      "arguments": {},
+      "inline": true
+    },
+    {
+      "name": "__bold",
+      "arguments": {},
+      "children": [
         {
-            "name": "raw",
-            "data": "Raw stuff",
-            "arguments": {},
-            "inline": true
-        },
-        {
-            "name": "__bold",
-            "arguments": {},
-            "children": [
-                {
-                    "name": "__text",
-                    "data": "Hello, world",
-                    "arguments": {},
-                    "inline": true
-                }
-            ]
+          "name": "__text",
+          "data": "Hello, world",
+          "arguments": {},
+          "inline": true
         }
-    ],
-    "__test_transform_to": "html",
-    "__test_expected_result": [
+      ]
+    }
+  ],
+  "__test_transform_to": "html",
+  "__test_expected_result": [
+    {
+      "data": "<!DOCTYPE html>",
+      "name": "raw"
+    },
+    {
+      "data": "<html><head><title>Document</title>",
+      "name": "raw"
+    },
+    {
+      "data": "<style>",
+      "name": "raw"
+    },
+    {
+      "data": ":root {\n  --color-dark: #252525;\n  --color-light: #efefef;\n  --color-primary: #1a8fe3;\n  --size-step-0: clamp(1rem, calc(0.96rem + 0.22vw), 1.13rem);\n  --size-step-1: clamp(1.25rem, calc(1.16rem + 0.43vw), 1.5rem);\n  --size-step-2: clamp(1.56rem, calc(1.41rem + 0.76vw), 2rem);\n  --size-step-3: clamp(1.95rem, calc(1.71rem + 1.24vw), 2.66rem);\n  --size-step-4: clamp(2.44rem, calc(2.05rem + 1.93vw), 3.55rem);\n}\n\nh1,\nh2,\nh3 {\n  font-weight: 800;\n  line-height: 1.1;\n}\n\na {\n  color: currentColor;\n  text-decoration-color: var(--color-primary);\n  text-decoration-thickness: 0.3ex;\n  text-underline-offset: 0.3ex;\n}\n\n.lede {\n  font-size: var(--size-step-1);\n  max-width: 50ch;\n  font-style: italic;\n}\n\n\nblockquote {\n  max-width: 50ch;\n}\n\nh1 {\n  max-width: 20ch;\n}\n\nh2,\nh3 {\n  max-width: 28ch;\n}\n\nbody {\n  background: var(--color-light);\n  color: var(--color-dark);\n  padding: 2em;\n  font-family: Georgia, serif;\n  font-size: var(--size-step-0);\n  line-height: 1.7;\n  min-height: 100vh;\n  text-rendering: optimizeSpeed;\n  padding: 2rem 10rem;\n}\n\n\n:is(h1, h2, h3, blockquote) {\n  --flow-space: 1.5em;\n}\n\n.lede {\n  font-size: var(--size-step-1);\n  font-style: italic;\n  max-width: 50ch;\n}\n\n.lede+* {\n  --flow-space: 2em;\n}\n\n:is(h1, h2, h3)+* {\n  --flow-space: 0.5em;\n}\n\n.flow>*+* {\n  margin-block-start: var(--flow-space, 1em);\n}\n\nblockquote {\n  padding-inline-start: 1em;\n  border-inline-start: 0.3em solid;\n  font-style: italic;\n  font-size: var(--size-step-1);\n}\n\nh1 {\n  font-size: var(--size-step-4);\n}\n\nh2 {\n  font-size: var(--size-step-3);\n}\n\nh3 {\n  font-size: var(--size-step-2);\n}\n\nul,\nol {\n  padding-inline-start: 1em;\n}\n\nimg,\npicture {\n  max-width: 100%;\n  display: block;\n}\n\ninput,\nbutton,\ntextarea,\nselect {\n  font: inherit;\n}\n\n@media (prefers-reduced-motion: reduce) {\n  html:focus-within {\n    scroll-behavior: auto;\n  }\n\n  *,\n  *::before,\n  *::after {\n    animation-duration: 0.01ms !important;\n    animation-iteration-count: 1 !important;\n    transition-duration: 0.01ms !important;\n    scroll-behavior: auto !important;\n  }\n}\n\nul[role='list'],\nol[role='list'] {\n  list-style: none;\n}\n\n/* Set core root defaults */\nhtml:focus-within {\n  scroll-behavior: smooth;\n}\n\nbody,\nh1,\nh2,\nh3,\nh4,\np,\nfigure,\nblockquote,\ndl,\ndd {\n  margin: 0;\n}\n\n*,\n*::before,\n*::after {\n  box-sizing: border-box;\n}\n\narticle>* {\n  max-width: 65ch;\n  margin-inline: auto;\n}\n\ntable {\n  border-collapse: collapse;\n}\n\nth, td {\n  padding: 0.5rem 0.75rem;\n  border: 1px solid #ccc;\n}\n\ntbody tr:nth-child(even) {\n  background: #ccc;\n}",
+      "name": "raw"
+    },
+    {
+      "data": "</style></head><body>",
+      "name": "raw"
+    },
+    {
+      "arguments": {},
+      "data": "Raw stuff",
+      "inline": true,
+      "name": "raw"
+    },
+    {
+      "arguments": {},
+      "children": [
         {
-            "name": "raw",
-            "data": "<html><head><title>Document</title></head><body>"
-        },
-        {
-            "name": "raw",
-            "data": "Raw stuff",
-            "arguments": {},
-            "inline": true
-        },
-        {
-            "name": "__bold",
-            "arguments": {},
-            "children": [
-                {
-                    "name": "__text",
-                    "data": "Hello, world",
-                    "arguments": {},
-                    "inline": true
-                }
-            ]
-        },
-        {
-            "name": "raw",
-            "data": "</body></html>"
+          "arguments": {},
+          "data": "Hello, world",
+          "inline": true,
+          "name": "__text"
         }
-    ]
+      ],
+      "name": "__bold"
+    },
+    {
+      "data": "</body></html>",
+      "name": "raw"
+    }
+  ]
 }

--- a/playground/static/compiler.js
+++ b/playground/static/compiler.js
@@ -28,6 +28,9 @@ onmessage = (event) => {
             case "transpile":
                 result = wasm_bindgen.transpile(event.data.source, event.data.format);
                 break;
+            case "transpile_no_document":
+                result = wasm_bindgen.transpile_no_document(event.data.source, event.data.format);
+                break;
         }
         postMessage({ result: result, success: true, ...event.data });
     } catch (error) {

--- a/playground/static/main.js
+++ b/playground/static/main.js
@@ -297,7 +297,8 @@ async function updateOutput(input) {
             case "transpile":
             case "render-iframe":
             case "render": {
-                let { content, warnings, errors } = JSON.parse(await compilerAction({ type: "transpile", source: input, format: "html" }));
+                let type = selector.value == "render" ? "transpile_no_document" : "transpile";
+                let { content, warnings, errors } = JSON.parse(await compilerAction({ type, source: input, format: "html" }));
                 errors.forEach(addError);
                 warnings.forEach(addWarning);
 


### PR DESCRIPTION
This PR  adds two CSS files for the html package, currently it just defaults to the one called `html.css`. Once variables and config is available #170 should be implemented. Also created a eval_no_document function in core that is now used by the playground to avoid getting html body and style tags.

- Resolves: GH-153.