### PR TITLE
Add different argument data types

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -74,8 +74,14 @@ pub enum CoreError {
     UnexpectedConfigModule,
     #[error("Invalid data type: expected {0} but got '{1}'")]
     ArgumentType(&'static str, String),
-    #[error("Invalid data type for default argument '{0}' for transform '{1}' in package '{2}', expected type '{3}' but got the value '{4}'")]
-    DefaultArgumentType(String, String, String, String, String),
+    #[error("Invalid data type for default argument '{argument_name}' for transform '{transform}' in package '{package}', expected type '{expected_type}' but got the value '{given_value}'")]
+    DefaultArgumentType {
+        argument_name: String,
+        transform: String,
+        package: String,
+        expected_type: String,
+        given_value: String,
+    },
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+
 use thiserror::Error;
 #[cfg(feature = "native")]
 #[allow(unused_imports)]
@@ -71,6 +72,10 @@ pub enum CoreError {
     UnusedConfigs(Vec<String>),
     #[error("Config modules are only allowed once at the very top of the document")]
     UnexpectedConfigModule,
+    #[error("Invalid data type: expected {0} but got '{1}'")]
+    ArgumentType(&'static str, String),
+    #[error("Invalid data type for default argument '{0}' for transform '{1}' in package '{2}', expected type '{3}' but got the value '{4}'")]
+    DefaultArgumentType(String, String, String, String, String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -74,6 +74,8 @@ pub enum CoreError {
     UnexpectedConfigModule,
     #[error("Invalid data type: expected {0} but got '{1}'")]
     ArgumentType(&'static str, String),
+    #[error("Invalid enum variant: expected one of {0:?}, but got '{1}'")]
+    EnumVariant(Vec<String>, String),
     #[error("Invalid data type for default argument '{argument_name}' for transform '{transform}' in package '{package}', expected type '{expected_type}' but got the value '{given_value}'")]
     DefaultArgumentType {
         argument_name: String,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -178,6 +178,10 @@ pub fn eval_elem<T>(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+
+    use crate::package::ArgType;
+
     use super::*;
 
     #[test]
@@ -196,32 +200,39 @@ mod tests {
                 arguments: vec![
                     ArgInfo {
                         name: "caption".to_string(),
-                        default: Some("".to_string()),
+                        default: Some(Value::String("".to_string())),
                         description: "The caption for the table".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "label".to_string(),
-                        default: Some("".to_string()),
+                        default: Some(Value::String("".to_string())),
                         description: "The label to use for the table, to be able to refer to it from the document".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "header".to_string(),
-                        default: Some("none".to_string()),
+                        default: Some(Value::String("none".to_string())),
                         description: "Style to apply to heading, none/bold".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "alignment".to_string(),
-                        default: Some("left".to_string()),
+                        default: Some(Value::String("left".to_string())),
                         description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "borders".to_string(),
-                        default: Some("all".to_string()),
+                        default: Some(Value::String("all".to_string())),
                         description: "Which borders to draw, all/horizontal/vertical/outer/none".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "delimiter".to_string(),
-                        default: Some("|".to_string()),
+                        default: Some(Value::String("|".to_string())),
                         description: "The delimiter between cells".to_string(),
+                        r#type: ArgType::String
                     }, ArgInfo {
                         name: "strip_whitespace".to_string(),
-                        default: Some("true".to_string()),
+                        default: Some(Value::String("true".to_string())),
                         description: "true/false to strip/don't strip whitespace in cells".to_string(),
+                        r#type: ArgType::String
                     },
                 ],
             }],

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -180,7 +180,7 @@ pub fn eval_elem<T>(
 mod tests {
     use serde_json::Value;
 
-    use crate::package::ArgType;
+    use crate::package::{ArgType, PrimitiveArgType};
 
     use super::*;
 
@@ -202,37 +202,37 @@ mod tests {
                         name: "caption".to_string(),
                         default: Some(Value::String("".to_string())),
                         description: "The caption for the table".to_string(),
-                        r#type: ArgType::String
+                        r#type: PrimitiveArgType::String.into()
                     }, ArgInfo {
                         name: "label".to_string(),
                         default: Some(Value::String("".to_string())),
                         description: "The label to use for the table, to be able to refer to it from the document".to_string(),
-                        r#type: ArgType::String
+                        r#type: PrimitiveArgType::String.into()
                     }, ArgInfo {
                         name: "header".to_string(),
                         default: Some(Value::String("none".to_string())),
                         description: "Style to apply to heading, none/bold".to_string(),
-                        r#type: ArgType::String
+                        r#type: ArgType::Enum(vec!["none".to_string(), "bold".to_string()])
                     }, ArgInfo {
                         name: "alignment".to_string(),
                         default: Some(Value::String("left".to_string())),
                         description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
-                        r#type: ArgType::String
+                        r#type: PrimitiveArgType::String.into()
                     }, ArgInfo {
                         name: "borders".to_string(),
                         default: Some(Value::String("all".to_string())),
-                        description: "Which borders to draw, all/horizontal/vertical/outer/none".to_string(),
-                        r#type: ArgType::String
+                        description: "Which borders to draw".to_string(),
+                        r#type: ArgType::Enum(vec!["all".to_string(), "horizontal".to_string(), "vertical".to_string(), "outer".to_string(), "none".to_string()])
                     }, ArgInfo {
                         name: "delimiter".to_string(),
                         default: Some(Value::String("|".to_string())),
                         description: "The delimiter between cells".to_string(),
-                        r#type: ArgType::String
+                        r#type: PrimitiveArgType::String.into()
                     }, ArgInfo {
                         name: "strip_whitespace".to_string(),
                         default: Some(Value::String("true".to_string())),
                         description: "true/false to strip/don't strip whitespace in cells".to_string(),
-                        r#type: ArgType::String
+                        r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()])
                     },
                 ],
             }],

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -129,10 +129,6 @@ impl ArgType {
         }
     }
 
-    pub(crate) fn is_same_type(&self, value: &ArgValue) -> bool {
-        self == &value.get_type()
-    }
-
     pub(crate) fn try_from_value(&self, value: &Value) -> Result<ArgValue, CoreError> {
         match self {
             ArgType::Enum(values) => value
@@ -273,11 +269,7 @@ impl ArgValue {
         }
     }
 
-    pub fn unwrap_enum_variant(self) -> String {
-        self.get_enum_variant().unwrap()
-    }
-
-    pub fn as_string(&self) -> Option<&str> {
+    pub fn as_str(&self) -> Option<&str> {
         if let ArgValue::String(s) = &self {
             Some(s)
         } else {
@@ -293,20 +285,12 @@ impl ArgValue {
         }
     }
 
-    pub fn unwrap_string(self) -> String {
-        self.get_string().unwrap()
-    }
-
     pub fn get_integer(self) -> Option<i64> {
         if let ArgValue::Integer(i) = self {
             Some(i)
         } else {
             None
         }
-    }
-
-    pub fn unwrap_integer(self) -> i64 {
-        self.get_integer().unwrap()
     }
 
     pub fn get_unsigned_integer(self) -> Option<u64> {
@@ -317,20 +301,12 @@ impl ArgValue {
         }
     }
 
-    pub fn unwrap_unsigned_integer(self) -> u64 {
-        self.get_unsigned_integer().unwrap()
-    }
-
     pub fn get_float(self) -> Option<f64> {
         if let ArgValue::Float(f) = self {
             Some(f)
         } else {
             None
         }
-    }
-
-    pub fn unwrap_float(self) -> f64 {
-        self.get_float().unwrap()
     }
 }
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::{io::Read, sync::Arc};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::value::Serializer as JsonSerializer;
+use serde_json::Value;
 #[cfg(feature = "native")]
 use wasmer::Engine;
 use wasmer::{Instance, Module, Store};
@@ -10,7 +13,7 @@ use crate::package::PackageImplementation::Native;
 use crate::{error::CoreError, OutputFormat};
 
 /// Transform from a node into another node
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Transform {
     pub from: String,
     pub to: Vec<OutputFormat>,
@@ -18,11 +21,13 @@ pub struct Transform {
     pub arguments: Vec<ArgInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ArgInfo {
     pub name: String,
-    pub default: Option<String>,
+    pub default: Option<Value>,
     pub description: String,
+    #[serde(default = "default_arg_type")]
+    pub r#type: ArgType,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -43,6 +48,62 @@ pub struct Package {
 pub enum PackageImplementation {
     Wasm(Module),
     Native,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ArgType {
+    #[serde(alias = "string")]
+    String,
+    #[serde(alias = "int", alias = "integer", alias = "i64")]
+    Integer,
+    #[serde(
+        rename = "Unsigned integer",
+        alias = "uint",
+        alias = "unsigned_integer",
+        alias = "u64"
+    )]
+    UnsignedInteger,
+    #[serde(alias = "float", alias = "number", alias = "f64")]
+    Float,
+}
+
+fn default_arg_type() -> ArgType {
+    ArgType::String
+}
+
+impl ArgType {
+    pub(crate) fn is_same_type(&self, value: &Value) -> bool {
+        match self {
+            ArgType::String => value.is_string(),
+            ArgType::Integer => value.is_i64(),
+            ArgType::UnsignedInteger => value.is_u64(),
+            ArgType::Float => value.is_f64(),
+        }
+    }
+
+    pub(crate) fn try_to_value(&self, value: &str) -> Result<Value, CoreError> {
+        match self {
+            ArgType::String => Ok(JsonSerializer.serialize_str(value)?),
+            ArgType::Integer => {
+                let integer = value
+                    .parse::<i64>()
+                    .map_err(|_| CoreError::ArgumentType("integer", value.to_string()))?;
+                Ok(JsonSerializer.serialize_i64(integer)?)
+            }
+            ArgType::UnsignedInteger => {
+                let integer = value
+                    .parse::<u64>()
+                    .map_err(|_| CoreError::ArgumentType("unsigned integer", value.to_string()))?;
+                Ok(JsonSerializer.serialize_u64(integer)?)
+            }
+            ArgType::Float => {
+                let float = value
+                    .parse::<f64>()
+                    .map_err(|_| CoreError::ArgumentType("float", value.to_string()))?;
+                Ok(JsonSerializer.serialize_f64(float)?)
+            }
+        }
+    }
 }
 
 /// Implements PartialEq for PackageImplementation in a way where two
@@ -137,16 +198,33 @@ impl Package {
         manifest.call(store, &[])?;
 
         // Read package info from stdin
-        let manifest = {
+        let manifest: PackageInfo = {
             let mut buffer = String::new();
             output.read_to_string(&mut buffer)?;
             serde_json::from_str(&buffer).map_err(|error| CoreError::DeserializationError {
                 string: buffer.clone(),
                 error,
             })
-        };
+        }?;
 
-        manifest
+        // Ensure all default values have the correct type
+        for transform in &manifest.transforms {
+            for argument in &transform.arguments {
+                if let Some(default) = argument.default.as_ref() {
+                    if !argument.r#type.is_same_type(default) {
+                        return Err(CoreError::DefaultArgumentType(
+                            argument.name.to_string(),
+                            transform.from.to_string(),
+                            manifest.name.to_string(),
+                            serde_json::to_string(&argument.r#type).unwrap(),
+                            default.clone().to_rust_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(manifest)
     }
 
     pub fn new_native(info: PackageInfo) -> Result<Self, CoreError> {
@@ -154,5 +232,30 @@ impl Package {
             info: Arc::new(info),
             implementation: Native,
         })
+    }
+}
+
+pub(crate) trait ValueExt {
+    fn to_rust_string(self) -> String;
+}
+
+impl ValueExt for Value {
+    fn to_rust_string(self) -> String {
+        match self {
+            Value::String(s) => s,
+            x => x.to_string(),
+        }
+    }
+}
+
+pub(crate) trait HashMapExt {
+    fn map_map(self) -> HashMap<String, String>;
+}
+
+impl HashMapExt for HashMap<String, Value> {
+    fn map_map(mut self) -> HashMap<String, String> {
+        self.drain()
+            .map(|(k, v)| (k, ValueExt::to_rust_string(v)))
+            .collect()
     }
 }

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use parser::ModuleArguments;
 
 use crate::context::Issue;
-use crate::package::{ArgType, ArgValue};
+use crate::package::{ArgValue, PrimitiveArgType};
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
 use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
 
@@ -36,19 +36,19 @@ define_native_packages! {
                 name: "source".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The source module/parent responsible for the warning".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
             ArgInfo {
                 name: "target".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The target output format when the warning was generated".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
             ArgInfo {
                 name: "input".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The input given to the module when it failed".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
         ] => native_warn,
         "error", vec![
@@ -56,19 +56,19 @@ define_native_packages! {
                 name: "source".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The source module/parent responsible for the error".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
             ArgInfo {
                 name: "target".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The target output format when the error was generated".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
             ArgInfo {
                 name: "input".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
                 description: "The input given to the module when it failed".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             },
         ] => native_err
     };
@@ -82,7 +82,7 @@ define_native_packages! {
                 name: "key".to_string(),
                 default: None,
                 description: "The key to set".to_string(),
-                r#type: ArgType::String
+                r#type: PrimitiveArgType::String.into()
             }
         ] => native_set_env,
     };

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -154,12 +154,12 @@ pub fn native_warn<T>(
 ) -> Result<Either<Element, String>, CoreError> {
     // Push the issue to warnings
     ctx.state.warnings.push(Issue {
-        source: args.remove("source").unwrap().unwrap_string(),
-        target: args.remove("target").unwrap().unwrap_string(),
+        source: args.remove("source").unwrap().get_string().unwrap(),
+        target: args.remove("target").unwrap().get_string().unwrap(),
         description: body.to_string(),
         input: args
             .remove("input")
-            .map(|v| v.unwrap_string())
+            .map(|v| v.get_string().unwrap())
             .and_then(|s| (s != "<unknown>").then_some(s)),
     });
 
@@ -174,11 +174,11 @@ pub fn native_err<T>(
     inline: bool,
     output_format: &OutputFormat,
 ) -> Result<Either<Element, String>, CoreError> {
-    let source = args.get("source").unwrap().clone().unwrap_string();
-    let target = args.get("target").unwrap().clone().unwrap_string();
+    let source = args.get("source").unwrap().clone().get_string().unwrap();
+    let target = args.get("target").unwrap().clone().get_string().unwrap();
     let input = args
         .get("input")
-        .map(|v| v.clone().unwrap_string())
+        .map(|v| v.clone().get_string().unwrap())
         .and_then(|s| (s != "<unknown>").then_some(s));
 
     // Push the issue to errors

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -51,7 +51,7 @@ macro_rules! define_native_packages {
             package_name: &str,
             node_name: &str, // name of module or parent
             element: &Element,
-            args: HashMap<String, Value>,
+            args: HashMap<String, ArgValue>,
             output_format: &OutputFormat
         ) -> Result<Either<Element, String>, CoreError> {
             match package_name {

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -51,7 +51,7 @@ macro_rules! define_native_packages {
             package_name: &str,
             node_name: &str, // name of module or parent
             element: &Element,
-            args: HashMap<String, String>,
+            args: HashMap<String, Value>,
             output_format: &OutputFormat
         ) -> Result<Either<Element, String>, CoreError> {
             match package_name {

--- a/packages/code/src/main.rs
+++ b/packages/code/src/main.rs
@@ -34,8 +34,8 @@ fn manifest() {
                     {"name": "lang", "default": "txt", "description":
                         "The language to be highlighted. For available languages, see \
                         https://github.com/sublimehq/Packages"},
-                    {"name": "font_size", "default": "12", "description": "The size of the font"},
-                    {"name": "tab_size", "default": "4", "description": "The size tabs will be adjusted to"},
+                    {"name": "font_size", "default": 12, "description": "The size of the font", "type": "uint"},
+                    {"name": "tab_size", "default": 4, "description": "The size tabs will be adjusted to", "type": "uint"},
                     {"name": "theme", "default": "mocha", "description":
                         "Theme of the code section. For available themes, see \
                         https://docs.rs/syntect/latest/syntect/highlighting/struct.ThemeSet.html#method.load_defaults"},
@@ -77,8 +77,8 @@ fn transform_code(to: &str) {
 
             let code = input["data"].as_str().unwrap();
             let lang = get_arg!(input, "lang");
-            let font_size = get_arg!(input, "font_size");
-            let tab_size = get_arg!(input, "tab_size");
+            let font_size = input["arguments"]["font_size"].as_u64().unwrap();
+            let tab_size = input["arguments"]["tab_size"].as_u64().unwrap();
             let theme = get_arg!(input, "theme");
             let bg = get_arg!(input, "bg");
 
@@ -102,8 +102,8 @@ fn transform_code(to: &str) {
 
 fn get_style(
     inline: &bool,
-    font_size: &String,
-    tab_size: &String,
+    font_size: u64,
+    tab_size: u64,
     bg: &String,
     default_bg: Option<Color>,
 ) -> String {

--- a/packages/code/tests/test_defaults.json
+++ b/packages/code/tests/test_defaults.json
@@ -2,8 +2,8 @@
     "name": "code",
     "arguments": {
         "lang": "txt",
-        "font_size": "12",
-        "tab_size": "4",
+        "font_size": 12,
+        "tab_size": 4,
         "theme": "mocha",
         "bg": "default"
     },

--- a/packages/code/tests/test_inline.json
+++ b/packages/code/tests/test_inline.json
@@ -2,8 +2,8 @@
     "name": "code",
     "arguments": {
         "lang": "rs",
-        "font_size": "12",
-        "tab_size": "4",
+        "font_size": 12,
+        "tab_size": 4,
         "theme": "mocha",
         "bg": "default"
     },

--- a/packages/code/tests/test_java.json
+++ b/packages/code/tests/test_java.json
@@ -2,8 +2,8 @@
     "name": "code",
     "arguments": {
         "lang": "java",
-        "font_size": "16",
-        "tab_size": "4",
+        "font_size": 16,
+        "tab_size": 4,
         "theme": "mocha",
         "bg": "06080A"
     },

--- a/packages/layout/src/main.rs
+++ b/packages/layout/src/main.rs
@@ -52,7 +52,7 @@ fn manifest() {
                             Note that content that is too wide will \
                             be cropped if used without wrapping."
                         },
-                        {"name": "wrap", "default": "false", "description": "true/false - Decides if items will wrap around to new rows."},
+                        {"name": "wrap", "default": "false", "type": ["true", "false"], "description": "Decides if items will wrap around to new rows."},
                     ]
                 },
                 {
@@ -71,7 +71,7 @@ fn manifest() {
                             Note that content that is too wide will \
                             be cropped if used without wrapping."
                         },
-                        {"name": "wrap", "default": "false", "description": "true/false - Decides if items will wrap around to new rows."},
+                        {"name": "wrap", "default": "false", "type": ["true", "false"], "description": "Decides if items will wrap around to new rows."},
                     ]
                 }
             ]

--- a/packages/list/src/lib.rs
+++ b/packages/list/src/lib.rs
@@ -182,7 +182,7 @@ impl List {
         json!(json_vec).to_string()
     }
 
-    pub fn from_str(s: &str, indent: u32) -> Result<Self, NoListError> {
+    pub fn from_str(s: &str, indent: u64) -> Result<Self, NoListError> {
         // If the first nonempty line is not a list item, return err
         s.lines()
             .find(|&l| !l.is_empty())

--- a/packages/list/src/main.rs
+++ b/packages/list/src/main.rs
@@ -29,7 +29,12 @@ fn manifest() {
                     "from": "list",
                     "to": ["html"],
                     "arguments": [
-                        {"name": "indent", "default": "4", "description": "Number of spaces needed for each level of indent when writing the list."}
+                        {
+                            "name": "indent",
+                            "default": 4,
+                            "description": "Number of spaces needed for each level of indent when writing the list.",
+                            "type": "unsigned_integer"
+                        }
                     ],
                 },
             ]
@@ -58,11 +63,7 @@ fn transform_list(to: &str) {
             };
 
             let body = input["data"].as_str().unwrap();
-            let indent = input["arguments"]["indent"]
-                .as_str()
-                .unwrap_or("4")
-                .parse()
-                .unwrap_or(4);
+            let indent = input["arguments"]["indent"].as_u64().unwrap_or(4);
 
             if let Ok(list) = List::from_str(body, indent) {
                 print!("{}", list.to_html())

--- a/packages/math/src/main.rs
+++ b/packages/math/src/main.rs
@@ -41,6 +41,7 @@ fn manifest() {
                         {
                             "name": "import",
                             "default": "false",
+                            "type": ["true", "false"],
                             "description": r#"If set to "true", a Mathjax import will be added to HTML outputs for maximum compatibility"#
                         }
                     ],

--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -50,11 +50,11 @@ fn manifest() {
                     "arguments": [
                         {"name": "caption", "default": "", "description": "The caption for the table"},
                         {"name": "label", "default":"", "description": "The label to use for the table, to be able to refer to it from the document"},
-                        {"name": "header", "default": "none", "description": "Style to apply to heading, none/bold"},
+                        {"name": "header", "default": "none", "type": ["none", "bold"], "description": "Style to apply to heading, none/bold"},
                         {"name": "alignment", "default": "left", "description": "Horizontal alignment in cells, left/center/right or l/c/r for each column"},
-                        {"name": "borders", "default": "all", "description": "Which borders to draw, all/horizontal/vertical/outer/none"},
+                        {"name": "borders", "default": "all", "type": ["all", "horizontal", "vertical", "outer", "none"], "description": "Which borders to draw"},
                         {"name": "delimiter", "default": "|", "description": "The delimiter between cells"},
-                        {"name": "strip_whitespace", "default": "true", "description": "true/false to strip/don't strip whitespace in cells"}
+                        {"name": "strip_whitespace", "default": "true", "type": ["true", "false"], "description": "true/false to strip/don't strip whitespace in cells"}
                     ],
                 }
             ]

--- a/playground/static/main.js
+++ b/playground/static/main.js
@@ -24,7 +24,7 @@ async function compilerAction(action) {
         compiler_callback = res;
         compiler_failure = rej;
     });
-    compiler.postMessage({ seq: ++seq, ...action });
+    compiler.postMessage({seq: ++seq, ...action});
     return promise;
 }
 
@@ -158,12 +158,20 @@ function toggleView() {
 }
 
 async function loadPackageInfo() {
-    const info = JSON.parse(await compilerAction({ type: "package_info" }));
+    const info = JSON.parse(await compilerAction({type: "package_info"}));
+
+    const type_str = (type) => {
+        if (Array.isArray(type)) {
+            return type.join("/");
+        } else {
+            return type;
+        }
+    }
 
     const createTransformList = (transform) => {
         let args = transform.arguments.map((arg) => `<li><div>
             <strong class="name">${arg.name}</strong>
-            <span class="default">${arg.type}, ${arg.default !== null ? 'default = ' + JSON.stringify(arg.default) : 'required'}</span>
+            <span class="default">${type_str(arg.type)}, ${arg.default !== null ? 'default = ' + JSON.stringify(arg.default) : 'required'}</span>
             <span class="description" > ${arg.description}</span>
         </div></li> `).join("\n");
 
@@ -175,7 +183,7 @@ async function loadPackageInfo() {
         </div> `
     };
 
-    const createElem = ({ name, version, description, transforms }) => {
+    const createElem = ({name, version, description, transforms}) => {
         let expanded = false;
 
         let container = document.createElement("div");
@@ -241,7 +249,7 @@ async function updateOutput(input) {
                 overleafButton.style.display = "none";
 
                 debugEditor.session.setMode("");
-                debugEditor.setValue(await compilerAction({ type: "ast", source: input }));
+                debugEditor.setValue(await compilerAction({type: "ast", source: input}));
                 debugEditor.getSession().selection.clearSelection()
                 break;
             case "ast-debug":
@@ -251,7 +259,7 @@ async function updateOutput(input) {
                 overleafButton.style.display = "none";
 
                 debugEditor.session.setMode("");
-                debugEditor.setValue(await compilerAction({ type: "ast_debug", source: input }));
+                debugEditor.setValue(await compilerAction({type: "ast_debug", source: input}));
                 debugEditor.getSession().selection.clearSelection();
                 break;
             case "json-output":
@@ -261,11 +269,15 @@ async function updateOutput(input) {
                 overleafButton.style.display = "none";
 
                 debugEditor.session.setMode("ace/mode/json");
-                debugEditor.setValue(await compilerAction({ type: "json_output", source: input }));
+                debugEditor.setValue(await compilerAction({type: "json_output", source: input}));
                 debugEditor.getSession().selection.clearSelection();
                 break;
             case "transpile-other": {
-                let { content, warnings, errors } = JSON.parse(await compilerAction({ type: "transpile", source: input, format: formatInput.value }));
+                let {content, warnings, errors} = JSON.parse(await compilerAction({
+                    type: "transpile",
+                    source: input,
+                    format: formatInput.value
+                }));
                 errors.forEach(addError);
                 warnings.forEach(addWarning);
 
@@ -275,14 +287,17 @@ async function updateOutput(input) {
                 render.style.display = "none";
 
 
-
                 debugEditor.session.setMode("");
                 debugEditor.setValue(content);
                 debugEditor.getSession().selection.clearSelection();
             }
                 break;
             case "latex":
-                let { content, warnings, errors } = JSON.parse(await compilerAction({ type: "transpile", source: input, format: "latex" }));
+                let {content, warnings, errors} = JSON.parse(await compilerAction({
+                    type: "transpile",
+                    source: input,
+                    format: "latex"
+                }));
                 errors.forEach(addError);
                 warnings.forEach(addWarning);
 
@@ -290,7 +305,7 @@ async function updateOutput(input) {
                 debugEditor.container.style.display = "block";
                 renderIframe.style.display = "none";
                 render.style.display = "none";
-                
+
                 debugEditor.session.setMode("ace/mode/latex");
                 debugEditor.setValue(content);
                 debugEditor.getSession().selection.clearSelection();
@@ -299,7 +314,11 @@ async function updateOutput(input) {
             case "render-iframe":
             case "render": {
                 let type = selector.value == "render" ? "transpile_no_document" : "transpile";
-                let { content, warnings, errors } = JSON.parse(await compilerAction({ type, source: input, format: "html" }));
+                let {content, warnings, errors} = JSON.parse(await compilerAction({
+                    type,
+                    source: input,
+                    format: "html"
+                }));
                 errors.forEach(addError);
                 warnings.forEach(addWarning);
 

--- a/playground/static/main.js
+++ b/playground/static/main.js
@@ -163,7 +163,7 @@ async function loadPackageInfo() {
     const createTransformList = (transform) => {
         let args = transform.arguments.map((arg) => `<li><div>
             <strong class="name">${arg.name}</strong>
-            <span class="default">${arg.default !== null ? 'default = \"' + arg.default + "\"" : 'required'}</span>
+            <span class="default">${arg.type}, ${arg.default !== null ? 'default = ' + JSON.stringify(arg.default) : 'required'}</span>
             <span class="description" > ${arg.description}</span>
         </div></li> `).join("\n");
 


### PR DESCRIPTION
This PR resolves GH-79 by adding a `type` field to `ArgInfo` and changing `default` from being `Option<String>` to `Option<Value>` (note that `type` is written `r#type` in Rust since `type` is a reserved keyword). It is an enum which can be deserialised from one of the following strings:

* `Integer`/`int`/`integer`/`i64` for the `i64` Rust data type, serialised as a Json Number
* `Unsigned integer`/`uint`/`unsigned_integer`/`u64` for the `u64` Rust data type, serialised as a Json number
* `Float`/`float`/`number`/`f64` for the `f64` Rust data type, serialised as a Json number
* `String`/`string` for the `String` Rust data type, serialised as a Json string. If the field is absent, this is the default value.

When reading an argument that is of a specific type, the string input is parsed into the corresponding Rust data type and is then serialised into the appropriate Json data type. The argument type is placed into the optional field `type` in the argument declaration in the manifest.

Note that the `Element::Parent` and `Element::Module` data types still internally houses a `HashMap<String, String>` for the arguments, since the argument types isn't known at that time, and is only turned into `HashMap<String, Value>` at the time of collecting the arguments, and thus a JsonEntry contains the "correct" data types while Element doesn't. This isn't a problem in most cases, however there are a few cases where an JsonEntry needs to be turned back into an Element which has arguments, and in that case the argument types are lost. Without making an additional IR, I think this is unavoidable. One extension adding `HashMap<String, Value>::map_map() → HashMap<String, String>` and one extension adding `Value::to_rust_string() → String` is added, which turns `Value`s to `String`s without encasing strings in quotes, which makes the resulting string deserialise to the correct data type.

In addition to this, this PR changes the standard packages to declare fields as `uint`s when appropriate, as well as adding the data type to the playground.