### PR TITLE
GH-114: Rewrite list to recursive struct and add support for latex

### DIFF
--- a/packages/list/src/main.rs
+++ b/packages/list/src/main.rs
@@ -4,6 +4,8 @@ use std::io::{self, Read};
 use list::List;
 use serde_json::{json, Value};
 
+// FIXME: latex requires enumitem package
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     let action = &args[0];
@@ -27,7 +29,7 @@ fn manifest() {
             "transforms": [
                 {
                     "from": "list",
-                    "to": ["html"],
+                    "to": ["html", "latex"],
                     "arguments": [
                         {
                             "name": "indent",
@@ -67,6 +69,26 @@ fn transform_list(to: &str) {
 
             if let Ok(list) = List::from_str(body, indent) {
                 print!("{}", list.to_html())
+            } else {
+                eprintln!("Module block does not start with a list")
+            }
+        }
+        "latex" => {
+            let input: Value = {
+                let mut buffer = String::new();
+                io::stdin().read_to_string(&mut buffer).unwrap();
+                serde_json::from_str(&buffer).unwrap()
+            };
+
+            let body = input["data"].as_str().unwrap();
+            let indent = input["arguments"]["indent"]
+                .as_str()
+                .unwrap_or("4")
+                .parse()
+                .unwrap_or(4);
+
+            if let Ok(list) = List::from_str(body, indent) {
+                print!("{}", list.to_latex())
             } else {
                 eprintln!("Module block does not start with a list")
             }

--- a/packages/list/tests/test_basic_list_html.json
+++ b/packages/list/tests/test_basic_list_html.json
@@ -6,14 +6,6 @@
   "__test_transform_to": "html",
   "__test_expected_result": [
     {
-      "data": "<ol type=\"i\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
       "data": "<ol type=\"i\" start=\"3\">",
       "name": "raw"
     },
@@ -23,18 +15,10 @@
     },
     {
       "data": "awefawef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ul>",
       "name": "raw"
     },
     {
@@ -43,18 +27,10 @@
     },
     {
       "data": "qwer",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "</ul>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"I\" start=\"4\">",
       "name": "raw"
     },
     {
@@ -63,18 +39,10 @@
     },
     {
       "data": "awe",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
       "name": "raw"
     },
     {
@@ -87,18 +55,10 @@
     },
     {
       "data": "wef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"7\">",
       "name": "raw"
     },
     {
@@ -107,7 +67,7 @@
     },
     {
       "data": "awef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
@@ -115,14 +75,6 @@
     },
     {
       "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"a\" start=\"5\">",
       "name": "raw"
     },
     {
@@ -131,26 +83,18 @@
     },
     {
       "data": "awfe",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
       "name": "raw"
     },
     {
-      "data": "<ol type=\"a\" start=\"1\">",
+      "data": "<ul>",
       "name": "raw"
     },
     {
-      "data": "<ol type=\"a\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"a\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
+      "data": "<ol type=\"1\" start=\"1\">",
       "name": "raw"
     },
     {
@@ -163,7 +107,7 @@
     },
     {
       "data": "awef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
@@ -171,14 +115,6 @@
     },
     {
       "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"1\">",
       "name": "raw"
     },
     {
@@ -187,18 +123,10 @@
     },
     {
       "data": "qwef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
       "name": "raw"
     },
     {
@@ -211,7 +139,7 @@
     },
     {
       "data": "wqfe",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
@@ -219,14 +147,6 @@
     },
     {
       "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"2\">",
       "name": "raw"
     },
     {
@@ -235,18 +155,10 @@
     },
     {
       "data": "qwef",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "<ul>",
-      "name": "raw"
-    },
-    {
-      "data": "</ul>",
       "name": "raw"
     },
     {
@@ -259,7 +171,19 @@
     },
     {
       "data": "qwef",
-      "name": "block_content"
+      "name": "raw"
+    },
+    {
+      "data": "</li>",
+      "name": "raw"
+    },
+    {
+      "data": "<li>",
+      "name": "raw"
+    },
+    {
+      "data": "qwef",
+      "name": "raw"
     },
     {
       "data": "</li>",
@@ -270,39 +194,11 @@
       "name": "raw"
     },
     {
-      "data": "<ol type=\"1\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "<li>",
-      "name": "raw"
-    },
-    {
-      "data": "qwef",
-      "name": "block_content"
-    },
-    {
-      "data": "</li>",
-      "name": "raw"
-    },
-    {
       "data": "</ol>",
       "name": "raw"
     },
     {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"1\" start=\"6\">",
+      "data": "</ul>",
       "name": "raw"
     },
     {
@@ -311,18 +207,10 @@
     },
     {
       "data": "qwfe",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",
-      "name": "raw"
-    },
-    {
-      "data": "<ol type=\"a\" start=\"1\">",
-      "name": "raw"
-    },
-    {
-      "data": "</ol>",
       "name": "raw"
     },
     {
@@ -335,7 +223,7 @@
     },
     {
       "data": "qwre",
-      "name": "block_content"
+      "name": "raw"
     },
     {
       "data": "</li>",


### PR DESCRIPTION
New and improved list package now with LaTeX support. A bit more of an extensive rewrite than I had expected but the code feels a lot better now. The type of the first item in the list is now used for the entire list.

- Resolves: GH-114
