### PR TITLE
GH-198: Ignore runtime errors where exit code was 0

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -602,13 +602,17 @@ impl<T> Context<T> {
         let fn_res = main_fn.call(&mut store, &[]);
 
         if let Err(e) = fn_res {
-            // An error occurred when executing Wasm module =>
-            // it probably crashed, so just insert an error node
-            return Ok(Left(create_issue(
-                true,
-                format!("Wasm module crash: {e}"),
-                &input_data,
-            )));
+            // TODO: See if this can be done without string comparison
+            let error_msg = e.to_string();
+            if !error_msg.contains("WASI exited with code: 0") {
+                // An error occurred when executing Wasm module =>
+                // it probably crashed, so just insert an error node
+                return Ok(Left(create_issue(
+                    true,
+                    format!("Wasm module crash: {error_msg}"),
+                    &input_data,
+                )));
+            }
         }
 
         // Read the output of the package from stdout


### PR DESCRIPTION
RuntimeError did not seem to be typed in any meaningful way so unfortunately I think the best way to do this might just be a string comparison.

Resolves #198 