### PR TITLE
Add Scheduler to Core

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.38"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 either = "1.8.1"
+granular-id = "0.2.1"
 
 # We need wasmer as a build dependency since we may want to pre-compile the bundled packages. However, we can't bring
 # it in since the build script is always built for the host, and Cargo enables the JS flags when targeting the web,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,10 @@ thiserror = "1.0.38"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 either = "1.8.1"
-granular-id = "0.2.1"
+granular-id = "0.4.1"
+bimap = "0.6.3"
+topological-sort = "0.2.2"
+num-traits = "0.2.15"
 
 # We need wasmer as a build dependency since we may want to pre-compile the bundled packages. However, we can't bring
 # it in since the build script is always built for the host, and Cargo enables the JS flags when targeting the web,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1.0.93"
 granular-id = "0.4.2"
 bimap = "0.6.3"
 topological-sort = "0.2.2"
-num-traits = "0.2.15"
 
 # We need wasmer as a build dependency since we may want to pre-compile the bundled packages. However, we can't bring
 # it in since the build script is always built for the host, and Cargo enables the JS flags when targeting the web,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,8 +14,7 @@ wasmer-vfs = { version = "3.1.1", default-features = false }
 thiserror = "1.0.38"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
-either = "1.8.1"
-granular-id = "0.4.1"
+granular-id = "0.4.2"
 bimap = "0.6.3"
 topological-sort = "0.2.2"
 num-traits = "0.2.15"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,3 +1,5 @@
