### PR TITLE
Handle "black boxes" and ensure that it is not possible to lie to the scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ Welcome to the main ModMark repo! This is the home of the ModMark modular markup
 
 To invoke the ModMark compiler, you can run
 
-> cargo run -- in.mdm out.html
+> cargo run -- compile in.mdm out.html
 
-This will compile the input document `in.mdm` transforming it to HTML, and saving the output as `out.html`. In addition to the host platform target, the `wasm32-wasi` target is needed; `rustup target add wasm32-wasi`. See more information about the CLI tool at [cli/readme](cli/README.md). 
+This will compile the input document `in.mdm` transforming it to HTML, and saving the output as `out.html`. In addition to the host platform target, the `wasm32-wasi` target is needed; `rustup target add wasm32-wasi`. See more information about the CLI tool at [cli/readme](cli/README.md).
 
 ## Overview
 
 The ModMark language is a markup language which is highly modular - you may use different packages to augment the language with new modules, adding completely new functionality. The packages themselves can be written in a variety of different programming languages and may be included in your project to be able to parse whole new expressions.
 
 Here is an example ModMark document:
+
 ```
 # Welcome to **ModMark**
 This is **ModMark**, a modular markup language. The language itself is
@@ -28,7 +29,9 @@ The `[link]` syntax invokes a **module**, which lives outside the language itsel
 You can see more of the syntax [here](MODMARK.md), or continue reading to find out more about the project structure and technical details.
 
 ## Structure
+
 The project is subdivided into multiple different parts:
+
 - [core](core) - the core of the language, that is, the code which actually transforms a ModMark document to another format, keeps track of the loaded packages and the modules they contain, and delegates the transformation to different packages and modules. It also contains the source code for some native modules, which are special modules that are built-in into the language itself.
 - [parser](parser) - the parser that parses the document itself into different syntactical expressions. You can see the raw output of the parser in the [playground](https://modmark.org) by changing the view to `Abstract syntax tree`.
 - [cli](cli) - the cli tool, giving you the ability to compile ModMark documents locally on your computer.
@@ -39,6 +42,7 @@ The project is subdivided into multiple different parts:
 Each of these parts lives in their own directory, and contains their own readme file. Go to one of these directories for more specific information.
 
 ## Technical details
+
 The language itself is written in [Rust](https://rust-lang.org), and the packages it may load are [WASI binaries](https://wasi.dev), which is [WebAssembly](https://webassembly.org) binaries with a system interface allowing them to act like terminal tools, being able to read `stdin`, `stderr`, `stdout`, environment variables, program arguments and so on. The [core](core) uses these system interfaces to interface with the packages themselves. The data to transform is sent via `stdin`, like piping the input data to a terminal program, and the resulting data is expected to be sent to `stdout`.
 
 You may write your own packages in any language that may be compiled to [WASI](https://wasi.dev), and it isn't much harder than reading the program arguments and `stdin`, and printing the result to `stdout`. More information can be found in [packages/readme](packages/README.md).
@@ -47,7 +51,7 @@ The [WASI](https://wasi.dev) binaries are being loaded into the WASM runtime [Wa
 
 For bundling the standard packages, if the feature `core/bundle_std_packages` is enabled (which it is by default), all packages are compiled targeting `wasm32-wasi` which yields one `.wasm` file for each package. These packages are then copied into the binary, and will then be loaded by [core](core) the first time a document is compiled.
 
-The language itself is completely output-agnostic, meaning that it may support any output format and the syntax doesn't change. Packages, like [`math`](packages/math), declares what output formats their declared modules support (in this case HTML and LaTeX), and will get the desired output format as an argument when called. When the document gets compiled and finds a `[math]` module, [core](core) will check if there is a transform from that module to the wanted output format. This means that even if the package implementing the default `[math]` module doesn't support it, one could just make a new package declaring a transform to the output format of their liking. In addition to this, there are so-called *language packages* which are packages responsible for transforming tags and other structural components, such as the document itself, to one output format. Examples of these are the [html](packages/html) and [latex](packages/latex) packages, but one could also write a language package of their own, or import one made by another third-party. There is nothing that sets a *language package* apart from any other package, but the ability to transform the whole document to the final output format as well as transforming tags and such to the final output format. It would thus probably be easy to make a new package supporting output formats like RTF or Markdown.
+The language itself is completely output-agnostic, meaning that it may support any output format and the syntax doesn't change. Packages, like [`math`](packages/math), declares what output formats their declared modules support (in this case HTML and LaTeX), and will get the desired output format as an argument when called. When the document gets compiled and finds a `[math]` module, [core](core) will check if there is a transform from that module to the wanted output format. This means that even if the package implementing the default `[math]` module doesn't support it, one could just make a new package declaring a transform to the output format of their liking. In addition to this, there are so-called _language packages_ which are packages responsible for transforming tags and other structural components, such as the document itself, to one output format. Examples of these are the [html](packages/html) and [latex](packages/latex) packages, but one could also write a language package of their own, or import one made by another third-party. There is nothing that sets a _language package_ apart from any other package, but the ability to transform the whole document to the final output format as well as transforming tags and such to the final output format. It would thus probably be easy to make a new package supporting output formats like RTF or Markdown.
 
 ## License
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,6 @@ warp = "0.3.3"
 futures-util = "0.3.27"
 portpicker = "0.1.1"
 notify =  { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
-
+walkdir = "2"
 [features]
 default = ["modmark_core/bundle_std_packages"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,10 +4,12 @@ ModMark can be run locally to compile documents using this CLI interface.
 
 ## How to run
 
-The CLI is used like this
+### Compile
+
+To compile a file in modmark, the CLI can be used like this:
 
 ```
