### PR TITLE
GH-173: Add `precompile_wasm` feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,11 +15,29 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 either = "1.8.1"
 
+# We need wasmer as a build dependency since we may want to pre-compile the bundled packages. However, we can't bring
+# it in since the build script is always built for the host, and Cargo enables the JS flags when targeting the web,
+# making a compile_error!() occur from wasmer. We can't conditionally enable/disable the dependency either since that
+# does only work when enabling/disabling it based on the host system, not the target system, for build-dependencies.
+# We can't bring in another version of the crate under the same name since Cargo only allows one version per major
+# patch (and 2.0 is a bit old to use). We only ever need the dependency when targeting native (and when that flag isn't
+# enabled, the dependency isn't even imported), but to get it to build I had to get into the source code, find the
+# actual implementation of the function I needed, bring in the crates implementing that and use them. So, thank you so
+# much Wasmer for not having additive features :'(
+[build-dependencies]
+wasmer-compiler-cranelift = "3.1.1"
+wasmer-compiler = "3.1.1"
 
-# Use the "web" feature to support web builds with:
+# native feature configures wasmer to target desktop platform
+# web feature configures wasmer to target web/js
+# bundle_std_packages bundles the standard packages into core/std_packages, making them availible without additional
+# files
+# precompile_wasm is an addition to bundle_std_packages, which also pre-compiles the wasm files using wasmer/cranelift,
+# so startup times are reduced by ≈98%
+# default is native, bundle_std_packages and precompile_wasm
 [features]
-# `wasm-pack build --target web`
-default = ["native", "bundle_std_packages"]
+default = ["native", "bundle_std_packages", "precompile_wasm"]
 native = ["wasmer/sys-default", "wasmer-wasi/sys-default"]
 web = ["wasmer/js-default", "wasmer-wasi/js"]
 bundle_std_packages = []
+precompile_wasm = []

