### PR TITLE
GH-186: No longer show "required" for default empty strings

### DIFF
--- a/playground/static/main.js
+++ b/playground/static/main.js
@@ -163,7 +163,7 @@ async function loadPackageInfo() {
     const createTransformList = (transform) => {
         let args = transform.arguments.map((arg) => `<li><div>
             <strong class="name">${arg.name}</strong>
-            <span class="default">${arg.default ? 'default = \"' + arg.default + "\"" : 'required'}</span>
+            <span class="default">${arg.default !== null ? 'default = \"' + arg.default + "\"" : 'required'}</span>
             <span class="description" > ${arg.description}</span>
         </div></li> `).join("\n");
 


### PR DESCRIPTION
This PR resolves GH-186 by checking if the default value is `null` (which the empty string isn't) rather than checking if it is falsy (which the empty string is).

Before:
<img width="309" alt="Before" src="https://user-images.githubusercontent.com/25929684/227246302-98aae7e2-221b-4241-8992-ce3e43dd4d9f.png">

After:
<img width="309" alt="After" src="https://user-images.githubusercontent.com/25929684/227247100-b3e6e9b4-129e-46c7-bec9-10b2a5f4d895.png">

I have also tested this on packages which doesn't have an default argument, and it correctly shows "required" in those cases.