-$ modmark [OPTIONS] <INPUT> <OUTPUT>
+$ modmark compile [OPTIONS] <INPUT> <OUTPUT>
 ```
 
 The `<INPUT>` should be a path to the input document, and the `<OUTPUT>` should be a path to the output document. You may run it like this:
@@ -21,12 +23,34 @@ This would compile the file `in.mdm` and output the compiled HTML file as `out.h
 **Optional flags**
 
 | Flag             | Usage                                                                    |
-|------------------|--------------------------------------------------------------------------|
+| ---------------- | ------------------------------------------------------------------------ |
 | `-f`/`--format`  | `-f <FORMAT>` overrides the inferred output format with the one supplied |
 | `-w`/`--watch`   | Watches the input file for changes and re-compiles at every change       |
 | `-d`/`--dev`     | Prints the parsed AST tree before compiling                              |
 | `-V`/`--version` | Prints the version of the CLI took                                       |
 | `-h`/`--help`    | Prints the usage information                                             |
+
+### Cache
+
+To handle the cache of packages the CLI can be used like this:
+
+Uninstalls all the cached packages
+
+```
+$ modmark cache clear
+```
+
+Lists all the cached packages:
+
+```
+$ modmark cache list
+```
+
+Prints the location of the cached packages:
+
+```
+$ modmark cache location
+```
 
 ## Compilation
 

--- a/cli/src/file_access.rs
+++ b/cli/src/file_access.rs
@@ -1,4 +1,4 @@
-use crate::Args;
+use crate::CompileArgs;
 use modmark_core::AccessPolicy;
 use std::collections::HashMap;
 use std::io::{stdin, stdout, Write};
