### PR TITLE
GH-225: Implement `unknown_content` for transforms

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
 
     struct UnimplementedResolver;
     impl Resolve for UnimplementedResolver {
-        fn resolve_all(&self, paths: Vec<ResolveTask>) {
+        fn resolve_all(&self, _: Vec<ResolveTask>) {
             unimplemented!()
         }
     }
@@ -338,7 +338,8 @@ mod tests {
                         r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()])
                     },
                 ],
-                variables: HashMap::new()
+                variables: HashMap::new(),
+                unknown_content: true
             }],
         };
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -21,6 +21,9 @@ pub struct Transform {
     pub arguments: Vec<ArgInfo>,
     #[serde(default)]
     pub variables: HashMap<String, VarAccess>,
+    #[serde(default)]
+    #[serde(rename = "unknown-content")]
+    pub unknown_content: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/core/src/package_store.rs
+++ b/core/src/package_store.rs
@@ -351,14 +351,7 @@ impl PackageStore {
         include_entries: bool,
         include_list: &[String],
     ) -> Result<(), CoreError> {
-        for transform @ Transform {
-            from,
-            to,
-            description: _,
-            arguments: _,
-            variables: _,
-        } in &pkg.info.transforms
-        {
+        for transform @ Transform { from, to, .. } in &pkg.info.transforms {
             if include_entries == include_list.contains(from) {
                 for output_format in to {
                     match output_format {

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -39,7 +39,9 @@ define_native_packages! {
     "Provides core functionality such as raw output, errors and warnings" => {
         "raw",
         "Outputs the body text as-is into the output document",
-        [], vec![] => native_raw,
+        [],
+        vec![],
+        false => native_raw,
         "warning",
         "Adds a compilation warning to the list of all warnings that have occurred during compilation",
         [],
@@ -62,7 +64,7 @@ define_native_packages! {
                 description: "The input given to the module when it failed".to_string(),
                 r#type: PrimitiveArgType::String.into()
             },
-        ] => native_warn,
+        ], false => native_warn,
         "error",
         "Adds a compilation error to the list of all errors that have occurred during compilation",
         [],
@@ -85,16 +87,16 @@ define_native_packages! {
                 description: "The input given to the module when it failed".to_string(),
                 r#type: PrimitiveArgType::String.into()
             },
-        ] => native_err
+        ], false => native_err
     };
     "reparse",
     "Provides an interface to the built-in ModMark parser" => {
         "inline_content",
         "Parses the content as inline-content, as if it was in a paragraph. The result may contain text, smart punctuation, inline module expressions and tags",
-        [], vec![] => native_inline_content,
+        [], vec![], true => native_inline_content,
         "block_content",
         "Parses the content as block-content, as if it was in the body of the document. The result may contain paragraphs containing inline content and multiline module expressions",
-        [], vec![] => native_block_content,
+        [], vec![], true => native_block_content,
     };
     "env",
     "[Temporary] Provides access to setting environment variables" => {
@@ -108,7 +110,7 @@ define_native_packages! {
                 description: "The key to set".to_string(),
                 r#type: PrimitiveArgType::String.into()
             }
-        ] => native_push_list,
+        ], false => native_push_list,
         "read-list",
         "Reads all strings from a list",
         [("$key".to_string(), VarAccess::List(ListAccess::Read))],
@@ -119,7 +121,7 @@ define_native_packages! {
                 description: "The key to set".to_string(),
                 r#type: PrimitiveArgType::String.into()
             }
-        ] => native_read_list,
+        ], false => native_read_list,
     };
 }
 

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -26,7 +26,7 @@
 /// }
 /// ```
 macro_rules! define_native_packages {
-    ($($name:expr, $desc:expr => { $($transform:expr, $tdesc:expr, $vars:expr, $arg_info:expr => $handler:ident),* $(,)? };)*) => {
+    ($($name:expr, $desc:expr => { $($transform:expr, $tdesc:expr, $vars:expr, $arg_info:expr, $ukwn:expr => $handler:ident),* $(,)? };)*) => {
         pub fn native_package_list() -> Vec<PackageInfo> {
             vec![
                 $(
@@ -41,7 +41,8 @@ macro_rules! define_native_packages {
                                     to: vec![],
                                     description: Some($tdesc.to_string()),
                                     arguments: $arg_info,
-                                    variables: $vars.into()
+                                    variables: $vars.into(),
+                                    unknown_content: $ukwn
                                 }),
                             )*
                         ]

--- a/packages/files/src/main.rs
+++ b/packages/files/src/main.rs
@@ -79,6 +79,7 @@ fn manifest() {
                     "from": "include",
                     "to": ["any"],
                     "arguments": [],
+                    "unknown-content": true
                 }
             ]
             }

--- a/packages/flow/src/main.rs
+++ b/packages/flow/src/main.rs
@@ -40,7 +40,8 @@ fn manifest() {
                                 "
                         },
                     ],
-                },
+                    "unknown-content": true
+                }
             ]
             }
         )

--- a/packages/layout/src/main.rs
+++ b/packages/layout/src/main.rs
@@ -53,7 +53,8 @@ fn manifest() {
                             be cropped if used without wrapping."
                         },
                         {"name": "wrap", "default": "false", "type": ["true", "false"], "description": "Decides if items will wrap around to new rows."},
-                    ]
+                    ],
+                    "unknown-content": true
                 },
                 {
                     "from": "center",
@@ -72,7 +73,8 @@ fn manifest() {
                             be cropped if used without wrapping."
                         },
                         {"name": "wrap", "default": "false", "type": ["true", "false"], "description": "Decides if items will wrap around to new rows."},
-                    ]
+                    ],
+                    "unknown-content": true
                 }
             ]
             }

--- a/packages/list/src/main.rs
+++ b/packages/list/src/main.rs
@@ -38,6 +38,7 @@ fn manifest() {
                             "type": "unsigned_integer"
                         }
                     ],
+                    "unknown-content": true
                 },
             ]
             }

--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -56,6 +56,7 @@ fn manifest() {
                         {"name": "delimiter", "default": "|", "description": "The delimiter between cells"},
                         {"name": "strip_whitespace", "default": "true", "type": ["true", "false"], "description": "true/false to strip/don't strip whitespace in cells"}
                     ],
+                    "unknown-content": true
                 }
             ]
             }


### PR DESCRIPTION
This PR resolves GH-225 by adding an optional field `unknown-content` to the manifest for a transform. Setting this field to true ensures that that module is executed before any module which has that field set to false.

Take this as an example:
```
[push-list abc] a

[inline_content]
[push-list abc] b

[read-list abc]
```

We have three modules, `push-list`, `inline_content` and `read-list`. We know that the scheduler will ensure `push-list` occurs before `read-list`, but the scheduler doesn't know anything about `inline_content` so it may schedule it whenever it sees fit. If it schedules it before evaluating `read-list`, the dependency will be picked up as expected but if it schedules it later, `read-list` would already have been executed.

This PR changes it so that `inline_content` in this case has *unknown content*, meaning that it will be executed before anything with known content. Thus, this hazard is no more.

This PR is ready for review immediately