--- a/core/build.rs
+++ b/core/build.rs
@@ -89,13 +89,13 @@ fn precompile_wasm(name: &str, output_path: &Path, engine: &Engine) {
         .join(name)
         .join("wasm32-wasi")
         .join("release")
-        .join(name.to_string() + ".wasm");
+        .join(format!("{name}.wasm"));
 
     let out_path = output_path
         .join(name)
         .join("wasm32-wasi")
         .join("release")
-        .join(name.to_string() + "-precompiled.wir");
+        .join(format!("{name}-precompiled.wir"));
 
     // Much of this code is taken from Module::serialize and by following what it does, function
     // calls etc

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -231,6 +231,17 @@ impl Context {
         self.load_package(pkg)
     }
 
+    /// This function loads a package from the serialized format retrieved from Module::serialize.
+    /// This is only available on native when using the precompile_wasm feature.
+    #[cfg(all(feature = "native", feature = "precompile_wasm"))]
+    pub(crate) fn load_precompiled_package_from_wasm(
+        &mut self,
+        wasm_source: &[u8],
+    ) -> Result<(), CoreError> {
+        let pkg = Package::new_precompiled(wasm_source, &self.engine)?;
+        self.load_package(pkg)
+    }
+
     /// Gets the transform and package the transform is in, for a transform from a specific element
     /// to a specific output format. Returns None if no such transform exists
     pub fn get_transform_to(

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,9 +1,11 @@
-use parser::ParseError;
 use thiserror::Error;
 #[cfg(feature = "native")]
-use wasmer::CompileError;
+#[allow(unused_imports)]
+use wasmer::{CompileError, DeserializeError};
 use wasmer::{ExportError, InstantiationError, RuntimeError};
 use wasmer_wasi::{WasiError, WasiStateCreationError};
+
+use parser::ParseError;
 
 #[derive(Error, Debug)]
 pub enum CoreError {
@@ -18,6 +20,9 @@ pub enum CoreError {
     #[cfg(feature = "native")]
     #[error("Compiler error")]
     WasmerCompiler(Box<CompileError>),
+    #[cfg(all(feature = "native", feature = "precompile_wasm"))]
+    #[error("Error deserializing pre-compiled module")]
+    Deserialize(#[from] DeserializeError),
     #[error("No package for transforming node '{0}' to '{1}'.")]
     MissingTransform(String, String),
     #[error("Wasi error '{0}'.")]

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -1,12 +1,13 @@
-use crate::package::PackageImplementation::Native;
-use crate::{error::CoreError, OutputFormat};
-use serde::{Deserialize, Serialize};
 use std::{io::Read, sync::Arc};
 
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use wasmer::Engine;
 use wasmer::{Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
+
+use crate::package::PackageImplementation::Native;
+use crate::{error::CoreError, OutputFormat};
 
 /// Transform from a node into another node
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -58,6 +59,29 @@ impl PartialEq for PackageImplementation {
 }
 
 impl Package {
+    /// This function gets a package from its precompiled source. It is similar to Package::new,
+    /// but replaces the compilation step by Module::deserialize.
+    /// Safety: Notice that the precompiled source bytes
+    /// 1. Are going to be deserialized directly into Rust objects.
+    /// 2. Contains the function assembly bodies and, if intercepted,
+    ///    a malicious actor could inject code into executable
+    ///    memory.
+    #[cfg(all(feature = "native", feature = "precompile_wasm"))]
+    pub(crate) fn new_precompiled(
+        precompiled_source: &[u8],
+        engine: &Engine,
+    ) -> Result<Self, CoreError> {
+        let mut store = Store::new(engine);
+        // SAFETY: This is safe since we have compiled the sources ourself and has not been
+        // tampered with
+        let module = unsafe { Module::deserialize(&store, precompiled_source) }?;
+        let package_info = Self::read_manifest(&module, &mut store)?;
+        Ok(Package {
+            info: Arc::new(package_info),
+            implementation: PackageImplementation::Wasm(module),
+        })
+    }
+
     /// Read the binary data from a `.wasm` file and create a Package
     /// containing info about the package as well as the compiled wasm source module.
     #[cfg(feature = "native")]

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -86,7 +86,25 @@ macro_rules! define_native_packages {
 /// that the standard package cargo name is the same as the containing folder name.
 macro_rules! define_standard_package_loader {
     ($($name:expr),* $(,)?) => {
-        #[cfg(feature = "bundle_std_packages")]
+        #[cfg(all(feature = "bundle_std_packages", feature = "native", feature = "precompile_wasm"))]
+        pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError> {
+            $(
+                ctx.load_precompiled_package_from_wasm(
+                    include_bytes!(
+                        concat!(
+                            env!("OUT_DIR"),
+                            "/",
+                            $name,
+                            "/wasm32-wasi/release/",
+                            $name,
+                            "-precompiled.wir"
+                        )
+                    )
+                )?;
+            )*
+            Ok(())
+        }
+        #[cfg(all(feature = "bundle_std_packages", not(all(feature = "native", feature = "precompile_wasm"))))]
         pub fn load_standard_packages(ctx: &mut Context) -> Result<(), CoreError> {
             $(
                 ctx.load_package_from_wasm(


### PR DESCRIPTION
This PR adds the feature `precompile_wasm` to `core`, which may be used when targeting `native` and using `bundle_std_packages`. When enabled, as a part of the build script which builds the packages, another step is added which runs the packages though the Cranelift compiler (which is the one we use in Wasmer), and saves that Cranelift-compiled module instead of the actual WebAssembly file. This file, that has already been compiled, is referred to by me as "precompiled" and is using the `.wir` file format (I made that up, Wasmer Internal Representation). The main benefit this has is improving start-up time for the ModMark binary, since Wasmer doesn't have to compile the WebAssembly modules.

Due to technical limitations in Cargo and to developer wrongdoings in Wasmer, the actual implementation of the compilation step is done using `wasmer-compiler` and `wasmer-compiler-cranelift` rather than just using `wasmer`. More details are in `Cargo.toml` and `build.rs`.

With this, there are three options for distributing a binary; without bundled packages (standalone), with bundled packages, and with precompiled packages. Here are how they compare (only basic testing has been done, compiled with `--release`, running `modmark in.mdm out.html`):
| Type | File size | Time to compile `example.mdm` |
|------|---------|----------------------------------|
| Standalone | 9.9MB | n/a |
| Bundled | 29.9MB | 2.05 s |
| Precompiled | 36.8MB | 0.02 s |

Since this gives such a big time improvement, and doesn't add much to the compile time (it compiles the wasm files to wir files once, which Cranelift would have to do on startup anyways), this is enabled by default (but just like bundle_std_packages it can be disabled by `--no-default-features`). Ready for review immediately!

Resolves GH-173
