### PR TITLE
GH-190: Make serialize-errors into runtime errors instead of failing the compilation

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -72,6 +72,8 @@ pub enum CoreError {
     UnusedConfigs(Vec<String>),
     #[error("Config modules are only allowed once at the very top of the document")]
     UnexpectedConfigModule,
+    #[error("Error serializing '{0}': {1}")]
+    SerializeElement(String, Box<CoreError>),
     #[error("Invalid data type: expected {0} but got '{1}'")]
     ArgumentType(&'static str, String),
     #[error("Invalid enum variant: expected one of {0:?}, but got '{1}'")]


### PR DESCRIPTION
Resolves GH-190.

Previously, if someone entered the wrong argument type in the playground, it would look something like this:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/25929684/227920041-5de3c378-c52f-45a1-b8f7-b5e73b6cfdd3.png">

This PR changes that instance to look something like this:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/25929684/227920119-f4fea301-507d-414c-bad3-891e86f82acd.png">