### PR TITLE
GH-127: Add flag to choose a different registry

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parser = {version= "*", path = "../parser/" }
-modmark_core = {version= "*", path = "../core/", default-features = false, features = ["native"]}
+parser = { version = "*", path = "../parser/" }
+modmark_core = { version = "*", path = "../core/", default-features = false, features = ["native"] }
 clap = { version = "4.1.4", features = ["derive"] }
 notify = "5.0.0"
 crossterm = "0.26.0"
 thiserror = "1.0.38"
-directories = "4.0.1"
+directories = "5.0.0"
 once_cell = "1.17.1"
 tokio = { version = "1.25.0", features = ["full"] }
 async-trait = "0.1.64"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.14", features = ["json"] }
 serde_json = "1.0.93"
 futures = "0.3.26"
 

--- a/cli/src/package.rs
+++ b/cli/src/package.rs
@@ -1,14 +1,16 @@
-use crate::error::CliError;
-use directories::ProjectDirs;
-use futures::future::join_all;
-use modmark_core::Resolve;
-use serde_json;
 use std::{
     env::current_dir,
     fs::{self, create_dir_all, File},
     io::copy,
     path::PathBuf,
 };
+
+use directories::ProjectDirs;
+use futures::future::join_all;
+
+use modmark_core::Resolve;
+
+use crate::error::CliError;
 
 static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()
@@ -17,132 +19,133 @@ static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync
         .unwrap()
 });
 
-pub struct PackageManager {}
+pub struct PackageManager {
+    pub(crate) registry: String,
+}
 
 impl Resolve for PackageManager {
     type Error = CliError;
     fn resolve(&self, path: &str) -> Result<Vec<u8>, Self::Error> {
-        RUNTIME.block_on(resolve_package(path))
+        RUNTIME.block_on(self.resolve_package(path))
     }
     fn resolve_all(&self, paths: &[&str]) -> Vec<Result<Vec<u8>, Self::Error>> {
-        RUNTIME.block_on(resolve_packages(paths))
+        RUNTIME.block_on(self.resolve_packages(paths))
     }
 }
 
