### PR TITLE
GH-204: Add description for native packages and modules

### DIFF
--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 
 use either::Either::{self, Left, Right};
 use serde_json::Value;
-
-use parser::ModuleArguments;
 #[cfg(feature = "native")]
 use wasmer::Engine;
+
+use parser::ModuleArguments;
 
 use crate::context::Issue;
 use crate::package::{ArgValue, PrimitiveArgType};
@@ -33,9 +33,14 @@ define_standard_package_loader! {
 // one being a function returning the manifests for those packages, and the other
 // being the entry point to run these packages.
 define_native_packages! {
-    "core" => {
-        "raw", vec![] => native_raw,
-        "warning", vec![
+    "core",
+    "Provides core functionality such as raw output, errors and warnings" => {
+        "raw",
+        "Outputs the body text as-is into the output document",
+        vec![] => native_raw,
+        "warning",
+        "Adds a compilation warning to the list of all warnings that have occurred during compilation",
+        vec![
             ArgInfo {
                 name: "source".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
@@ -55,7 +60,9 @@ define_native_packages! {
                 r#type: PrimitiveArgType::String.into()
             },
         ] => native_warn,
-        "error", vec![
+        "error",
+        "Adds a compilation error to the list of all errors that have occurred during compilation",
+        vec![
             ArgInfo {
                 name: "source".to_string(),
                 default: Some(Value::String("<unknown>".to_string())),
@@ -76,12 +83,20 @@ define_native_packages! {
             },
         ] => native_err
     };
-    "reparse" => {
-        "inline_content", vec![] => native_inline_content,
-        "block_content", vec![] => native_block_content,
+    "reparse",
+    "Provides an interface to the built-in ModMark parser" => {
+        "inline_content",
+        "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
+        vec![] => native_inline_content,
+        "block_content",
+        "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
+        vec![] => native_block_content,
     };
-    "env" => {
-        "set-env", vec![
+    "env",
+    "[Temporary] Provides access to setting environment variables" => {
+        "set-env",
+        "Sets an environment variable",
+        vec![
             ArgInfo {
                 name: "key".to_string(),
                 default: None,

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -23,20 +23,20 @@
 /// }
 /// ```
 macro_rules! define_native_packages {
-    ($($name:expr => { $($transform:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
+    ($($name:expr, $desc:expr => { $($transform:expr, $tdesc:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
             vec![
                 $(
                     (PackageInfo {
                         name: $name.to_string(),
                         version: "1".to_string(),
-                        description: "A native package supporting native modules".to_string(),
+                        description: $desc.to_string(),
                         transforms: vec![
                             $(
                                 (Transform {
                                     from: $transform.to_string(),
                                     to: vec![],
-                                    description: None,
+                                    description: Some($tdesc.to_string()),
                                     arguments: $arg_info,
                                 }),
                             )*


### PR DESCRIPTION
Resolves GH-204.

See GH-204. Before the change, the native packages looked like this:
<img width="1170" alt="Screenshot 2023-04-03 at 15 14 32" src="https://user-images.githubusercontent.com/25929684/229520401-0bd4302f-8bed-4a35-aca2-6b4badb7d43a.png">

This PR changes them to look like this:
<img width="1170" alt="Screenshot 2023-04-03 at 15 16 44" src="https://user-images.githubusercontent.com/25929684/229520976-ac80e65e-6510-455d-b0ea-be3f6a97585b.png">

You can see this change in the preview playground of this PR.

It changes the structure of the macro so that instead of writing this to define reparse with inline_content and block_content transforms:
```rs
    "reparse" => {
        "inline_content",
        vec![] => native_inline_content,
        "block_content",
        vec![] => native_block_content,
    };
```

you would write this:
```rs
    "reparse",
    "Provides an interface to the built-in ModMark parser" => {
        "inline_content",
        "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
        vec![] => native_inline_content,
        "block_content",
        "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
        vec![] => native_block_content,
    };
```