### PR TITLE
Remove debounce watcher

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,8 +21,8 @@ tokio = { version = "1.26.0", features = ["full"] }
 tokio-stream = "0.1.12"
 warp = "0.3.3"
 futures-util = "0.3.27"
-notify-debouncer-mini = { version = "0.2.1", default-features = false }
 portpicker = "0.1.1"
+notify =  { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
 
 [features]
 default = ["modmark_core/bundle_std_packages"]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,5 +1,4 @@
 use modmark_core::CoreError;
-use notify_debouncer_mini::notify;
 use parser::ParseError;
 use std::io;
 use thiserror::Error;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -525,6 +525,8 @@ async fn watch_files<P: AsRef<Path>>(
                         continue;
                     }
                 }
+                // Take a quick nap to ensure that the file is closed before we start compiling
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 // We only care about changes from when files are created, removed or modified
                 if event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove() {
                     compile(document.as_ref(), connections.as_ref(), args).await?;


### PR DESCRIPTION
Resolves GH-211 by removing the debouncing file watcher in favour of a simpler one. A bit of regression since I think we are at risk of doing multiple unnecessary recompilations back-to-back in some cases. But, it should not be to bad and I rather have something semi-optimal that works then something broken. 