-async fn resolve_packages(paths: &[&str]) -> Vec<Result<Vec<u8>, CliError>> {
-    let futures = paths.into_iter().map(|&path| resolve_package(path));
-    return join_all(futures).await;
-}
+impl PackageManager {
+    async fn resolve_packages(&self, paths: &[&str]) -> Vec<Result<Vec<u8>, CliError>> {
+        let futures = paths.iter().map(|&path| self.resolve_package(path));
+        join_all(futures).await
+    }
 
-async fn resolve_package(path: &str) -> Result<Vec<u8>, CliError> {
-    let splitter = path.split_once(':');
+    async fn resolve_package(&self, path: &str) -> Result<Vec<u8>, CliError> {
+        let splitter = path.split_once(':');
 
-    let Some((specifier, package_path)) = splitter else {
-           return fetch_local(path);
+        let Some((specifier, package_path)) = splitter else {
+            return self.fetch_local(path);
         };
 
-    match specifier {
-        "http" => fetch_url(&path).await,
-        "https" => fetch_url(&path).await,
-        "pkgs" => fetch_registry(package_path).await,
-        other => Err(CliError::Specifier(other.to_string())),
-    }
-}
-
-async fn fetch_url(package_path: &str) -> Result<Vec<u8>, CliError> {
-    let mut cache_path = match ProjectDirs::from("org", "modmark", "packages") {
-        Some(path) => path.cache_dir().to_path_buf(),
-        None => return Err(CliError::Cache),
-    };
-
-    let splitter = package_path.split_once(':');
-    let Some((_, mut domain_path)) = splitter else {
-        return Err(CliError::Cache)
-    };
-
-    if domain_path.len() < 2 {
-        return Err(CliError::Cache);
+        match specifier {
+            "http" => self.fetch_url(path).await,
+            "https" => self.fetch_url(path).await,
+            "pkgs" => self.fetch_registry(package_path).await,
+            other => Err(CliError::Specifier(other.to_string())),
+        }
     }
 
-    domain_path = &domain_path[2..];
+    async fn fetch_url(&self, package_path: &str) -> Result<Vec<u8>, CliError> {
+        let mut cache_path = match ProjectDirs::from("org", "modmark", "packages") {
+            Some(path) => path.cache_dir().to_path_buf(),
+            None => return Err(CliError::Cache),
+        };
 
-    cache_path.push(PathBuf::from(&domain_path));
+        let splitter = package_path.split_once(':');
+        let Some((_, mut domain_path)) = splitter else {
+            return Err(CliError::Cache)
+        };
 
-    let Some(path) = cache_path.parent() else {return Err(CliError::Cache)};
-
-    create_dir_all(path)?;
-
-    if cache_path.exists() {
-        Ok(fs::read(cache_path)?)
-    } else {
-        let response = reqwest::get(package_path).await?;
-
-        if response.status() != 200 {
-            return Err(CliError::Get(response.status().to_string()));
+        if domain_path.len() < 2 {
+            return Err(CliError::Cache);
         }
 
-        let content = response.bytes().await?;
+        domain_path = &domain_path[2..];
 
-        let mut file = File::create(&cache_path)?;
+        cache_path.push(PathBuf::from(&domain_path));
 
-        copy(&mut content.as_ref(), &mut file)?;
+        let Some(path) = cache_path.parent() else { return Err(CliError::Cache) };
 
-        Ok(fs::read(cache_path)?)
+        create_dir_all(path)?;
+
+        if cache_path.exists() {
+            Ok(fs::read(cache_path)?)
+        } else {
+            let response = reqwest::get(package_path).await?;
+
+            if response.status() != 200 {
+                return Err(CliError::Get(response.status().to_string()));
+            }
+
+            let content = response.bytes().await?;
+
+            let mut file = File::create(&cache_path)?;
+
+            copy(&mut content.as_ref(), &mut file)?;
+
+            Ok(fs::read(cache_path)?)
+        }
     }
-}
 
-async fn fetch_registry(package_name: &str) -> Result<Vec<u8>, CliError> {
-    let mut cache_path = match ProjectDirs::from("org", "modmark", "packages") {
-        Some(path) => path.cache_dir().to_path_buf(),
-        None => return Err(CliError::Cache),
-    };
-    let mut file_name = package_name.to_string();
-    file_name.push_str(".wasm");
+    async fn fetch_registry(&self, package_name: &str) -> Result<Vec<u8>, CliError> {
+        let mut cache_path = match ProjectDirs::from("org", "modmark", "packages") {
+            Some(path) => path.cache_dir().to_path_buf(),
+            None => return Err(CliError::Cache),
+        };
+        let mut file_name = package_name.to_string();
+        file_name.push_str(".wasm");
 
-    cache_path.push("pkgs");
-    cache_path.push(&file_name);
-
-    if cache_path.exists() {
-        Ok(fs::read(cache_path)?)
-    } else {
-        cache_path.pop();
-        create_dir_all(PathBuf::from(&cache_path))?;
+        cache_path.push("pkgs");
         cache_path.push(&file_name);
 
-        let registry_link = "https://raw.githubusercontent.com/modmark-org/package-registry/main/package-registry.json";
-        let registry = reqwest::get(registry_link).await?;
-        let registry_content = registry.text().await?;
+        if cache_path.exists() {
+            Ok(fs::read(cache_path)?)
+        } else {
+            cache_path.pop();
+            create_dir_all(PathBuf::from(&cache_path))?;
+            cache_path.push(&file_name);
 
-        let json_content: serde_json::Value = serde_json::from_str(&registry_content)?;
+            let registry = reqwest::get(&self.registry).await?;
+            let content: serde_json::Value = registry.json().await?;
 
-        let package_link = &json_content[&package_name]["source"];
-        let Some(package_link) = package_link.as_str() else {return Err(CliError::Registry)};
-        let package_response = reqwest::get(package_link).await?;
+            let package_link = &content[&package_name]["source"];
+            let Some(package_link) = package_link.as_str() else { return Err(CliError::Registry) };
+            let package_response = reqwest::get(package_link).await?;
 
-        if package_response.status() != 200 {
-            return Err(CliError::Get(package_response.status().to_string()));
+            if package_response.status() != 200 {
+                return Err(CliError::Get(package_response.status().to_string()));
+            }
+
+            let package_content = package_response.bytes().await?;
+
+            let mut file = File::create(&cache_path)?;
+
+            copy(&mut package_content.as_ref(), &mut file)?;
+
+            Ok(fs::read(cache_path)?)
+        }
+    }
+
+    fn fetch_local(&self, package_path: &str) -> Result<Vec<u8>, CliError> {
+        let mut package_path = package_path.to_string();
+        package_path.push_str(".wasm");
+
+        let mut local_path = current_dir()?;
+        local_path.push(PathBuf::from(&package_path));
+
+        if !local_path.exists() {
+            return Err(CliError::Local(package_path));
         }
 
-        let package_content = package_response.bytes().await?;
-
-        let mut file = File::create(&cache_path)?;
-
-        copy(&mut package_content.as_ref(), &mut file)?;
-
-        Ok(fs::read(cache_path)?)
+        Ok(fs::read(local_path)?)
     }
-}
-
-fn fetch_local(package_path: &str) -> Result<Vec<u8>, CliError> {
-    let mut package_path = package_path.to_string();
-    package_path.push_str(".wasm");
-
-    let mut local_path = current_dir()?;
-    local_path.push(PathBuf::from(&package_path));
-
-    if !local_path.exists() {
-        return Err(CliError::Local(package_path));
-    }
-
-    return Ok(fs::read(local_path)?);
 }


### PR DESCRIPTION
Resolves GH-127. This PR adds a `--registry` flag (shorthand `-r`) which lets the user specify an URL to a different registry that the user wants to use rather than the default registry we provide. This is achieved by adding a `registry: String` field to the PackageManager which holds the registry URL, and constructing the `Context` with a `PackageManager` created after the arguments has been parsed. It changes the `Lazy<...<Context<PackageManager>>>` for `OnceCell<...<Context<PackageManager>>>` since we can't just create a `Context` immediately; we need to parse the arguments before creating one. At all places where the `Context` is used, it is forcefully unwrapped since it is guaranteed to be set immediately after parsing the arguments (or, if it fails to create a `Context`, it will `panic!` as it did previously).

Additionally, this PR includes some small improvements to the PackageManager, such as using the `json` feature in `Reqwest` to include `serde_json` and being able to call `response.json()` instead of `response.text()` and parsing the json separately afterwards. It also bumps the version of `directories` to `5.0.0`.