### PR TITLE
GH-118: Delegate text-only math tags to math module

### DIFF
--- a/packages/html/tests/test_math.json
+++ b/packages/html/tests/test_math.json
@@ -1,0 +1,21 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+        {
+            "name": "__text",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        }
+    ],
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "math",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        }
+    ]
+}

--- a/packages/html/tests/test_math_empty.json
+++ b/packages/html/tests/test_math_empty.json
@@ -1,0 +1,9 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+    ],
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+    ]
+}

--- a/packages/html/tests/test_math_interspersed.json
+++ b/packages/html/tests/test_math_interspersed.json
@@ -1,0 +1,33 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+        {
+            "name": "__text",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        },
+        {
+            "name": "code",
+            "data": "abc",
+            "arguments": {},
+            "inline": true
+        },
+        {
+            "name": "__text",
+            "data": " y^2",
+            "arguments": {},
+            "inline": true
+        }
+    ],
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "math",
+            "data": "x^2 y^2",
+            "arguments": {},
+            "inline": true
+        }
+    ]
+}

--- a/packages/latex/tests/test_math.json
+++ b/packages/latex/tests/test_math.json
@@ -1,0 +1,21 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+        {
+            "name": "__text",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        }
+    ],
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "name": "math",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        }
+    ]
+}

--- a/packages/latex/tests/test_math_empty.json
+++ b/packages/latex/tests/test_math_empty.json
@@ -1,0 +1,9 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+    ],
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+    ]
+}

--- a/packages/latex/tests/test_math_interspersed.json
+++ b/packages/latex/tests/test_math_interspersed.json
@@ -1,0 +1,33 @@
+{
+    "name": "__math",
+    "arguments": {},
+    "children": [
+        {
+            "name": "__text",
+            "data": "x^2",
+            "arguments": {},
+            "inline": true
+        },
+        {
+            "name": "code",
+            "data": "abc",
+            "arguments": {},
+            "inline": true
+        },
+        {
+            "name": "__text",
+            "data": " y^2",
+            "arguments": {},
+            "inline": true
+        }
+    ],
+    "__test_transform_to": "latex",
+    "__test_expected_result": [
+        {
+            "name": "math",
+            "data": "x^2 y^2",
+            "arguments": {},
+            "inline": true
+        }
+    ]
+}


### PR DESCRIPTION
This PR resolves GH-118 by adding support for math tags `$$` containing text only, by taking the text and making a `math` module containing the very same text. More detailed explanation on why to delegate it to the `math` module rather than implementing support for it in the language packages directly can be found in the [original issue](https://github.com/modmark-org/modmark/issues/118). The support is added to both the HTML and LaTeX language packages. Even though it could in theory be implemented in the `math` package, I think it makes more sense to add them to the language packages which should be responsible for handling all tags.

All text from within the math tags gets concatenated, and that is the input to the `math` module. Since the tags are non-recursive, only text and modules may occur within, and if a module appears within an warning is generated. I think this is ready for review as-is! It also includes 6 tests, testing "normal operation", math tags with modules inside, and empty math tags, for both of the languages.