### PR TITLE
Improve files package

### DIFF
--- a/packages/files/src/main.rs
+++ b/packages/files/src/main.rs
@@ -97,21 +97,12 @@ fn transform_text(input: Value, to: &str) {
     match to {
         "html" | "latex" => {
             let path = input["data"].as_str().unwrap().trim();
-            match fs::read_to_string(path) {
-                Ok(contents) => {
-                    let data = if to == "html" {
-                        format!("<p>{contents}</p>")
-                    } else {
-                        contents
-                    };
-                    let json = json!({"name": "raw", "data": data}).to_string();
-                    print!("[{json}]");
-                }
-                _ => {
-                    let json = json!({"name": "raw", "data": ""}).to_string();
-                    print!("[{json}]");
-                    eprintln!("File could not be accessed at {path}")
-                }
+            if let Ok(contents) = fs::read_to_string(path) {
+                let text = json!([{"name": "__text", "data": contents}]);
+                let json = json!({"name": "__paragraph", "arguments": {}, "children": text}).to_string();
+                print!("[{json}]");
+            } else {
+                eprintln!("File could not be accessed at {path}");
             }
         }
         other => {
@@ -225,15 +216,10 @@ fn transform_image(input: Value, to: &str) {
 // Because everything inside is reparsed, we do not match against output format
 fn transform_include(input: Value) {
     let path = input["data"].as_str().unwrap().trim();
-    match fs::read_to_string(path) {
-        Ok(contents) => {
-            let json = json!({"name": "block_content", "data": contents}).to_string();
-            print!("[{json}]");
-        }
-        _ => {
-            let json = json!({"name": "raw", "data": ""}).to_string();
-            print!("[{json}]");
-            eprintln!("File could not be accessed at {path}")
-        }
+    if let Ok(contents) = fs::read_to_string(path) {
+        let json = json!({"name": "block_content", "data": contents}).to_string();
+        print!("[{json}]");
+    } else {
+        eprintln!("File could not be accessed at {path}");
     }
 }

--- a/packages/latex/src/main.rs
+++ b/packages/latex/src/main.rs
@@ -177,7 +177,7 @@ fn transform_math(node: Value) -> String {
 fn transform_document(doc: Value) -> String {
     let mut result = String::new();
     result.push('[');
-    write!(result, r#"{{"name": "raw", "data": "\\documentclass{{article}}\n\n\\usepackage[normalem]{{ulem}}\n\\usepackage{{enumitem}}\n\\usepackage[hidelinks]{{hyperref}}\n\\usepackage{{float}}\n\n\\begin{{document}}\n"}},"#,).unwrap();
+    write!(result, r#"{{"name": "raw", "data": "\\documentclass{{article}}\n\n\\usepackage[normalem]{{ulem}}\n\\usepackage{{enumitem}}\n\\usepackage[hidelinks]{{hyperref}}\n\\usepackage{{float}}\n\\usepackage{{graphicx}}\n\n\\begin{{document}}\n"}},"#,).unwrap();
     if let Value::Array(children) = &doc["children"] {
         for child in children {
             result.push_str(&serde_json::to_string(child).unwrap());

--- a/packages/latex/tests/test_document.json
+++ b/packages/latex/tests/test_document.json
@@ -24,7 +24,7 @@
   "__test_transform_to": "latex",
   "__test_expected_result": [
     {
-      "data": "\\documentclass{article}\n\n\\usepackage[normalem]{ulem}\n\\usepackage{enumitem}\n\\usepackage[hidelinks]{hyperref}\n\\usepackage{float}\n\n\\begin{document}\n",
+      "data": "\\documentclass{article}\n\n\\usepackage[normalem]{ulem}\n\\usepackage{enumitem}\n\\usepackage[hidelinks]{hyperref}\n\\usepackage{float}\n\\usepackage{graphicx}\n\n\\begin{document}\n",
       "name": "raw"
     },
     {


### PR DESCRIPTION
Resolves #209, resolves #179 

This PR adds transforms to LaTeX for all modules inside the files package.

The [image] module also includes `caption`, `label` and `width` as arguments. I'm a little unsure to optimally handle the user not specifying `width`, and what it should default to in that case. Currently it defaults to "width=1.0\textwidth".


