### PR TITLE
GH-197: Fix y-overflow in playground

### DIFF
--- a/playground/static/style.css
+++ b/playground/static/style.css
@@ -145,13 +145,13 @@ select:hover,
     width: 50%;
     height: 100%;
     box-sizing: border-box;
-    overflow: auto;
     margin: 0;
     border: none;
     transition: 0.3s width;
 }
 
 #preview {
+    overflow: auto;
     background: rgb(242, 242, 242);
 }
 


### PR DESCRIPTION
Resolves: #197 

It seems the issue was caused by overwriting the overflow property to "auto" for the editor element. Ace sets this to "hidden" otherwise.