### PR TITLE
Add any as special output format

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -92,28 +92,28 @@ impl<T, U> Debug for Context<T, U> {
 
 /// This enum represents the different variants a transform can occur. Either a module/parent may be
 /// transformed natively (in one way), or externally (possibly in different ways, depending on the
-/// output format)
+/// output format). `ExternalAny` is used for external transforms that support any output format.
 #[derive(Debug)]
 pub enum TransformVariant {
     Native((Transform, Package)),
     External(HashMap<OutputFormat, (Transform, Package)>),
-    Any((Transform, Package)),
+    ExternalAny((Transform, Package)),
 }
 
 impl TransformVariant {
-    /// This function finds the transform to an output format. If the transform is a native
-    /// transform, that is returned regardless of the output format, but if it is external, the
-    /// map is searched to find the appropriate transform
+    /// This function finds the transform to an output format. If this if of the `External` variant,
+    /// the map is searched to find the appropriate transform. If this is of the `Native` or
+    /// `ExternalAny` variant, the transform is returned regardless of the output format.
     pub(crate) fn find_transform_to(&self, format: &OutputFormat) -> Option<&(Transform, Package)> {
         match self {
             TransformVariant::Native(t) => Some(t),
             TransformVariant::External(map) => map.get(format),
-            TransformVariant::Any(t) => Some(t),
+            TransformVariant::ExternalAny(t) => Some(t),
         }
     }
 
     /// This function `.insert`s an entry to the map if this is of the `External` variant. If it
-    /// is of the `Native` variant, this call does nothing.
+    /// is of the `Native` or `ExternalAny` variant, this call does nothing.
     pub(crate) fn insert_into_external(
         &mut self,
         format: OutputFormat,
@@ -124,7 +124,7 @@ impl TransformVariant {
             TransformVariant::External(map) => {
                 map.insert(format, entry);
             }
-            TransformVariant::Any(_) => {}
+            TransformVariant::ExternalAny(_) => {}
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -106,9 +106,8 @@ impl TransformVariant {
     /// `ExternalAny` variant, the transform is returned regardless of the output format.
     pub(crate) fn find_transform_to(&self, format: &OutputFormat) -> Option<&(Transform, Package)> {
         match self {
-            TransformVariant::Native(t) => Some(t),
             TransformVariant::External(map) => map.get(format),
-            TransformVariant::ExternalAny(t) => Some(t),
+            TransformVariant::ExternalAny(t) | TransformVariant::Native(t) => Some(t),
         }
     }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -43,6 +43,8 @@ pub enum CoreError {
     IoError(#[from] std::io::Error),
     #[error("Failed to parse transforms of package '{0}'.")]
     ParseTransforms(String),
+    #[error("Package '{0}' contains a transform from '{1}' with overlapping output formats. If 'any' is specified as output format, no other formats should be specified.")]
+    OverlappingOutputFormats(String, String),
     #[error("You repeated the argument '{0}' for the '{1}' element.")]
     RepeatedArgument(String, String),
     #[error("Argument '{0}' is missing in element '{1}'.")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -73,6 +73,8 @@ impl OutputFormat {
     }
 }
 
+// Custom deserialization to separate "any" as a special output format immediately. This is to
+// avoid having to check for and distinguish "any" in several places elsewhere.
 impl<'de> Deserialize<'de> for OutputFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -109,6 +111,7 @@ impl Serialize for OutputFormat {
         S: Serializer,
     {
         use OutputFormat::*;
+        // since deserialize never returns Name("any") we can serialize Any as "any"
         match self {
             Any => serializer.serialize_str("any"),
             Name(n) => serializer.serialize_str(n),
@@ -131,7 +134,7 @@ impl PartialEq for OutputFormat {
 impl Hash for OutputFormat {
     fn hash<H: Hasher>(&self, state: &mut H) {
         use OutputFormat::*;
-        // should be fine to hash Any as "any", because deserialize will never give Name("any")
+        // since deserialize never returns Name("any") we can hash Any as "any"
         match self {
             Any => "any".hash(state),
             Name(n) => n.to_lowercase().hash(state),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -156,7 +156,7 @@ impl FromStr for OutputFormat {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "any" {
+        if s.to_lowercase() == "any" {
             Ok(OutputFormat::Any)
         } else {
             Ok(OutputFormat::new(s))

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -101,6 +101,17 @@ impl PackageInfo {
                 }
             }
         }
+
+        // Ensure package does not specify other output formats when "any" is specified
+        for transform in &self.transforms {
+            if transform.to.contains(&OutputFormat::Any) && transform.to.len() > 1 {
+                return Err(CoreError::OverlappingOutputFormats(
+                    self.name.to_string(),
+                    transform.from.clone(),
+                ));
+            }
+        }
+
         Ok(())
     }
 }

--- a/core/src/package_store.rs
+++ b/core/src/package_store.rs
@@ -363,21 +363,19 @@ impl PackageStore {
                 for output_format in to {
                     match output_format {
                         OutputFormat::Any => {
-                            // this assures that we don't have overlapping transforms when Any is present
-                            match map.get(from) {
-                                Some(_) => {
-                                    return Err(CoreError::OccupiedTransform(
-                                        from.clone(),
-                                        output_format.to_string(),
-                                        pkg.info.name.clone(),
-                                    ));
-                                }
-                                None => {
-                                    map.insert(
-                                        from.clone(),
-                                        TransformVariant::Any((transform.clone(), pkg.clone())),
-                                    );
-                                }
+                            // this ensures Any does not overlap with any transforms with a
+                            // specific output format
+                            if map.get(from).is_some() {
+                                return Err(CoreError::OccupiedTransform(
+                                    from.clone(),
+                                    output_format.to_string(),
+                                    pkg.info.name.clone(),
+                                ));
+                            } else {
+                                map.insert(
+                                    from.clone(),
+                                    TransformVariant::ExternalAny((transform.clone(), pkg.clone())),
+                                );
                             }
                         }
                         OutputFormat::Name(_) => {

--- a/packages/files/src/main.rs
+++ b/packages/files/src/main.rs
@@ -77,7 +77,7 @@ fn manifest() {
                 },
                 {
                     "from": "include",
-                    "to": ["html", "latex"],
+                    "to": ["any"],
                     "arguments": [],
                 }
             ]


### PR DESCRIPTION
Resolves: #128 

TODO: 
- [x] update existing comments and comment some of the new code
- [x] test collision behaviour

To try it out you can use the `[include]` module, which I've changed to use "any" as output format. 

Collisions seem to work as intended. I tested this by adding a `[hello] -> any` transform and then importing hello from the catalog.