### PR TITLE
Implement variable store

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -77,6 +77,14 @@ impl Element {
             _ => None,
         }
     }
+
+    /// Get the name of a element (if it has one).
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Element::Parent { name, .. } | Element::Module { name, .. } => Some(name),
+            Element::Raw(_) | Element::Compound(_) => None,
+        }
+    }
 }
 
 impl Element {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -8,7 +8,7 @@ use wasmer::{ExportError, InstantiationError, RuntimeError};
 use wasmer_wasi::{WasiError, WasiStateCreationError};
 
 use crate::package::ArgType;
-use crate::variables::VarAccess;
+use crate::variables::{VarAccess, VarType};
 use parser::ParseError;
 
 #[derive(Error, Debug)]
@@ -102,6 +102,22 @@ pub enum CoreError {
         transform: String,
         package: String,
     },
+    #[error("Attempted to access variable '{variable_name}' using multiple different variable types for transform '{transform}' in '{package}' ")]
+    ClashingVariableAccesses {
+        variable_name: String,
+        transform: String,
+        package: String,
+    },
+    #[error("Attempted to access the variable '{name}' as a '{expected_type}' but the name is already occupied by value of type '{present_type}'.")]
+    TypeMismatch {
+        name: String,
+        expected_type: VarType,
+        present_type: VarType,
+    },
+    #[error("Attempted to redeclare the constant '{0}'.")]
+    ConstantRedeclaration(String),
+    #[error("Forbidden variable name '{0}'. Only ASCII letters and digits as well as '_' is allowed. The name may also not start with a digit.")]
+    ForbiddenVariableName(String),
     #[error("A package request was dropped before resolving")]
     DroppedRequest,
     #[error("Missing standard package named '{0}'")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -275,7 +275,6 @@ mod tests {
 
     use crate::package::{ArgType, PrimitiveArgType};
     use crate::package_store::ResolveTask;
-    use crate::variables::{ConstantAccess, VarAccess};
 
     use super::*;
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -75,8 +75,7 @@ impl PackageInfo {
         // Ensure all mentioned argument-dependent variables has corresponding arguments
         for transform in &self.transforms {
             for (var, access) in &transform.variables {
-                if var.starts_with('$') {
-                    let arg_name = &var[1..];
+                if let Some(arg_name) = var.strip_prefix('$') {
                     // Check if the argument exist
                     if let Some(arg_info) =
                         transform.arguments.iter().find(|arg| arg.name == arg_name)
@@ -98,7 +97,7 @@ impl PackageInfo {
                             argument_name: arg_name.to_string(),
                             transform: transform.from.to_string(),
                             package: self.name.to_string(),
-                            var_access: access.clone(),
+                            var_access: *access,
                         });
                     }
                 }

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -11,7 +11,7 @@ use crate::element::GranularId;
 use crate::package::{ArgValue, PrimitiveArgType};
 use crate::package_store::PackageStore;
 use crate::std_packages_macros::{define_native_packages, define_standard_package_loader};
-use crate::variables::{ListAccess, VarAccess};
+use crate::variables::{self, ConstantAccess, ListAccess, SetAccess, VarAccess, VarType};
 use crate::{ArgInfo, Context, CoreError, Element, OutputFormat, PackageInfo, Transform};
 
 // Here, all standard packages are declared. The macro expands to one function
@@ -35,94 +35,207 @@ define_standard_package_loader! {
 // one being a function returning the manifests for those packages, and the other
 // being the entry point to run these packages.
 define_native_packages! {
-    "core",
-    "Provides core functionality such as raw output, errors and warnings" => {
-        "raw",
-        "Outputs the body text as-is into the output document",
-        [],
-        vec![],
-        false => native_raw,
-        "warning",
-        "Adds a compilation warning to the list of all warnings that have occurred during compilation",
-        [],
-        vec![
-            ArgInfo {
-                name: "source".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The source module/parent responsible for the warning".to_string(),
-                r#type: PrimitiveArgType::String.into()
+    "core" => {
+        desc: "Provides core functionality such as raw output, errors and warnings",
+        transforms: [
+            {
+                name: "raw",
+                desc: "Outputs the body text as-is into the output document",
+                unknown_content: false,
+                vars: [],
+                args: vec![],
+                func: native_raw
             },
-            ArgInfo {
-                name: "target".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The target output format when the warning was generated".to_string(),
-                r#type: PrimitiveArgType::String.into()
+            {
+                name: "warning",
+                desc: "Adds a compilation warning to the list of all warnings that have occurred during compilation",
+                unknown_content: false,
+                vars: [],
+                args: vec![
+                    ArgInfo {
+                        name: "source".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The source module/parent responsible for the warning".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "target".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The target output format when the warning was generated".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "input".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The input given to the module when it failed".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                ],
+                func: native_warn
             },
-            ArgInfo {
-                name: "input".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The input given to the module when it failed".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-        ], false => native_warn,
-        "error",
-        "Adds a compilation error to the list of all errors that have occurred during compilation",
-        [],
-        vec![
-            ArgInfo {
-                name: "source".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The source module/parent responsible for the error".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-            ArgInfo {
-                name: "target".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The target output format when the error was generated".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-            ArgInfo {
-                name: "input".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The input given to the module when it failed".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-        ], false => native_err
-    };
-    "reparse",
-    "Provides an interface to the built-in ModMark parser" => {
-        "inline_content",
-        "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
-        [], vec![], true => native_inline_content,
-        "block_content",
-        "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
-        [], vec![], true => native_block_content,
-    };
-    "env",
-    "[Temporary] Provides access to setting environment variables" => {
-        "push-list",
-        "Pushes a string to a list",
-        [("$key".to_string(), VarAccess::List(ListAccess::Push))],
-        vec![
-            ArgInfo {
-                name: "key".to_string(),
-                default: None,
-                description: "The key to set".to_string(),
-                r#type: PrimitiveArgType::String.into()
+            {
+                name: "error",
+                desc: "Adds a compilation error to the list of all errors that have occurred during compilation",
+                unknown_content: false,
+                vars: [],
+                args: vec![
+                    ArgInfo {
+                        name: "source".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The source module/parent responsible for the error".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "target".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The target output format when the error was generated".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "input".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The input given to the module when it failed".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                ],
+                func: native_err
             }
-        ], false => native_push_list,
-        "read-list",
-        "Reads all strings from a list",
-        [("$key".to_string(), VarAccess::List(ListAccess::Read))],
-        vec![
-            ArgInfo {
-                name: "key".to_string(),
-                default: None,
-                description: "The key to set".to_string(),
-                r#type: PrimitiveArgType::String.into()
+        ]
+    }
+    "reparse" => {
+        desc: "Provides an interface to the built-in ModMark parser",
+        transforms: [
+            {
+                name: "inline_content",
+                desc: "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
+                unknown_content: true,
+                vars: [],
+                args: vec![],
+                func: native_inline_content
+            },
+            {
+                name: "block_content",
+                desc: "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
+                unknown_content: true,
+                vars: [],
+                args: vec![],
+                func: native_block_content
             }
-        ], false => native_read_list,
-    };
+        ]
+    }
+    "variables" => {
+        desc: "Read and write to environment variables.",
+        transforms: [
+            {
+                name: "const-decl",
+                desc: "Declare a constant",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::Constant(ConstantAccess::Declare))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name to declare".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: const_decl
+            },
+            {
+                name: "const-read",
+                desc: "Read a constant",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::Constant(ConstantAccess::Read))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name of the constant to read".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "default".to_string(),
+                        default: Some(Value::from("<log error>")),
+                        description: "A fallback text to used if the variable is undefined. If a 'default' is not provided a error will be created.".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: const_read
+            },
+            {
+                name: "list-push",
+                desc: "Push a string to a list",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::List(ListAccess::Push))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name of the list".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: list_push
+            },
+            {
+                name: "list-read",
+                desc: "Read a list. The list will be serialized as a JSON array.",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::List(ListAccess::Read))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name of the list to read".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "default".to_string(),
+                        default: Some(Value::from("<log error>")),
+                        description: "A fallback text to used if the variable is undefined. If a 'default' is not provided a error will be created.".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: list_read
+            },
+            {
+                name: "set-add",
+                desc: "Add a string to a set. Note that sets do not contains duplicates and are not ordered.",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::Set(SetAccess::Add))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name of the set".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: set_add
+            },
+            {
+                name: "set-read",
+                desc: "Read a set. The set will be serialized as a JSON array. Note that sets do not follow a deterministic order.",
+                unknown_content: false,
+                vars: [("$name".to_string(), VarAccess::Set(SetAccess::Read))],
+                args: vec![
+                    ArgInfo {
+                        name: "name".to_string(),
+                        default: None,
+                        description: "The name of the set to read".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "default".to_string(),
+                        default: Some(Value::from("<log error>")),
+                        description: "A fallback text to used if the variable is undefined. If a 'default' is not provided a error will be created.".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: set_read
+            },
+        ]
+    }
 }
 
 /// Returns a string containing the body of this invocation. This is the "leaf" call; no tree will
@@ -176,41 +289,174 @@ pub fn native_block_content<T, U>(
     Ok(Element::Compound(elements))
 }
 
-/// Example function for pushing a string to a list
-pub fn native_push_list<T, U>(
+/// Helper function to create text elements
+fn text_element(contents: String, id: GranularId) -> Element {
+    Element::Module {
+        name: "__text".to_string(),
+        args: Default::default(),
+        body: contents,
+        inline: true,
+        id,
+    }
+}
+
+/// Declare a constant
+pub fn const_decl<T, U>(
     ctx: &mut Context<T, U>,
-    body: &str,
+    value: &str,
     args: HashMap<String, ArgValue>,
-    _inline: bool,
-    _output_format: &OutputFormat,
-    _id: &GranularId,
+    _: bool,
+    _: &OutputFormat,
+    _: &GranularId,
 ) -> Result<Element, CoreError> {
-    let key = args.get("key").unwrap().as_str().unwrap();
-    let entry = ctx.lists.entry(key.to_string()).or_default();
-    entry.push(body.to_string());
+    let name = args.get("name").unwrap().as_str().unwrap();
+    ctx.state.variables.constant_declare(name, value)?;
+
     Ok(Element::Compound(vec![]))
 }
 
-/// Example function for reading a list
-pub fn native_read_list<T, U>(
+/// Read a constant
+pub fn const_read<T, U>(
     ctx: &mut Context<T, U>,
-    _body: &str,
+    _: &str,
     args: HashMap<String, ArgValue>,
-    _inline: bool,
-    _output_format: &OutputFormat,
+    _: bool,
+    format: &OutputFormat,
     id: &GranularId,
 ) -> Result<Element, CoreError> {
-    let key = args.get("key").unwrap().as_str().unwrap();
-    if let Some(list) = ctx.lists.get(key) {
-        Ok(Element::Module {
-            name: "__text".to_string(),
-            args: Default::default(),
-            body: list.join(","),
-            inline: false,
-            id: id.clone(),
-        })
-    } else {
-        Ok(Element::Compound(vec![]))
+    let name = args.get("name").unwrap().as_str().unwrap();
+
+    match ctx.state.variables.get(name) {
+        Some(value @ variables::Value::Constant(_)) => {
+            Ok(text_element(value.to_string(), id.clone()))
+        }
+        Some(value) => Err(CoreError::TypeMismatch {
+            name: name.to_string(),
+            expected_type: VarType::Constant,
+            present_type: value.get_type(),
+        }),
+        None => {
+            let default = args.get("default").map(ArgValue::as_str).flatten().unwrap();
+            if default == "<log error>" {
+                // No default was provided as fallback, let's log a error
+                Ok(get_read_error(name, "const-read", id, format))
+            } else {
+                Ok(text_element(default.to_string(), id.clone()))
+            }
+        }
+    }
+}
+
+/// Push a value to a list
+pub fn list_push<T, U>(
+    ctx: &mut Context<T, U>,
+    value: &str,
+    args: HashMap<String, ArgValue>,
+    _: bool,
+    _: &OutputFormat,
+    _: &GranularId,
+) -> Result<Element, CoreError> {
+    let name = args.get("name").unwrap().as_str().unwrap();
+    ctx.state.variables.list_push(name, value)?;
+    Ok(Element::Compound(vec![]))
+}
+
+/// Read a list of values
+pub fn list_read<T, U>(
+    ctx: &mut Context<T, U>,
+    _: &str,
+    args: HashMap<String, ArgValue>,
+    _: bool,
+    format: &OutputFormat,
+    id: &GranularId,
+) -> Result<Element, CoreError> {
+    let name = args.get("name").unwrap().as_str().unwrap();
+
+    match ctx.state.variables.get(name) {
+        Some(value @ variables::Value::List(_)) => Ok(text_element(value.to_string(), id.clone())),
+        Some(value) => Err(CoreError::TypeMismatch {
+            name: name.to_string(),
+            expected_type: VarType::List,
+            present_type: value.get_type(),
+        }),
+        None => {
+            let default = args.get("default").map(ArgValue::as_str).flatten().unwrap();
+            if default == "<log error>" {
+                // No default was provided as fallback, let's log a error
+                Ok(get_read_error(name, "list-read", id, format))
+            } else {
+                Ok(text_element(default.to_string(), id.clone()))
+            }
+        }
+    }
+}
+
+/// Add a string to a set
+pub fn set_add<T, U>(
+    ctx: &mut Context<T, U>,
+    value: &str,
+    args: HashMap<String, ArgValue>,
+    _: bool,
+    _: &OutputFormat,
+    _: &GranularId,
+) -> Result<Element, CoreError> {
+    let name = args.get("name").unwrap().as_str().unwrap();
+    ctx.state.variables.set_add(name, value)?;
+    Ok(Element::Compound(vec![]))
+}
+
+/// Read a list of values
+pub fn set_read<T, U>(
+    ctx: &mut Context<T, U>,
+    _: &str,
+    args: HashMap<String, ArgValue>,
+    _: bool,
+    format: &OutputFormat,
+    id: &GranularId,
+) -> Result<Element, CoreError> {
+    let name = args.get("name").unwrap().as_str().unwrap();
+
+    match ctx.state.variables.get(name) {
+        Some(value @ variables::Value::Set(_)) => Ok(text_element(value.to_string(), id.clone())),
+        Some(value) => Err(CoreError::TypeMismatch {
+            name: name.to_string(),
+            expected_type: VarType::Set,
+            present_type: value.get_type(),
+        }),
+        None => {
+            let default = args.get("default").map(ArgValue::as_str).flatten().unwrap();
+            if default == "<log error>" {
+                // No default was provided as fallback, let's log a error
+                Ok(get_read_error(name, "set-read", id, format))
+            } else {
+                Ok(text_element(default.to_string(), id.clone()))
+            }
+        }
+    }
+}
+
+fn get_read_error(
+    variable_name: &str,
+    module_name: &str,
+    id: &GranularId,
+    format: &OutputFormat,
+) -> Element {
+    Element::Module {
+        name: "error".to_string(),
+        args: ModuleArguments {
+            positioned: None,
+            named: Some({
+                let mut map = HashMap::new();
+                map.insert("source".to_string(), module_name.to_string());
+                map.insert("target".to_string(), format.to_string());
+                // read modules do not take any input
+                map.insert("input".to_string(), "".to_string());
+                map
+            }),
+        },
+        body: format!("Attempted to read undefined variable '{variable_name}'. Try defining the variable or provide a 'default' argument to the read module."),
+        inline: true,
+        id: id.clone(),
     }
 }
 

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -26,7 +26,7 @@
 /// }
 /// ```
 macro_rules! define_native_packages {
-    ($($name:expr, $desc:expr => { $($transform:expr, $tdesc:expr, $vars:expr, $arg_info:expr, $ukwn:expr => $handler:ident),* $(,)? };)*) => {
+    ($($name:expr => { desc: $desc:expr, transforms: [ $({name: $transform:expr, desc: $tdesc:expr, unknown_content: $ukwn:expr, vars: $vars:expr, args: $arg_info:expr, func: $handler:ident}),* $(,)? ]})*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
             vec![
                 $(


### PR DESCRIPTION
This PR implements:
* A `VariableStore` which lives in the `Context` struct and keeps all shared state.
* Six new modules: `const-read`, `const-decl`, `list-push`, `list-read`, `set-add`, `set-read` for manipulating variables stored in the shared state.
* A way of accessing the variables in packages by using WASI env variables `env::var("<TYPE>_<NAME>=<VALUE>")`.

Feel free to try out, I've left a sample document at the bottom of the PR.

# Questions
* Currently we allow two variables to have the same name as long as they have different types. This is a bit unconventional and complicates the code somewhat. And most importantly it might cause some confusions for package authors because if they declare a variable `"variables: { "foo": {type: "const", access: "read"}}` they must remember to use key `const_foo` when accessing it and not just `foo`. **Should we keep this behaviour or not?**
* Sadly `-` is now allowed in env variables. This means that it would be impossible to access a variable named `some-thing` for example. Either we keep it this way and give a error if the user attempts to create a variable containing "-". Alternatively, we could treat "-" and "_" as the same character and convert every hyphen to underscore when sending the env vars using WASI, but this might end up confusing users, **what do you think we should do?**
* Naming of the modules, feel free to suggest any alternative names too. For instance, I'm not convinced that `const-decl`  is the best name...

## Example document
```
# Contents

[list-read headings]()

# Figures
[list-push headings](Figures)
[set-read figures]{}

# All figures
[list-push headings](All figures)

# Intro
[list-push headings](Intro)

# Abstract
[list-push headings](Abstract)


[code matlab theme=github]
hold on
plot(x, y);


[code py theme=eighties]
for x in range(10):
    print(x)

[code py]
for x in range(10):
    print(x)


[const-decl code_theme](eighties)

[set-add figures](1)
[set-add figures](1)
[set-add figures](1)
[set-add figures](2)
[set-add figures](3)
[set-add figures](4)
[set-add figures](5)
[set-add figures](6)
[set-add figures](7)
```

Resolves GH-217