+// Some functions are used conditionally based on features, so we allow dead code so we don't emit
+// build warnings for functions not used
 #![allow(dead_code)]
 
 use std::process::Child;

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::process::Child;
 use std::{
     env, fs,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -20,7 +20,7 @@ use wasmer_wasi::{Pipe, WasiState};
 use parser::config::{Config, HideConfig, ImportConfig};
 use parser::ModuleArguments;
 
-use crate::element::GranId;
+use crate::element::GranularId;
 use crate::fs::CoreFs;
 use crate::package::{ArgValue, PackageImplementation};
 use crate::package_store::{PackageID, PackageStore};
@@ -197,7 +197,7 @@ impl<T, U> Context<T, U> {
     // RwLock (which allows multiple readers).
     // Another note: It may or may not be good to have something more than "name" to identify the
     // variable accesses, like also passing "args" and possibly have variable accesses dependent
-    // on variables. It is fully possible and will work since this is called once per each element.
+    // on variables. This is now implemented for module expressions.
     #[allow(unused_variables)] // Remove this when doing the actual impl
     pub fn get_variable_accesses(
         &self,
@@ -272,7 +272,7 @@ where
     fn transform_from_wasm(
         &self,
         module: &Module,
-        module_id: &GranId,
+        module_id: &GranularId,
         name: &str,
         from: &Element,
         output_format: &OutputFormat,
@@ -491,7 +491,7 @@ impl<T, U> Context<T, U> {
     }
 
     /// Deserialize a compound (i.e a list of `JsonEntries`) that are received from a package
-    pub fn deserialize_compound(input: &str, id: GranId) -> Result<Element, CoreError> {
+    pub fn deserialize_compound(input: &str, id: GranularId) -> Result<Element, CoreError> {
         let entries: Vec<JsonEntry> =
             serde_json::from_str(input).map_err(|error| CoreError::DeserializationError {
                 string: input.to_string(),
@@ -508,7 +508,7 @@ impl<T, U> Context<T, U> {
     }
 
     /// Convert a `JsonEntry` to an `Element`
-    fn entry_to_element(entry: JsonEntry, id: GranId) -> Element {
+    fn entry_to_element(entry: JsonEntry, id: GranularId) -> Element {
         let type_erase = |mut map: HashMap<String, Value>| {
             map.drain()
                 .map(|(k, v)| {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -10,7 +10,6 @@ use std::{
     io::{Read, Write},
 };
 
-use granular_id::GranularId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[cfg(feature = "native")]
@@ -188,8 +187,29 @@ where
 }
 
 impl<T, U> Context<T, U> {
-    pub fn get_variable_accesses(&self, name: &str) -> Option<Vec<(Variable, VarAccess)>> {
+    /// This function returns the "variable accesses", which is all variables the transform
+    /// requires. This is used to schedule when the transform may run in relations to each other.
+    // Note to implementers: this most likely requires reading the PackageStore. This function will
+    // be called once for each element in the entire document tree, and when a Parent is evaluated,
+    // it will be called one additional time. Since it isn't done in parallel, however, and this
+    // is the only thing that only needs read access (afaik, or at least, other things that may
+    // happen in parallel often require write access), I don't think it is worth changing Mutex to
+    // RwLock (which allows multiple readers).
+    // Another note: It may or may not be good to have something more than "name" to identify the
+    // variable accesses, like also passing "args" and possibly have variable accesses dependent
+    // on variables. It is fully possible and will work since this is called once per each element.
+    #[allow(unused_variables)] // Remove this when doing the actual impl
+    pub fn get_variable_accesses(
+        &self,
+        name: &str,
+        args: Option<&ModuleArguments>,
+        format: &OutputFormat,
+    ) -> Option<Vec<(Variable, VarAccess)>> {
         // FIXME: add impl here
+        // Note that the var accesses may be dependent on argument, so if we are looking up a
+        // module, args is Some with the module arguments. This is important if we do a
+        // [set-env], which will have its accesses dependent on arguments. In addition to this,
+        // since arguments are dependent on output format, we also get the format passed here
         Some(vec![])
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -22,9 +22,11 @@ use wasmer_wasi::{Pipe, WasiState};
 use parser::config::{Config, HideConfig, ImportConfig};
 use parser::ModuleArguments;
 
+use crate::element::GranId;
 use crate::fs::CoreFs;
 use crate::package::{ArgValue, PackageImplementation};
 use crate::package_store::{PackageID, PackageStore};
+use crate::variables::{VarAccess, Variable};
 use crate::{std_packages, AccessPolicy, Element, Resolve};
 use crate::{ArgInfo, CoreError, OutputFormat, Package, Transform};
 
@@ -186,6 +188,13 @@ where
     }
 }
 
+impl<T, U> Context<T, U> {
+    pub fn get_variable_accesses(&self, name: &str) -> Option<Vec<(Variable, VarAccess)>> {
+        // FIXME: add impl here
+        Some(vec![])
+    }
+}
+
 impl<T, U> Context<T, U>
 where
     U: AccessPolicy,
@@ -243,7 +252,7 @@ where
     fn transform_from_wasm(
         &self,
         module: &Module,
-        module_id: &GranularId<u32>,
+        module_id: &GranId,
         name: &str,
         from: &Element,
         output_format: &OutputFormat,
@@ -461,7 +470,7 @@ impl<T, U> Context<T, U> {
     }
 
     /// Deserialize a compound (i.e a list of `JsonEntries`) that are received from a package
-    pub fn deserialize_compound(input: &str, id: GranularId<u32>) -> Result<Element, CoreError> {
+    pub fn deserialize_compound(input: &str, id: GranId) -> Result<Element, CoreError> {
         let entries: Vec<JsonEntry> =
             serde_json::from_str(input).map_err(|error| CoreError::DeserializationError {
                 string: input.to_string(),
@@ -478,7 +487,7 @@ impl<T, U> Context<T, U> {
     }
 
     /// Convert a `JsonEntry` to an `Element`
-    fn entry_to_element(entry: JsonEntry, id: GranularId<u32>) -> Element {
+    fn entry_to_element(entry: JsonEntry, id: GranId) -> Element {
         let type_erase = |mut map: HashMap<String, Value>| {
             map.drain()
                 .map(|(k, v)| {
@@ -541,7 +550,7 @@ impl<T, U> Context<T, U> {
                 name,
                 args,
                 children,
-                id,
+                id: _,
             } => {
                 let converted_children: Result<Vec<JsonEntry>, CoreError> = children
                     .iter()

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -10,7 +10,6 @@ use std::{
     io::{Read, Write},
 };
 
-use either::{Either, Left};
 use granular_id::GranularId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -34,8 +34,8 @@ impl Element {
             .into_iter()
             .fold(Some(self), |current, id| {
                 current.and_then(|c| match c {
-                    Element::Parent { children, .. } => children.get(id as usize),
-                    Element::Compound(children) => children.get(id as usize),
+                    Element::Parent { children, .. } => children.get(id),
+                    Element::Compound(children) => children.get(id),
                     _ => None,
                 })
             })
@@ -46,8 +46,8 @@ impl Element {
         let components: Vec<usize> = id.into();
         components.into_iter().fold(Some(self), |current, id| {
             current.and_then(|c| match c {
-                Element::Parent { children, .. } => children.get_mut(id as usize),
-                Element::Compound(children) => children.get_mut(id as usize),
+                Element::Parent { children, .. } => children.get_mut(id),
+                Element::Compound(children) => children.get_mut(id),
                 _ => None,
             })
         })

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -53,6 +53,8 @@ impl Element {
         })
     }
 
+    /// Checks if this element can be flattened to a string using `flatten`. If this returns `true`,
+    /// `flatten` will result in `Some`.
     pub fn is_flat(&self) -> bool {
         match self {
             Element::Parent { .. } | Element::Module { .. } => false,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -88,6 +88,10 @@ pub enum CoreError {
     DroppedRequest,
     #[error("Missing standard package named '{0}'")]
     NoSuchStdPackage(String),
+    #[error("Could not generate a good schedule; there might be dependency loops")]
+    Schedule,
+    #[error("Could not flatten structure, internal scheduling error")]
+    Flat,
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -88,7 +88,7 @@ pub enum CoreError {
     DroppedRequest,
     #[error("Missing standard package named '{0}'")]
     NoSuchStdPackage(String),
-    #[error("Could not generate a good schedule; there might be dependency loops")]
+    #[error("Could not generate a good schedule; there might be cyclic dependencies")]
     Schedule,
     #[error("Could not flatten structure, internal scheduling error")]
     Flat,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,7 +2,6 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::str::FromStr;
 
-use granular_id::GranularId;
 use serde::{Deserialize, Serialize};
 
 pub use context::Context;
@@ -12,6 +11,7 @@ pub use package::{ArgInfo, Package, PackageInfo, Transform};
 use package_store::Resolve;
 
 use crate::context::CompilationState;
+pub use crate::element::GranularId;
 use crate::schedule::Schedule;
 
 pub mod context;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -184,11 +184,11 @@ where
     U: AccessPolicy,
 {
     let mut schedule = Schedule::default();
-    schedule.add_element(&root, &ctx);
+    schedule.add_element(&root, ctx, format);
     while let Some(id) = schedule.pop() {
         let elem = root.get_by_id(id.clone()).unwrap();
         let new_elem = ctx.transform(&elem, format)?;
-        schedule.add_element(&new_elem, &ctx);
+        schedule.add_element(&new_elem, ctx, format);
         *root.get_by_id_mut(id).unwrap() = new_elem;
     }
 

--- a/core/src/schedule.rs
+++ b/core/src/schedule.rs
@@ -1,0 +1,173 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::ops::RangeFrom;
+
+use bimap::BiBTreeMap;
+use granular_id::GranularId;
+use num_traits::bounds::UpperBounded;
+use topological_sort::TopologicalSort;
+
+use crate::element::GranId;
+use crate::variables::{VarAccess, Variable};
+use crate::{Context, Element};
+
+type TrashId = usize;
+
+// In short, each element is identified by its "GranId". We can use these Ids in our sorting, and
+// then get the next ID to be evaluated. But when a parent node is evaluated, all its children
+// is invalid and any returned IDs from its children (which is "new") may previously have been
+// assigned to the previous children (which doesn't exist anymore). This means that we need to be
+// able to "remove" IDs, but that isn't possible in TopologicalSort. For this reason, we assign
+// new unique IDs to each GranId, of the type TrashId. We have an BiBTreeMap to keep track if this
+// mapping.
+
+pub struct Schedule {
+    dag: TopologicalSort<TrashId>,
+    dep_info: HashMap<Variable, Vec<(TrashId, VarAccess)>>,
+    id_map: BiBTreeMap<GranId, TrashId>,
+    id_iter: RangeFrom<TrashId>, // Assume this is infinite
+}
+
+impl Default for Schedule {
+    fn default() -> Self {
+        Self {
+            dag: Default::default(),
+            dep_info: Default::default(),
+            id_map: Default::default(),
+            id_iter: TrashId::MIN..,
+        }
+    }
+}
+
+impl Schedule {
+    pub fn is_empty(&self) -> bool {
+        self.dag.is_empty()
+    }
+
+    pub fn pop(&mut self) -> Option<GranId> {
+        // TODO LATER: use pop all and reorder them so modules of the same type are evaluated
+        //  after each other, that way we can keep the same wasm module alive for better performance
+
+        // trash_id is the ID of the next node to be evaluated
+        while let Some(trash_id) = self.dag.pop() {
+            // If this isn't in our BiBTreeMap it means that it doesn't exist anymore (it may once
+            // have been a child of an element that is now evaluated). Then we pop the next ID.
+            let Some((gran_id, _)) = self.id_map.remove_by_right(&trash_id) else {
+                continue;
+            };
+
+            // We need to remove all children, and we do this by getting the next sibling and
+            // extracting that range. If we, for example, want to evaluate the ID 0.1, we need to
+            // remove all IDs 0.1.x, and we do that with the range 0.1..0.2. So, we find the next
+            // sibling, or if none (we are root), take the max value of the type.
+            let end_range = gran_id
+                .next_siblings()
+                .next()
+                .unwrap_or(GranularId::max_value());
+            // We collect all TrashIds that will now be invalid due to the pop operation
+            let removed_ids = self
+                .id_map
+                .left_range(&gran_id..&end_range)
+                .map(|(_gran, trash)| *trash)
+                .collect::<Vec<_>>();
+            // For each ID that is removed, remove it from the ID map and from all dep infos
+            removed_ids.into_iter().for_each(|id| {
+                // By removing the ID from the map, it becomes a "tombstone id" and won't be
+                // returned from further calls to this function
+                self.id_map.remove_by_right(&id);
+                // This may be optimised with other data structures
+                self.dep_info.iter_mut().for_each(|(_k, v)| {
+                    v.retain(|elem| elem.0 != id);
+                });
+            });
+            return Some(gran_id);
+        }
+
+        if !self.dag.is_empty() {
+            // FIXME: Don't panic here, return error
+            panic!("Cycle");
+        }
+        None
+    }
+
+    pub fn add_element<T, U>(&mut self, element: &Element, ctx: &Context<T, U>) {
+        let (
+            Element::Parent{
+                name, id: this_id, ..
+            }
+            |
+            Element::Module {
+                name, id: this_id, ..
+            }
+        ) = element else {
+            // Handle raw and compound
+            return;
+        };
+
+        // Get new TrashId
+        let this_trashid = self.id_iter.next().unwrap();
+
+        // Insert this TrashId and put in the map
+        self.dag.insert(this_trashid.clone());
+        {
+            let overwritten = self.id_map.insert(this_id.clone(), this_trashid);
+            // Assert that the GranId isn't already in the map
+            debug_assert!(matches!(overwritten, bimap::Overwritten::Neither));
+        }
+
+        // Look in the context to find info about which variables the element is interested in
+        if let Some(variables) = &ctx.get_variable_accesses(name) {
+            for (var, access) in variables {
+                let mut deps = self.dep_info.remove(var).unwrap_or_default();
+
+                // Update the dependency edges of the DAG
+                for (other_trashid, other_access_type) in &deps {
+                    let cmp = other_access_type.partial_cmp(access).unwrap();
+
+                    match cmp {
+                        Ordering::Less => {
+                            self.dag
+                                .add_dependency(other_trashid.clone(), this_trashid.clone());
+                        }
+                        Ordering::Greater => {
+                            self.dag
+                                .add_dependency(this_trashid.clone(), other_trashid.clone());
+                        }
+
+                        // Some variable types care about the order in which they are written to (like lists for instance)
+                        Ordering::Equal if access.order_granular() => {
+                            let other_id = self.id_map.get_by_right(other_trashid).unwrap();
+                            match other_id.cmp(&this_id) {
+                                Ordering::Less => {
+                                    self.dag.add_dependency(
+                                        other_trashid.clone(),
+                                        this_trashid.clone(),
+                                    );
+                                }
+                                Ordering::Greater => {
+                                    self.dag.add_dependency(
+                                        this_trashid.clone(),
+                                        other_trashid.clone(),
+                                    );
+                                }
+                                _ => (),
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+
+                // Add this element to the deps map as well
+                deps.push((this_trashid.clone(), *access));
+                self.dep_info.insert(var.clone(), deps);
+            }
+        }
+
+        // If the element is a parent, also add the children
+        if let Element::Parent { children, .. } = element {
+            children
+                .iter()
+                .for_each(|child| self.add_element(child, ctx));
+        }
+    }
+}

--- a/core/src/schedule.rs
+++ b/core/src/schedule.rs
@@ -3,29 +3,28 @@ use std::collections::HashMap;
 use std::ops::RangeFrom;
 
 use bimap::BiBTreeMap;
-use granular_id::GranularId;
-use num_traits::bounds::UpperBounded;
+use granular_id::{GranularId, UpperBounded};
 use topological_sort::TopologicalSort;
 
 use crate::element::GranId;
 use crate::variables::{VarAccess, Variable};
 use crate::{Context, Element};
 
-type TrashId = usize;
+type ScheduleId = usize;
 
 // In short, each element is identified by its "GranId". We can use these Ids in our sorting, and
 // then get the next ID to be evaluated. But when a parent node is evaluated, all its children
 // is invalid and any returned IDs from its children (which is "new") may previously have been
 // assigned to the previous children (which doesn't exist anymore). This means that we need to be
 // able to "remove" IDs, but that isn't possible in TopologicalSort. For this reason, we assign
-// new unique IDs to each GranId, of the type TrashId. We have an BiBTreeMap to keep track if this
-// mapping.
+// new unique IDs to each GranId, of the type ScheduleId. We have an BiBTreeMap to keep track of
+// this mapping.
 
 pub struct Schedule {
-    dag: TopologicalSort<TrashId>,
-    dep_info: HashMap<Variable, Vec<(TrashId, VarAccess)>>,
-    id_map: BiBTreeMap<GranId, TrashId>,
-    id_iter: RangeFrom<TrashId>, // Assume this is infinite
+    dag: TopologicalSort<ScheduleId>,
+    dep_info: HashMap<Variable, Vec<(ScheduleId, VarAccess)>>,
+    id_map: BiBTreeMap<GranId, ScheduleId>,
+    id_iter: RangeFrom<ScheduleId>, // Assume this is infinite
 }
 
 impl Default for Schedule {
@@ -34,7 +33,7 @@ impl Default for Schedule {
             dag: Default::default(),
             dep_info: Default::default(),
             id_map: Default::default(),
-            id_iter: TrashId::MIN..,
+            id_iter: ScheduleId::MIN..,
         }
     }
 }
@@ -48,11 +47,11 @@ impl Schedule {
         // TODO LATER: use pop all and reorder them so modules of the same type are evaluated
         //  after each other, that way we can keep the same wasm module alive for better performance
 
-        // trash_id is the ID of the next node to be evaluated
-        while let Some(trash_id) = self.dag.pop() {
+        // schedule_id is the ID of the next node to be evaluated
+        while let Some(schedule_id) = self.dag.pop() {
             // If this isn't in our BiBTreeMap it means that it doesn't exist anymore (it may once
             // have been a child of an element that is now evaluated). Then we pop the next ID.
-            let Some((gran_id, _)) = self.id_map.remove_by_right(&trash_id) else {
+            let Some((gran_id, _)) = self.id_map.remove_by_right(&schedule_id) else {
                 continue;
             };
 
@@ -64,13 +63,12 @@ impl Schedule {
                 .next_siblings()
                 .next()
                 .unwrap_or(GranularId::max_value());
-            // We collect all TrashIds that will now be invalid due to the pop operation
+            // We collect all ScheduleIds that will now be invalid due to the pop operation
             let removed_ids = self
                 .id_map
                 .left_range(&gran_id..&end_range)
-                .map(|(_gran, trash)| *trash)
+                .map(|(_gran, sched)| *sched)
                 .collect::<Vec<_>>();
-            println!("Removing {} ids", removed_ids.len());
             // For each ID that is removed, remove it from the ID map and from all dep infos
             removed_ids.into_iter().for_each(|id| {
                 // By removing the ID from the map, it becomes a "tombstone id" and won't be
@@ -84,14 +82,19 @@ impl Schedule {
             return Some(gran_id);
         }
 
-        if !self.dag.is_empty() {
-            // FIXME: Don't panic here, return error
-            panic!("Cycle");
-        }
+        // In this case, we couldn't pop one element, and this may occur either if there is a
+        // cycle or if the DAG is empty. This will be checked externally.ﬁ
         None
     }
 
     pub fn add_element<T, U>(&mut self, element: &Element, ctx: &Context<T, U>) {
+        // Element may be one of four kinds:
+        // * Raw => We don't add it to the schedule
+        // * Module => We add it to the schedule
+        // * Parent => We add it and all its children to the schedule
+        // * Compound => We add all its children to the schedule, but not the compound itself
+
+        // Check if we have a compound element
         if let Element::Compound(children) = element {
             for child in children {
                 self.add_element(child, &ctx);
@@ -99,28 +102,24 @@ impl Schedule {
             return;
         }
 
-        let (
-            Element::Parent{
-                name, id: this_id, ..
+        // For adding to the schedule, we need the name and GranId for that element
+        // We could do this with a guard (let {name, id} = element else ...) but then rustfmt
+        // doesn't format it for some reason
+        let (name, this_id) = {
+            match element {
+                Element::Parent { name, id, .. } => (name, id),
+                Element::Module { name, id, .. } => (name, id),
+                _ => return,
             }
-            |
-            Element::Module {
-                name, id: this_id, ..
-            }
-        ) = element else {
-            // Handle raw and compound
-            // NOTE: compound handled above
-            return;
         };
-        println!("Adding elem {name}; before: {} ids", self.id_map.len());
 
-        // Get new TrashId
-        let this_trashid = self.id_iter.next().unwrap();
+        // Get new ScheduleId
+        let this_schedule_id = self.id_iter.next().unwrap();
 
-        // Insert this TrashId and put in the map
-        self.dag.insert(this_trashid.clone());
+        // Insert this ScheduleId and put in the map
+        self.dag.insert(this_schedule_id.clone());
         {
-            let overwritten = self.id_map.insert(this_id.clone(), this_trashid);
+            let overwritten = self.id_map.insert(this_id.clone(), this_schedule_id);
             // Assert that the GranId isn't already in the map
             debug_assert!(matches!(overwritten, bimap::Overwritten::Neither));
         }
@@ -131,33 +130,37 @@ impl Schedule {
                 let mut deps = self.dep_info.remove(var).unwrap_or_default();
 
                 // Update the dependency edges of the DAG
-                for (other_trashid, other_access_type) in &deps {
+                for (other_schedule_id, other_access_type) in &deps {
                     let cmp = other_access_type.partial_cmp(access).unwrap();
 
                     match cmp {
                         Ordering::Less => {
-                            self.dag
-                                .add_dependency(other_trashid.clone(), this_trashid.clone());
+                            self.dag.add_dependency(
+                                other_schedule_id.clone(),
+                                this_schedule_id.clone(),
+                            );
                         }
                         Ordering::Greater => {
-                            self.dag
-                                .add_dependency(this_trashid.clone(), other_trashid.clone());
+                            self.dag.add_dependency(
+                                this_schedule_id.clone(),
+                                other_schedule_id.clone(),
+                            );
                         }
 
                         // Some variable types care about the order in which they are written to (like lists for instance)
                         Ordering::Equal if access.order_granular() => {
-                            let other_id = self.id_map.get_by_right(other_trashid).unwrap();
+                            let other_id = self.id_map.get_by_right(other_schedule_id).unwrap();
                             match other_id.cmp(&this_id) {
                                 Ordering::Less => {
                                     self.dag.add_dependency(
-                                        other_trashid.clone(),
-                                        this_trashid.clone(),
+                                        other_schedule_id.clone(),
+                                        this_schedule_id.clone(),
                                     );
                                 }
                                 Ordering::Greater => {
                                     self.dag.add_dependency(
-                                        this_trashid.clone(),
-                                        other_trashid.clone(),
+                                        this_schedule_id.clone(),
+                                        other_schedule_id.clone(),
                                     );
                                 }
                                 _ => (),
@@ -168,18 +171,16 @@ impl Schedule {
                 }
 
                 // Add this element to the deps map as well
-                deps.push((this_trashid.clone(), *access));
+                deps.push((this_schedule_id.clone(), *access));
                 self.dep_info.insert(var.clone(), deps);
             }
         }
 
-        println!("Adding {name}; after: {} ids", self.id_map.len());
         // If the element is a parent, also add the children
         if let Element::Parent { children, .. } = element {
             children
                 .iter()
                 .for_each(|child| self.add_element(child, ctx));
         }
-        println!("Adding {name}s children; after: {} ids", self.id_map.len());
     }
 }

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -7,7 +7,7 @@ use wasmer::Engine;
 use parser::ModuleArguments;
 
 use crate::context::Issue;
-use crate::element::GranId;
+use crate::element::GranularId;
 use crate::package::{ArgValue, PrimitiveArgType};
 use crate::package_store::PackageStore;
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
@@ -115,7 +115,7 @@ pub fn native_raw<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranId,
+    _id: &GranularId,
 ) -> Result<Element, CoreError> {
     Ok(Element::Raw(body.to_owned()))
 }
@@ -128,7 +128,7 @@ pub fn native_inline_content<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    id: &GranId,
+    id: &GranularId,
 ) -> Result<Element, CoreError> {
     let elements = parser::parse_inline(body)?
         .into_iter()
@@ -147,7 +147,7 @@ pub fn native_block_content<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    id: &GranId,
+    id: &GranularId,
 ) -> Result<Element, CoreError> {
     let elements = parser::parse_blocks(body)?
         .into_iter()
@@ -165,7 +165,7 @@ pub fn native_set_env<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranId,
+    _id: &GranularId,
 ) -> Result<Element, CoreError> {
     unimplemented!("native_set_env")
 }
@@ -176,7 +176,7 @@ pub fn native_warn<T, U>(
     mut args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranId,
+    _id: &GranularId,
 ) -> Result<Element, CoreError> {
     // Push the issue to warnings
     ctx.state.warnings.push(Issue {
@@ -199,7 +199,7 @@ pub fn native_err<T, U>(
     args: HashMap<String, ArgValue>,
     inline: bool,
     output_format: &OutputFormat,
-    id: &GranId,
+    id: &GranularId,
 ) -> Result<Element, CoreError> {
     let source = args.get("source").unwrap().clone().get_string().unwrap();
     let target = args.get("target").unwrap().clone().get_string().unwrap();

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -9,6 +9,7 @@ use wasmer::Engine;
 use parser::ModuleArguments;
 
 use crate::context::Issue;
+use crate::element::GranId;
 use crate::package::{ArgValue, PrimitiveArgType};
 use crate::package_store::PackageStore;
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
@@ -116,7 +117,7 @@ pub fn native_raw<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranularId<u32>,
+    _id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     Ok(Right(body.to_owned()))
 }
@@ -129,7 +130,7 @@ pub fn native_inline_content<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    id: &GranularId<u32>,
+    id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_inline(body)?
         .into_iter()
@@ -148,7 +149,7 @@ pub fn native_block_content<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    id: &GranularId<u32>,
+    id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     let elements = parser::parse_blocks(body)?
         .into_iter()
@@ -166,7 +167,7 @@ pub fn native_set_env<T, U>(
     _args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranularId<u32>,
+    _id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     unimplemented!("native_set_env")
 }
@@ -177,7 +178,7 @@ pub fn native_warn<T, U>(
     mut args: HashMap<String, ArgValue>,
     _inline: bool,
     _output_format: &OutputFormat,
-    _id: &GranularId<u32>,
+    _id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     // Push the issue to warnings
     ctx.state.warnings.push(Issue {
@@ -200,7 +201,7 @@ pub fn native_err<T, U>(
     args: HashMap<String, ArgValue>,
     inline: bool,
     output_format: &OutputFormat,
-    id: &GranularId<u32>,
+    id: &GranId,
 ) -> Result<Either<Element, String>, CoreError> {
     let source = args.get("source").unwrap().clone().get_string().unwrap();
     let target = args.get("target").unwrap().clone().get_string().unwrap();

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use either::Either::{self, Left, Right};
-use granular_id::GranularId;
 use serde_json::Value;
 #[cfg(feature = "native")]
 use wasmer::Engine;

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -1,6 +1,6 @@
 /// This macro defines takes a declaration of native packages, and generates two functions,
 /// `pub fn native_package_list() -> Vec<PackageInfo>` returning a list of PackageInfos for the
-/// packages, and `pub fn handle_native(...) -> Result<Either<Element, String>, CoreError>` which
+/// packages, and `pub fn handle_native(...) -> Result<Element, CoreError>` which
 /// takes a call to a native module and calls it by the handle given in the declaration.
 ///
 /// The native module handlers should have the signature:
@@ -146,7 +146,7 @@ macro_rules! define_standard_package_loader {
             Ok(())
         }
         #[cfg(not(feature = "bundle_std_packages"))]
-        pub fn load_standard_packages(_: &mut PackageStore, #[cfg(feature = "native")] engine: &Engine)
+        pub fn load_standard_packages(_: &mut PackageStore, #[cfg(feature = "native")] _: &Engine)
             -> Result<(), CoreError> {
             Ok(())
         }

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -6,7 +6,7 @@
 /// The native module handlers should have the signature:
 /// `pub fn fn_name(ctx: &mut Context, body: &str, args: HashMap<String, String>,
 ///     inline: bool, output_format: &OutputFormat, id: &GranId)
-///     -> Result<Either<Element, String>, CoreError>;`
+///     -> Result<Element, CoreError>;`
 ///
 /// Example usage:
 /// ```rust,ignore
@@ -54,7 +54,7 @@ macro_rules! define_native_packages {
             element: &Element,
             args: HashMap<String, ArgValue>,
             output_format: &OutputFormat
-        ) -> Result<Either<Element, String>, CoreError> {
+        ) -> Result<Element, CoreError> {
             match package_name {
                 $(
                     $name => match node_name {

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -5,7 +5,8 @@
 ///
 /// The native module handlers should have the signature:
 /// `pub fn fn_name(ctx: &mut Context, body: &str, args: HashMap<String, String>,
-///     inline: bool, output_format: &OutputFormat) -> Result<Either<Element, String>, CoreError>;`
+///     inline: bool, output_format: &OutputFormat, id: &GranularId<u32>)
+///     -> Result<Either<Element, String>, CoreError>;`
 ///
 /// Example usage:
 /// ```rust,ignore
@@ -64,7 +65,8 @@ macro_rules! define_native_packages {
                                     args: _,
                                     body,
                                     inline,
-                                } => $handler(ctx, body, args, *inline, output_format),
+                                    id,
+                                } => $handler(ctx, body, args, *inline, output_format, id),
                                 _ => Err(
                                     CoreError::NonModuleToNative(
                                         package_name.to_string(),

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -5,7 +5,7 @@
 ///
 /// The native module handlers should have the signature:
 /// `pub fn fn_name(ctx: &mut Context, body: &str, args: HashMap<String, String>,
-///     inline: bool, output_format: &OutputFormat, id: &GranId)
+///     inline: bool, output_format: &OutputFormat, id: &GranularId)
 ///     -> Result<Element, CoreError>;`
 ///
 /// Example usage:

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -5,7 +5,7 @@
 ///
 /// The native module handlers should have the signature:
 /// `pub fn fn_name(ctx: &mut Context, body: &str, args: HashMap<String, String>,
-///     inline: bool, output_format: &OutputFormat, id: &GranularId<u32>)
+///     inline: bool, output_format: &OutputFormat, id: &GranId)
 ///     -> Result<Either<Element, String>, CoreError>;`
 ///
 /// Example usage:

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -24,21 +24,21 @@ pub enum VarAccess {
 }
 
 impl VarAccess {
-    // If two access levels are deemed the same (no one should strictly be done before the other),
-    // this function is called to see if the granularid (occurance in the source document) should
-    // determine the order of evaluation. If not, the order is arbitrarily chosen.
+    /// If two access levels are deemed the same (no one should strictly be done before the other),
+    /// this function is called to see if the granularid (occurrence in the source document) should
+    /// determine the order of evaluation. If not, the order is arbitrarily chosen.
     pub fn order_granular(&self) -> bool {
         matches!(&self, VarAccess::List(_))
     }
 }
 
 impl PartialOrd for VarAccess {
-    // Two different accesses `a` and `b` may or may not need to be ordered in a certain way.
-    // The result when comparing the two determines how they are ordered:
-    // * If `a` < `b`, `a` *will* occur before `b`
-    // * If `a` > `b`, `a` *will* occur after `b`
-    // * If `a` = `b`, `a` may occur before or after `b` (see ::order_granular)
-    // * If there is no ordering (this function returns None), any may occur before the other
+    /// Two different accesses `a` and `b` may or may not need to be ordered in a certain way.
+    /// The result when comparing the two determines how they are ordered:
+    /// * If `a` < `b`, `a` *will* occur before `b`
+    /// * If `a` > `b`, `a` *will* occur after `b`
+    /// * If `a` = `b`, `a` may occur before or after `b` (see ::order_granular)
+    /// * If there is no ordering (this function returns None), any may occur before the other
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         use VarAccess::*;
         match &self {
@@ -72,11 +72,11 @@ impl PartialOrd for VarAccess {
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Variable(pub String, pub VarType);
 
-// The ordering of these is very important. For determining what variable access types must occur
-// before others, VarAccess::partial_cmp is used which in turn uses the ordering of this accesses.
-// #derive Ord makes an ordering based on the order they are defined. Lesser accesses always occur
-// before greater accesses, so defining SetAccess::Add before SetAccess::Read ensures that, for any
-// given set, all Add operations occur before any Read operation does.
+// The ordering of these enum variants is very important. For determining what variable access types
+// must occur before others, VarAccess::partial_cmp is used which in turn uses the ordering of this
+// accesses. #derive Ord makes an ordering based on the order they are defined. Lesser accesses
+// always occur before greater accesses, so defining SetAccess::Add before SetAccess::Read ensures
+// that, for any given set, all Add operations occur before any Read operation does.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub enum SetAccess {
     Add,

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -70,7 +70,7 @@ impl PartialOrd for VarAccess {
 // Note we can have two different variables with the same name
 // if they have different types
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct Variable(String, VarType);
+pub struct Variable(pub String, pub VarType);
 
 // The ordering of these is very important. For determining what variable access types must occur
 // before others, VarAccess::partial_cmp is used which in turn uses the ordering of this accesses.

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -1,0 +1,96 @@
+use std::cmp::Ordering;
+
+// This is, for now, a placeholder file for variables. The data types it contains is (some) of the
+// once it will contain when the variable store is actually implemented.
+
+// The type of a variable
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum VarType {
+    // Set<String>, a collection of unordered unique strings, like for imports and such
+    Set,
+    // List<String>, a list of ordered strings ordered top-to-bottom in order of writes in the
+    // document, for headings and such
+    List,
+    // Constant is a variable type that may only be written once
+    Constant,
+}
+
+// This is the type of accesses that a transform may request to a certain variable
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum VarAccess {
+    Set(SetAccess),
+    List(ListAccess),
+    Constant(ConstantAccess),
+}
+
+impl VarAccess {
+    // If two access levels are deemed the same (no one should strictly be done before the other),
+    // this function is called to see if the granularid (occurance in the source document) should
+    // determine the order of evaluation. If not, the order is arbitrarily chosen.
+    pub fn order_granular(&self) -> bool {
+        matches!(&self, VarAccess::List(_))
+    }
+}
+
+impl PartialOrd for VarAccess {
+    // Two different accesses `a` and `b` may or may not need to be ordered in a certain way.
+    // The result when comparing the two determines how they are ordered:
+    // * If `a` < `b`, `a` *will* occur before `b`
+    // * If `a` > `b`, `a` *will* occur after `b`
+    // * If `a` = `b`, `a` may occur before or after `b` (see ::order_granular)
+    // * If there is no ordering (this function returns None), any may occur before the other
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        use VarAccess::*;
+        match &self {
+            Set(a) => {
+                if let Set(b) = other {
+                    Some(a.cmp(b))
+                } else {
+                    None
+                }
+            }
+            List(a) => {
+                if let List(b) = other {
+                    Some(a.cmp(b))
+                } else {
+                    None
+                }
+            }
+            Constant(a) => {
+                if let Constant(b) = other {
+                    Some(a.cmp(b))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+// Note we can have two different variables with the same name
+// if they have different types
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct Variable(String, VarType);
+
+// The ordering of these is very important. For determining what variable access types must occur
+// before others, VarAccess::partial_cmp is used which in turn uses the ordering of this accesses.
+// #derive Ord makes an ordering based on the order they are defined. Lesser accesses always occur
+// before greater accesses, so defining SetAccess::Add before SetAccess::Read ensures that, for any
+// given set, all Add operations occur before any Read operation does.
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, PartialEq, Eq)]
+pub enum SetAccess {
+    Add,
+    Read,
+}
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, PartialEq, Eq)]
+pub enum ListAccess {
+    Push,
+    Read,
+}
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, PartialEq, Eq)]
+pub enum ConstantAccess {
+    Declare,
+    Read,
+}

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -25,7 +25,6 @@ wasmer-vfs = { version = "3.1.1", default-features = false, features = ["mem-fs"
 js-sys = "0.3.61"
 wasm-bindgen-futures = "0.4.34"
 once_cell = "1.17.1"
-granular-id = "0.4.1"
 
 [dependencies.web-sys]
 version = "0.3.61"

--- a/playground/web_bindings/Cargo.toml
+++ b/playground/web_bindings/Cargo.toml
@@ -25,6 +25,7 @@ wasmer-vfs = { version = "3.1.1", default-features = false, features = ["mem-fs"
 js-sys = "0.3.61"
 wasm-bindgen-futures = "0.4.34"
 once_cell = "1.17.1"
+granular-id = "0.4.1"
 
 [dependencies.web-sys]
 version = "0.3.61"

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,21 +1,17 @@
-use std::cell::RefCell;
-use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-use modmark_core::{
-    eval, eval_no_document, Context, CoreError, DefaultAccessManager, OutputFormat,
-};
+use modmark_core::{Context, CoreError, DefaultAccessManager, Element, eval, eval_no_document, OutputFormat};
 use once_cell::sync::Lazy;
 use parser::ParseError;
 use serde::Serialize;
+use std::cell::RefCell;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
-
 use wasmer_vfs::FileSystem;
+use web_resolver::WebResolver;
+use granular_id::GranularId;
 
 mod web_resolver;
-use web_resolver::WebResolver;
-
 thread_local! {
     static CONTEXT: RefCell<Context<WebResolver, DefaultAccessManager>> =
         RefCell::new(Context::new(WebResolver, DefaultAccessManager).unwrap())
@@ -168,7 +164,7 @@ fn escape(text: String) -> String {
 pub fn json_output(source: &str) -> Result<String, PlaygroundError> {
     let result = CONTEXT.with(|ctx| {
         let ctx = ctx.borrow_mut();
-        let doc = parser::parse(source)?.try_into().map_err(|e| vec![e])?;
+        let doc = Element::try_from_ast(parser::parse(source)?, GranularId::root()).map_err(|e| vec![e])?;
         ctx.serialize_element(&doc, &OutputFormat::new("html"))
             .map_err(|e| vec![e])
             .map_err(|e| Into::<PlaygroundError>::into(e))

--- a/playground/web_bindings/src/lib.rs
+++ b/playground/web_bindings/src/lib.rs
@@ -1,4 +1,7 @@
-use modmark_core::{Context, CoreError, DefaultAccessManager, Element, eval, eval_no_document, OutputFormat};
+use modmark_core::{
+    eval, eval_no_document, Context, CoreError, DefaultAccessManager, Element, GranularId,
+    OutputFormat,
+};
 use once_cell::sync::Lazy;
 use parser::ParseError;
 use serde::Serialize;
@@ -9,7 +12,6 @@ use thiserror::Error;
 use wasm_bindgen::prelude::*;
 use wasmer_vfs::FileSystem;
 use web_resolver::WebResolver;
-use granular_id::GranularId;
 
 mod web_resolver;
 thread_local! {
@@ -164,7 +166,8 @@ fn escape(text: String) -> String {
 pub fn json_output(source: &str) -> Result<String, PlaygroundError> {
     let result = CONTEXT.with(|ctx| {
         let ctx = ctx.borrow_mut();
-        let doc = Element::try_from_ast(parser::parse(source)?, GranularId::root()).map_err(|e| vec![e])?;
+        let doc = Element::try_from_ast(parser::parse(source)?, GranularId::root())
+            .map_err(|e| vec![e])?;
         ctx.serialize_element(&doc, &OutputFormat::new("html"))
             .map_err(|e| vec![e])
             .map_err(|e| Into::<PlaygroundError>::into(e))


### PR DESCRIPTION
This PR adds a new struct `Schedule` to `Core`. This struct keeps track of all elements there are and may be polled to get the next element it think should be evaluated. 

The code we had previously to evaluate a document was this:

```rs
pub fn eval_elem<T, U>(root: Element) -> Result<String, CoreError> {
    use Element::{Compound, Module, Parent};
    match root {
        Compound(children) => {
            let mut raw_content = String::new();

            for child in children {
                raw_content.push_str(&eval_elem(child, ctx, format)?);
            }
            Ok(raw_content)
        }
        Module { .. } | Parent { .. } => {
            let either = ctx.transform(&root, format)?;
            match either {
                Left(elem) => eval_elem(elem, ctx, format),
                Right(res) => Ok(res),
            }
        }
    }
}
```
*Note that some details not important to getting the point across are omitted from this and upcoming code snippets*

One can clearly see that it evaluates all elements from the outer element inwards. So, if we want to evaluate a `Parent` (like `__document`), we evaluate it and then recursively evaluate all new elements. This works fine if there are no dependencies, but if we have a dependency saying like "we need to evaluate all headings before the TOC" or "we need to compute all imports before adding the document header", this doesn't suffice.

The `Schedule`r knows about such dependencies, and instead of naively evaluate from the outside in, we poll the `Schedule`r for what element to evaluate next:
```rs
pub fn evaluate_scheduled<T, U>(mut root: Element) -> Result<String, CoreError> {
    let mut schedule = Schedule::default();
    schedule.add_element(&root, &ctx);
    while let Some(id) = schedule.pop() {
        let elem = root.get_by_id(id.clone()).unwrap();
        let new_elem = ctx.transform(&elem, format)?;
        schedule.add_element(&new_elem, &ctx);
        *root.get_by_id_mut(id).unwrap() = new_elem;
    }

    root.flatten().map(|s| s.join("")).unwrap()
}
```

For this to work, the `Either<Element, String>` structure was removed in favour of adding a new `Element` kind `Raw` which holds the evaluated string which will in the end be put in the document. This is because we need to be able to serialize it; previously we always evaluated parents first so no children were evaluated but this is just not always the case anymore. Additionally, we need a way to index elements, and I made the crate [granular-id](https://docs.rs/granular-id) for this purpose. It assigns the first element id `0`, the second id `1` etc, and all children of the first element will be assigned `0.0`, `0.1` etc.

The scheduler itself doesn't inherently know all dependencies, but when new elements are added, the context will be queried for what dependencies that specific element has. Currently, since we have no way to specify dependencies, there is an empty placeholder function which always returns that there is no dependencies.

To actually be able to write the code that generates the graph, some of the structure of variable declarations and dependency types, orderings etc were needed. For this reason, `variables.rs` was created, holding such enums. Note that this **does not implement variables**, it just has some enums for different variable types, and these (as well as the access types) may be modified when actually implementing the variable store.

This PR is to a large extent done. There is some clean-up work left to do before it is ready for merging. If you want to test this out, you can hard-code the `get_variable_accesses` function like this:
```rs
    pub fn get_variable_accesses(&self, name: &str) -> Option<Vec<(Variable, VarAccess)>> {
        match name {
            "__paragraph" => Some(vec![(Variable("abc".to_string(), Constant), VarAccess::Constant(ConstantAccess::Read))]),
            "__heading" => Some(vec![(Variable("abc".to_string(), Constant), VarAccess::Constant(ConstantAccess::Declare))]),
            _ => Some(vec![])
        }
    }
```
This more or less says that any headings must be evaluated before any paragraphs. Then, you can add prints to the `transform_from_wasm` function to see what elements are being transformed, and test with some documents containing multiple interleaved paragraphs and headings and see that the headings are in fact evaluated before the paragraphs.

Resolves GH-215.