@@ -77,7 +77,7 @@ fn prompt_user(prompt: &str) -> bool {
 }
 
 impl CliAccessManager {
-    pub(crate) fn new(args: &Args) -> Self {
+    pub(crate) fn new(args: &CompileArgs) -> Self {
         Self {
             root: args.assets.clone(),
             deny_read: args.deny_read,

--- a/cli/src/package.rs
+++ b/cli/src/package.rs
@@ -39,6 +39,13 @@ impl Resolve for PackageManager {
     }
 }
 
+pub(crate) fn cache_location() -> Result<PathBuf, CliError> {
+    match ProjectDirs::from("org", "modmark", "packages") {
+        Some(path) => return Ok(path.cache_dir().to_path_buf()),
+        None => return Err(CliError::Cache),
+    };
+}
+
 impl PackageManager {
     async fn resolve(&self, task: ResolveTask) {
         let PackageID {
@@ -55,10 +62,7 @@ impl PackageManager {
     }
 
     async fn fetch_url(&self, package_path: &str) -> Result<Vec<u8>, CliError> {
-        let mut cache_path = match ProjectDirs::from("org", "modmark", "packages") {
-            Some(path) => path.cache_dir().to_path_buf(),
-            None => return Err(CliError::Cache),
-        };
+        let mut cache_path = cache_location()?;
 
         let splitter = package_path.split_once(':');
         let Some((_, mut domain_path)) = splitter else {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -221,9 +221,8 @@ impl<T, U> Context<T, U> {
         format: &OutputFormat,
     ) -> Result<Vec<(Variable, VarAccess)>, CoreError> {
         let Some(name) = element.name() else {
-            // Compounds and Raw elements do not have a name, but they don't
-            // depend on any variables either so we can just return a empty vector.  
-            return Ok(vec![]);
+            // Compounds and Raw elements do not have names and we should not check for the dependencies either
+            unreachable!("Unexpected use of compound or raw element in get_var_dependencies")
         };
 
         // Now, let's find the relevent transform for provided output format

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -78,6 +78,7 @@ impl CompilationState {
     fn clear(&mut self) {
         self.warnings.clear();
         self.errors.clear();
+        self.variables.clear();
     }
 }
 

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -77,6 +77,15 @@ impl Element {
             _ => None,
         }
     }
+
+    /// Get the name of a element (if it has one).
+    pub fn name(&self) -> Option<&String> {
+        match self {
+            Element::Parent { name, .. } => Some(name),
+            Element::Module { name, .. } => Some(name),
+            Element::Raw(_) | Element::Compound(_) => None,
+        }
+    }
 }
 
 impl Element {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -112,6 +112,8 @@ pub enum CoreError {
     Flat,
     #[error("Attempted to redeclare the constant '{0}'.")]
     ConstantRedeclaration(String),
+    #[error("Forbidden variable name '{0}'. Only ASCII letters and numbers as well as '_' is allowed. The name may also not start with a number.")]
+    ForbiddenVariableName(String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -110,6 +110,8 @@ pub enum CoreError {
     Schedule,
     #[error("Could not flatten structure, internal scheduling error")]
     Flat,
+    #[error("Attempted to redeclare the constant '{0}'.")]
+    ConstantRedeclaration(String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -8,7 +8,7 @@ use wasmer::{ExportError, InstantiationError, RuntimeError};
 use wasmer_wasi::{WasiError, WasiStateCreationError};
 
 use crate::package::ArgType;
-use crate::variables::VarAccess;
+use crate::variables::{VarAccess, VarType};
 use parser::ParseError;
 
 #[derive(Error, Debug)]
@@ -88,26 +88,36 @@ pub enum CoreError {
         expected_type: String,
         given_value: String,
     },
-    #[error("Could not find argument '{argument_name}' which variable accesses depends on in element '{element}' in package '{package}' (variable access '{var_access:?}')")]
+    #[error("Could not find argument '{argument_name}' which variable accesses depends on in transform '{transform}' in package '{package}' (variable access '{var_access:?}')")]
     ArgumentDependentVariable {
         argument_name: String,
-        element: String,
+        transform: String,
         package: String,
         var_access: VarAccess,
     },
-    #[error("Invalid argument dependent variable type, expected String or Enum variant, got '{argument_type:?}'; argument '{argument_name}' for element '{element}' in package '{package}'")]
+    #[error("Invalid argument dependent variable type, expected String or Enum variant, got '{argument_type:?}'; argument '{argument_name}' for transform '{transform}' in package '{package}'")]
     ArgumentDependentVariableType {
         argument_type: ArgType,
         argument_name: String,
-        element: String,
+        transform: String,
         package: String,
     },
-    #[error("Attempted to access variable '{variable_name}' using multiple different operations for element '{element}' in '{package}' ")]
+    #[error("Attempted to access variable '{variable_name}' using multiple different variable types for transform '{transform}' in '{package}' ")]
     ClashingVariableAccesses {
         variable_name: String,
-        element: String,
+        transform: String,
         package: String,
     },
+    #[error("Attempted to access the variable '{name}' as a '{expected_type}' but the name is already occupied by value of type '{present_type}'.")]
+    TypeMismatch {
+        name: String,
+        expected_type: VarType,
+        present_type: VarType,
+    },
+    #[error("Attempted to redeclare the constant '{0}'.")]
+    ConstantRedeclaration(String),
+    #[error("Forbidden variable name '{0}'. Only ASCII letters and numbers as well as '_' is allowed. The name may also not start with a number.")]
+    ForbiddenVariableName(String),
     #[error("A package request was dropped before resolving")]
     DroppedRequest,
     #[error("Missing standard package named '{0}'")]
@@ -116,10 +126,6 @@ pub enum CoreError {
     Schedule,
     #[error("Could not flatten structure, internal scheduling error")]
     Flat,
-    #[error("Attempted to redeclare the constant '{0}'.")]
-    ConstantRedeclaration(String),
-    #[error("Forbidden variable name '{0}'. Only ASCII letters and numbers as well as '_' is allowed. The name may also not start with a number.")]
-    ForbiddenVariableName(String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -88,18 +88,24 @@ pub enum CoreError {
         expected_type: String,
         given_value: String,
     },
-    #[error("Could not find argument '{argument_name}' which variable accesses depends on in transform '{transform}' in package '{package}' (variable access '{var_access:?}')")]
+    #[error("Could not find argument '{argument_name}' which variable accesses depends on in element '{element}' in package '{package}' (variable access '{var_access:?}')")]
     ArgumentDependentVariable {
         argument_name: String,
-        transform: String,
+        element: String,
         package: String,
         var_access: VarAccess,
     },
-    #[error("Invalid argument dependent variable type, expected String or Enum variant, got '{argument_type:?}'; argument '{argument_name}' for transform '{transform}' in package '{package}'")]
+    #[error("Invalid argument dependent variable type, expected String or Enum variant, got '{argument_type:?}'; argument '{argument_name}' for element '{element}' in package '{package}'")]
     ArgumentDependentVariableType {
         argument_type: ArgType,
         argument_name: String,
-        transform: String,
+        element: String,
+        package: String,
+    },
+    #[error("Attempted to access variable '{variable_name}' using multiple different operations for element '{element}' in '{package}' ")]
+    ClashingVariableAccesses {
+        variable_name: String,
+        element: String,
         package: String,
     },
     #[error("A package request was dropped before resolving")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -299,6 +299,7 @@ mod tests {
                 from: "table".to_string(),
                 to: vec![OutputFormat::new("html"), OutputFormat::new("latex")],
                 description: None,
+                black_box: true,
                 arguments: vec![
                     ArgInfo {
                         name: "caption".to_string(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -275,13 +275,12 @@ mod tests {
 
     use crate::package::{ArgType, PrimitiveArgType};
     use crate::package_store::ResolveTask;
-    use crate::variables::{ConstantAccess, VarAccess};
 
     use super::*;
 
     struct UnimplementedResolver;
     impl Resolve for UnimplementedResolver {
-        fn resolve_all(&self, paths: Vec<ResolveTask>) {
+        fn resolve_all(&self, _: Vec<ResolveTask>) {
             unimplemented!()
         }
     }

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -21,6 +21,8 @@ pub struct Transform {
     pub arguments: Vec<ArgInfo>,
     #[serde(default)]
     pub variables: HashMap<String, VarAccess>,
+    #[serde(default, rename = "kebab-case")]
+    pub black_box: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -72,8 +72,7 @@ impl PackageInfo {
         // Ensure all mentioned argument-dependent variables has corresponding arguments
         for transform in &self.transforms {
             for (var, access) in &transform.variables {
-                if var.starts_with('$') {
-                    let arg_name = &var[1..];
+                if let Some(arg_name) = var.strip_prefix('$') {
                     // Check if the argument exist
                     if let Some(arg_info) =
                         transform.arguments.iter().find(|arg| arg.name == arg_name)
@@ -85,7 +84,7 @@ impl PackageInfo {
                             return Err(CoreError::ArgumentDependentVariableType {
                                 argument_type: arg_info.r#type.clone(),
                                 argument_name: arg_name.to_string(),
-                                element: transform.from.to_string(),
+                                transform: transform.from.to_string(),
                                 package: self.name.to_string(),
                             });
                         }
@@ -93,9 +92,9 @@ impl PackageInfo {
                         // If not, we are missing that argument and the manifest is invalid
                         return Err(CoreError::ArgumentDependentVariable {
                             argument_name: arg_name.to_string(),
-                            element: transform.from.to_string(),
+                            transform: transform.from.to_string(),
                             package: self.name.to_string(),
-                            var_access: access.clone(),
+                            var_access: *access,
                         });
                     }
                 }

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -85,7 +85,7 @@ impl PackageInfo {
                             return Err(CoreError::ArgumentDependentVariableType {
                                 argument_type: arg_info.r#type.clone(),
                                 argument_name: arg_name.to_string(),
-                                transform: transform.from.to_string(),
+                                element: transform.from.to_string(),
                                 package: self.name.to_string(),
                             });
                         }
@@ -93,7 +93,7 @@ impl PackageInfo {
                         // If not, we are missing that argument and the manifest is invalid
                         return Err(CoreError::ArgumentDependentVariable {
                             argument_name: arg_name.to_string(),
-                            transform: transform.from.to_string(),
+                            element: transform.from.to_string(),
                             package: self.name.to_string(),
                             var_access: access.clone(),
                         });

--- a/core/src/package_store.rs
+++ b/core/src/package_store.rs
@@ -351,14 +351,7 @@ impl PackageStore {
         include_entries: bool,
         include_list: &[String],
     ) -> Result<(), CoreError> {
-        for transform @ Transform {
-            from,
-            to,
-            description: _,
-            arguments: _,
-            variables: _,
-        } in &pkg.info.transforms
-        {
+        for transform @ Transform { from, to, .. } in &pkg.info.transforms {
             if include_entries == include_list.contains(from) {
                 for output_format in to {
                     match output_format {

--- a/core/src/schedule.rs
+++ b/core/src/schedule.rs
@@ -8,7 +8,7 @@ use granular_id::UpperBounded;
 use topological_sort::TopologicalSort;
 
 use crate::element::GranularId;
-use crate::variables::{VarAccess, Variable};
+use crate::variables::{VarAccess, VarType};
 use crate::{Context, CoreError, Element, OutputFormat};
 
 type ScheduleId = usize;
@@ -23,7 +23,7 @@ type ScheduleId = usize;
 
 pub(crate) struct Schedule {
     dag: TopologicalSort<ScheduleId>,
-    dep_info: HashMap<Variable, Vec<(ScheduleId, VarAccess)>>,
+    dep_info: HashMap<(String, VarType), Vec<(ScheduleId, VarAccess)>>,
     id_map: BiBTreeMap<GranularId, ScheduleId>,
     id_iter: RangeFrom<ScheduleId>, // Assume this is infinite
 }

--- a/core/src/schedule.rs
+++ b/core/src/schedule.rs
@@ -111,9 +111,9 @@ impl Schedule {
             return Ok(());
         }
 
-        let (name, this_id) = {
+        let this_id = {
             match element {
-                Element::Parent { name, id, .. } | Element::Module { name, id, .. } => (name, id),
+                Element::Parent { id, .. } | Element::Module { id, .. } => id,
                 Element::Compound(_) => return Ok(()),
                 Element::Raw(_) => return Ok(()),
             }
@@ -131,7 +131,7 @@ impl Schedule {
         }
 
         // Look in the context to find info about which variables the element is interested in
-        let variables = &ctx.get_variable_accesses(name, element, format)?;
+        let variables = &ctx.get_var_dependencies(element, format)?;
         //if let Some(variables) = &ctx.get_variable_accesses(name, element, format)? {
         for (var, access) in variables {
             let mut deps = self.dep_info.remove(var).unwrap_or_default();

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -41,6 +41,7 @@ define_native_packages! {
             {
                 name: "raw",
                 desc: "Outputs the body text as-is into the output document",
+                black_box: false,
                 vars: [],
                 args: vec![],
                 func: native_raw
@@ -48,6 +49,7 @@ define_native_packages! {
             {
                 name: "warning",
                 desc: "Adds a compilation warning to the list of all warnings that have occurred during compilation",
+                black_box: false,
                 vars: [],
                 args: vec![
                     ArgInfo {
@@ -74,6 +76,7 @@ define_native_packages! {
             {
                 name: "error",
                 desc: "Adds a compilation error to the list of all errors that have occurred during compilation",
+                black_box: false,
                 vars: [],
                 args: vec![
                     ArgInfo {
@@ -105,6 +108,7 @@ define_native_packages! {
             {
                 name: "inline_content",
                 desc: "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
+                black_box: true,
                 vars: [],
                 args: vec![],
                 func: native_inline_content
@@ -112,6 +116,7 @@ define_native_packages! {
             {
                 name: "block_content",
                 desc: "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
+                black_box: true,
                 vars: [],
                 args: vec![],
                 func: native_block_content
@@ -124,6 +129,7 @@ define_native_packages! {
             {
                 name: "const-decl",
                 desc: "Declare a constant",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::Constant(ConstantAccess::Declare))],
                 args: vec![
                     ArgInfo {
@@ -138,6 +144,7 @@ define_native_packages! {
             {
                 name: "const-read",
                 desc: "Read a constant",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::Constant(ConstantAccess::Read))],
                 args: vec![
                     ArgInfo {
@@ -152,6 +159,7 @@ define_native_packages! {
             {
                 name: "list-push",
                 desc: "Push a string to a list",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::List(ListAccess::Push))],
                 args: vec![
                     ArgInfo {
@@ -166,6 +174,7 @@ define_native_packages! {
             {
                 name: "list-read",
                 desc: "Read a list. The list will be serialized as a JSON array.",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::List(ListAccess::Read))],
                 args: vec![
                     ArgInfo {
@@ -180,6 +189,7 @@ define_native_packages! {
             {
                 name: "set-add",
                 desc: "Add a string to a set. Note that sets do not contains duplicates and are not ordered.",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::Set(SetAccess::Add))],
                 args: vec![
                     ArgInfo {
@@ -194,6 +204,7 @@ define_native_packages! {
             {
                 name: "set-read",
                 desc: "Read a set. The set will be serialized as a JSON array. Note that sets do not follow a deterministic order.",
+                black_box: false,
                 vars: [("$name".to_string(), VarAccess::Set(SetAccess::Read))],
                 args: vec![
                     ArgInfo {

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -281,7 +281,7 @@ pub fn const_decl<T, U>(
     _: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    ctx.variables.constant_declare(name, value)?;
+    ctx.state.variables.constant_declare(name, value)?;
 
     Ok(Element::Compound(vec![]))
 }
@@ -296,7 +296,7 @@ pub fn const_read<T, U>(
     id: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    let value = ctx.variables.get(name, &VarType::Constant);
+    let value = ctx.state.variables.get(name, &VarType::Constant);
 
     if let Some(value) = value {
         Ok(text_element(value.to_string(), id.clone()))
@@ -316,7 +316,7 @@ pub fn list_push<T, U>(
     _: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    ctx.variables.list_push(name, value)?;
+    ctx.state.variables.list_push(name, value)?;
     Ok(Element::Compound(vec![]))
 }
 
@@ -330,7 +330,7 @@ pub fn list_read<T, U>(
     id: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    let value = ctx.variables.get(name, &VarType::List);
+    let value = ctx.state.variables.get(name, &VarType::List);
 
     if let Some(value) = value {
         Ok(text_element(value.to_string(), id.clone()))
@@ -350,7 +350,7 @@ pub fn set_add<T, U>(
     _: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    ctx.variables.set_add(name, value)?;
+    ctx.state.variables.set_add(name, value)?;
     Ok(Element::Compound(vec![]))
 }
 
@@ -364,7 +364,7 @@ pub fn set_read<T, U>(
     id: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    let value = ctx.variables.get(name, &VarType::Set);
+    let value = ctx.state.variables.get(name, &VarType::Set);
 
     if let Some(value) = value {
         Ok(text_element(value.to_string(), id.clone()))

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -165,7 +165,7 @@ define_native_packages! {
             },
             {
                 name: "list-read",
-                desc: "Read a list",
+                desc: "Read a list. The list will be serialized as a JSON array.",
                 vars: [("$name".to_string(), VarAccess::List(ListAccess::Read))],
                 args: vec![
                     ArgInfo {
@@ -193,7 +193,7 @@ define_native_packages! {
             },
             {
                 name: "set-read",
-                desc: "Read a set. Note that sets do not follow a deterministic order.",
+                desc: "Read a set. The set will be serialized as a JSON array. Note that sets do not follow a deterministic order.",
                 vars: [("$name".to_string(), VarAccess::Set(SetAccess::Read))],
                 args: vec![
                     ArgInfo {

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -316,7 +316,7 @@ pub fn list_push<T, U>(
     _: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    ctx.variables.list_push(name, value);
+    ctx.variables.list_push(name, value)?;
     Ok(Element::Compound(vec![]))
 }
 
@@ -350,7 +350,7 @@ pub fn set_add<T, U>(
     _: &GranularId,
 ) -> Result<Element, CoreError> {
     let name = args.get("name").unwrap().as_str().unwrap();
-    ctx.variables.set_add(name, value);
+    ctx.variables.set_add(name, value)?;
     Ok(Element::Compound(vec![]))
 }
 

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -35,92 +35,122 @@ define_standard_package_loader! {
 // one being a function returning the manifests for those packages, and the other
 // being the entry point to run these packages.
 define_native_packages! {
-    "core",
-    "Provides core functionality such as raw output, errors and warnings" => {
-        "raw",
-        "Outputs the body text as-is into the output document",
-        [], vec![] => native_raw,
-        "warning",
-        "Adds a compilation warning to the list of all warnings that have occurred during compilation",
-        [],
-        vec![
-            ArgInfo {
-                name: "source".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The source module/parent responsible for the warning".to_string(),
-                r#type: PrimitiveArgType::String.into()
+    "core" => {
+        desc: "Provides core functionality such as raw output, errors and warnings",
+        transforms: [
+            {
+                name: "raw",
+                desc: "Outputs the body text as-is into the output document",
+                vars: [],
+                args: vec![],
+                func: native_raw
             },
-            ArgInfo {
-                name: "target".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The target output format when the warning was generated".to_string(),
-                r#type: PrimitiveArgType::String.into()
+            {
+                name: "warning",
+                desc: "Adds a compilation warning to the list of all warnings that have occurred during compilation",
+                vars: [],
+                args: vec![
+                    ArgInfo {
+                        name: "source".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The source module/parent responsible for the warning".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "target".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The target output format when the warning was generated".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "input".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The input given to the module when it failed".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                ],
+                func: native_warn
             },
-            ArgInfo {
-                name: "input".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The input given to the module when it failed".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-        ] => native_warn,
-        "error",
-        "Adds a compilation error to the list of all errors that have occurred during compilation",
-        [],
-        vec![
-            ArgInfo {
-                name: "source".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The source module/parent responsible for the error".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-            ArgInfo {
-                name: "target".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The target output format when the error was generated".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-            ArgInfo {
-                name: "input".to_string(),
-                default: Some(Value::String("<unknown>".to_string())),
-                description: "The input given to the module when it failed".to_string(),
-                r#type: PrimitiveArgType::String.into()
-            },
-        ] => native_err
-    };
-    "reparse",
-    "Provides an interface to the built-in ModMark parser" => {
-        "inline_content",
-        "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
-        [], vec![] => native_inline_content,
-        "block_content",
-        "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
-        [], vec![] => native_block_content,
-    };
-    "env",
-    "[Temporary] Provides access to setting environment variables" => {
-        "push-list",
-        "Pushes a string to a list",
-        [("$key".to_string(), VarAccess::List(ListAccess::Push))],
-        vec![
-            ArgInfo {
-                name: "key".to_string(),
-                default: None,
-                description: "The key to set".to_string(),
-                r#type: PrimitiveArgType::String.into()
+            {
+                name: "error",
+                desc: "Adds a compilation error to the list of all errors that have occurred during compilation",
+                vars: [],
+                args: vec![
+                    ArgInfo {
+                        name: "source".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The source module/parent responsible for the error".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "target".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The target output format when the error was generated".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                    ArgInfo {
+                        name: "input".to_string(),
+                        default: Some(Value::String("<unknown>".to_string())),
+                        description: "The input given to the module when it failed".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    },
+                ],
+                func: native_err
             }
-        ] => native_push_list,
-        "read-list",
-        "Reads all strings from a list",
-        [("$key".to_string(), VarAccess::List(ListAccess::Read))],
-        vec![
-            ArgInfo {
-                name: "key".to_string(),
-                default: None,
-                description: "The key to set".to_string(),
-                r#type: PrimitiveArgType::String.into()
+        ]
+    }
+    "reparse" => {
+        desc: "Provides an interface to the built-in ModMark parser",
+        transforms: [
+            {
+                name: "inline_content",
+                desc: "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
+                vars: [],
+                args: vec![],
+                func: native_inline_content
+            },
+            {
+                name: "block_content",
+                desc: "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
+                vars: [],
+                args: vec![],
+                func: native_block_content
             }
-        ] => native_read_list,
-    };
+        ]
+    }
+    "env" => {
+        desc: "[Temporary] Provides access to setting environment variables",
+        transforms: [
+            {
+                name: "push-list",
+                desc: "Pushes a string to a list",
+                vars: [("$key".to_string(), VarAccess::List(ListAccess::Push))],
+                args: vec![
+                    ArgInfo {
+                        name: "key".to_string(),
+                        default: None,
+                        description: "The key to set".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: native_push_list
+            },
+            {
+                name: "read-list",
+                desc: "Reads all strings from a list",
+                vars: [("$key".to_string(), VarAccess::List(ListAccess::Read))],
+                args: vec![
+                    ArgInfo {
+                        name: "key".to_string(),
+                        default: None,
+                        description: "The key to set".to_string(),
+                        r#type: PrimitiveArgType::String.into()
+                    }
+                ],
+                func: native_read_list
+            }
+        ]
+    }
 }
 
 /// Returns a string containing the body of this invocation. This is the "leaf" call; no tree will

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -26,7 +26,7 @@
 /// }
 /// ```
 macro_rules! define_native_packages {
-    ($($name:expr => { desc: $desc:expr, transforms: [ $({name: $transform:expr, desc: $tdesc:expr, vars: $vars:expr, args: $arg_info:expr, func: $handler:ident}),* $(,)? ]})*) => {
+    ($($name:expr => { desc: $desc:expr, transforms: [ $({name: $transform:expr, desc: $tdesc:expr, black_box: $black_box:expr, vars: $vars:expr, args: $arg_info:expr, func: $handler:ident}),* $(,)? ]})*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
             vec![
                 $(
@@ -41,7 +41,8 @@ macro_rules! define_native_packages {
                                     to: vec![],
                                     description: Some($tdesc.to_string()),
                                     arguments: $arg_info,
-                                    variables: $vars.into()
+                                    variables: $vars.into(),
+                                    black_box: $black_box
                                 }),
                             )*
                         ]

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -26,7 +26,7 @@
 /// }
 /// ```
 macro_rules! define_native_packages {
-    ($($name:expr, $desc:expr => { $($transform:expr, $tdesc:expr, $vars:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
+    ($($name:expr => { desc: $desc:expr, transforms: [ $({name: $transform:expr, desc: $tdesc:expr, vars: $vars:expr, args: $arg_info:expr, func: $handler:ident}),* $(,)? ]})*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
             vec![
                 $(

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -161,18 +161,17 @@ pub enum Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            // Lists and sets are encoded as JSON values in order to escape ','
             Value::Set(items) => {
-                for (i, item) in items.iter().enumerate() {
-                    write!(f, "{item}")?;
-                    if i != items.len() - 1 {
-                        write!(f, ",")?;
-                    }
-                }
+                let json_list: serde_json::Value = items.into_iter().cloned().collect();
+                write!(f, "{}", json_list)
             }
-            Value::List(items) => write!(f, "{}", items.join(","))?,
-            Value::Constant(value) => write!(f, "{value}")?,
+            Value::List(items) => {
+                let json_list: serde_json::Value = items.clone().into();
+                write!(f, "{}", json_list)
+            }
+            Value::Constant(value) => write!(f, "{value}"),
         }
-        Ok(())
     }
 }
 

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -10,7 +10,7 @@ pub struct VariableStore(HashMap<(String, VarType), Value>);
 
 impl VariableStore {
     pub fn get(&self, name: &str, ty: &VarType) -> Option<&Value> {
-        self.0.get(&(name, ty) as &dyn VariableTrait)
+        self.0.get(&(name, ty) as &dyn AsVariable)
     }
 
     /// Clears the variable store
@@ -39,33 +39,33 @@ pub type Variable = (String, VarType);
 /// having to clone. See: https://stackoverflow.com/questions/45786717/how-to-implement-hashmap-with-two-keys/45795699#45795699
 /// We lose a bit of performance due to dynamic dispatch but I think it should be rather negligible, especially since other options
 /// (nested or multiple hashmaps) has their problems performance
-trait VariableTrait {
+trait AsVariable {
     fn name(&self) -> &str;
     fn ty(&self) -> &VarType;
 }
 
-impl<'a> Borrow<dyn VariableTrait + 'a> for (String, VarType) {
-    fn borrow(&self) -> &(dyn VariableTrait + 'a) {
+impl<'a> Borrow<dyn AsVariable + 'a> for (String, VarType) {
+    fn borrow(&self) -> &(dyn AsVariable + 'a) {
         self
     }
 }
 
-impl Hash for (dyn VariableTrait + '_) {
+impl Hash for (dyn AsVariable + '_) {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().hash(state);
         self.ty().hash(state);
     }
 }
 
-impl PartialEq for (dyn VariableTrait + '_) {
+impl PartialEq for (dyn AsVariable + '_) {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name() && self.ty() == other.ty()
     }
 }
 
-impl Eq for (dyn VariableTrait + '_) {}
+impl Eq for (dyn AsVariable + '_) {}
 
-impl VariableTrait for (String, VarType) {
+impl AsVariable for (String, VarType) {
     fn name(&self) -> &str {
         &self.0
     }
@@ -74,7 +74,7 @@ impl VariableTrait for (String, VarType) {
     }
 }
 
-impl VariableTrait for (&str, &VarType) {
+impl AsVariable for (&str, &VarType) {
     fn name(&self) -> &str {
         self.0
     }
@@ -83,7 +83,7 @@ impl VariableTrait for (&str, &VarType) {
     }
 }
 
-impl VariableTrait for (&String, &VarType) {
+impl AsVariable for (&String, &VarType) {
     fn name(&self) -> &str {
         self.0
     }

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -1,23 +1,20 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
-// This is, for now, a placeholder file for variables. The data types it contains is (some) of the
-// once it will contain when the variable store is actually implemented.
-
-// The type of a variable
+/// The type of a variable
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum VarType {
-    // Set<String>, a collection of unordered unique strings, like for imports and such
+    /// Set<String>, a collection of unordered unique strings, like for imports and such
     Set,
-    // List<String>, a list of ordered strings ordered top-to-bottom in order of writes in the
-    // document, for headings and such
+    /// List<String>, a list of ordered strings ordered top-to-bottom in order of writes in the
+    /// document, for headings and such
     List,
-    // Constant is a variable type that may only be written once
+    /// Constant is a variable type that may only be written once
     Constant,
 }
 
-// This is the type of accesses that a transform may request to a certain variable
-// The enum names here are used as the "type" field in the manifest
+/// This is the type of accesses that a transform may request to a certain variable
+/// The enum names here are used as the "type" field in the manifest
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "access", rename_all = "lowercase")]
 pub enum VarAccess {
@@ -80,8 +77,9 @@ impl PartialOrd for VarAccess {
     }
 }
 
-// Note we can have two different variables with the same name
-// if they have different types
+/// A identifier and type of a variable.
+/// Note we can have two different variables with the same name
+/// if they have different types
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Variable(pub String, pub VarType);
 

--- a/core/src/variables.rs
+++ b/core/src/variables.rs
@@ -163,6 +163,17 @@ pub enum VarType {
     Constant,
 }
 
+impl fmt::Display for VarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            VarType::Set => "set",
+            VarType::List => "list",
+            VarType::Constant => "const",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 /// This is the type of accesses that a transform may request to a certain variable
 /// The enum names here are used as the "type" field in the manifest
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -170,6 +181,7 @@ pub enum VarType {
 pub enum VarAccess {
     Set(SetAccess),
     List(ListAccess),
+    #[serde(alias = "const")]
     Constant(ConstantAccess),
 }
 
@@ -188,6 +200,16 @@ impl VarAccess {
             VarAccess::Set(_) => VarType::Set,
             VarAccess::List(_) => VarType::List,
             VarAccess::Constant(_) => VarType::Constant,
+        }
+    }
+
+    /// Returns true if it is a read access
+    pub fn is_read(&self) -> bool {
+        match self {
+            VarAccess::Set(SetAccess::Read) => true,
+            VarAccess::List(ListAccess::Read) => true,
+            VarAccess::Constant(ConstantAccess::Read) => true,
+            _ => false,
         }
     }
 }

--- a/packages/code/src/main.rs
+++ b/packages/code/src/main.rs
@@ -75,7 +75,7 @@ fn get_theme(input: &Value) -> String {
 
     // use env as a fallback if possible
     if theme == "default" {
-        if let Ok(value) = env::var("const_code_theme") {
+        if let Ok(value) = env::var("code_theme") {
             // also ensure that the env variable was set to a valid theme
             if [
                 "ocean-dark",

--- a/packages/code/src/main.rs
+++ b/packages/code/src/main.rs
@@ -42,7 +42,7 @@ fn manifest() {
                     {"name": "bg", "default": "default", "description": "Background of the code section"},
                 ],
                 "variables": {
-                    "code_theme": {"type": "constant", "access": "read"}
+                    "code_theme": {"type": "const", "access": "read"}
                 }
             }
         ]


### PR DESCRIPTION
We want to inform the scheduler about transforms that produces arbitrary content (that may access any variable) so these modules can be evaluated first. I'm calling the property `black-box` for now tto avoid to much bikeshedding, but I agree with @CMDJojo that we should probably use another name. I think his suggestions are good, maybe `arbitrary_content` or `unrestricted_var_access` could work too? I don't really have a strong opinion.

We also want to make sure that packages can't lie about what variables they access and break the scheduling. We will likely have some sort of object that describes the variable privileges that the module has and let new elements that are spawned by that element inherit the same privileges and then check for errors later when evaluating those new elements)  

A simple test case for the `black-box` property would be:
```
[inline_content]{
    [list-push foo] 1
}


[list-push foo] 2

[list-read foo]
```

Testing the privilege system could look something like this perhaps:
```
[id_functions_without_var_access]
[inline_content] inline content requires full access since it may contain anything
```

