### PR TITLE
GH-234: Parser adjustments

### DIFF
--- a/package-tests/tests/package_tests.rs
+++ b/package-tests/tests/package_tests.rs
@@ -280,7 +280,7 @@ fn check_transform(transform: &Transform) {
     assert!(
         transform.arguments.iter().all(|arg|
             arg.name.starts_with(|c: char| c.is_ascii_lowercase()) &&
-                arg.name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+                arg.name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
         ),
         "Argument names should start with lowercase letter, and must only contain lowercase letters, digits and underscores (transform from {} failed)",
         transform.from

--- a/parser/src/module.rs
+++ b/parser/src/module.rs
@@ -115,11 +115,11 @@ fn parse_opening_delim<'a>(
         if inline {
             opt(verify(take(1usize), |s: &str| {
                 let c = s.chars().next().unwrap();
-                !c.is_alphanumeric() && !c.is_whitespace()
+                !c.is_alphanumeric() && !c.is_whitespace() && !")]}>".contains(c)
             }))(i)
         } else {
             opt(take_while1(|c: char| {
-                !c.is_alphanumeric() && !c.is_whitespace()
+                !c.is_alphanumeric() && !c.is_whitespace() && !")]}>".contains(c)
             }))(i)
         }
     }
@@ -151,10 +151,6 @@ fn closing_delim(string: &str) -> String {
             '<' => '>',
             '»' => '«',
             '›' => '‹',
-            ')' => '(',
-            '}' => '{',
-            ']' => '[',
-            '>' => '<',
             '«' => '»',
             '‹' => '›',
             x => x,
@@ -421,7 +417,7 @@ fn get_named_arg_parser<'a>(
 ///
 /// returns: The parsing result capturing the argument name
 fn arg_key_parser(input: &str) -> IResult<&str, &str> {
-    take_while1(|c: char| c.is_alphanumeric() || c == '_')(input)
+    take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '-')(input)
 }
 
 /// Parses the argument to a function removing optional quotation marks and returning the value.

--- a/parser/tests/compilation_tests/inline_module.mdmtest
+++ b/parser/tests/compilation_tests/inline_module.mdmtest
@@ -11,7 +11,7 @@ Cases below:
 6. Should just take the first < as delimiter
 7. Should not include anything since body closes immediately
 8. Only closing brackets should close in this case
-9. Only opening brackets should close in this case
+9. Since closing brackets can't be used as delimiter, all should be captured
 
 ```mdm
 Equations:
@@ -23,7 +23,7 @@ Equations:
 [six]<"yes1 "yes2" yes3">
 [sev]""no no"
 [eig]<y<y<y>
-[nin]>y>y<n
+[nin]>y>y<y
 ```
 
 ```json
@@ -93,10 +93,9 @@ Equations:
                 {
                     "name": "nin",
                     "args": {},
-                    "body": "y>y",
+                    "body": ">y>y<y",
                     "one_line": true
-                },
-                "n"
+                }
             ]
         }
     ]

--- a/parser/tests/compilation_tests/invocation_with_named_arguments.mdmtest
+++ b/parser/tests/compilation_tests/invocation_with_named_arguments.mdmtest
@@ -1,7 +1,7 @@
 Testing parsing of modules with only named arguments
 
 ```mdm
-[code lang=py indent=tabs]
+[code lang=py indent-with=tabs]
 print("hello world")
 ```
 
@@ -13,7 +13,7 @@ print("hello world")
         "name": "code",
         "args": {
             "lang": "py",
-            "indent": "tabs"
+            "indent-with": "tabs"
         },
         "body": "print(\"hello world\")",
         "one_line": false
@@ -21,4 +21,3 @@ print("hello world")
   ]
 }
 ```
-


### PR DESCRIPTION
Resolves GH-234.

Now, this document contains two module expressions and some text:
```
[foo]()

abc

[foo]()
```
whereas it previously was one multiline module expression and no text.

This also parses: `[foo some-key=some-value]` whereas it previously didn't.