### PR TITLE
Use set for LaTeX imports

### DIFF
--- a/packages/latex/tests/test_bold.json
+++ b/packages/latex/tests/test_bold.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\textbf{",
         {
-            "data": "\\textbf{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
+        },
+        "}"
     ]
 }

--- a/packages/latex/tests/test_document.json
+++ b/packages/latex/tests/test_document.json
@@ -23,10 +23,8 @@
   ],
   "__test_transform_to": "latex",
   "__test_expected_result": [
-    {
-      "data": "\\documentclass{article}\n\n\\usepackage[normalem]{ulem}\n\\usepackage{enumitem}\n\\usepackage[hidelinks]{hyperref}\n\\usepackage{float}\n\\usepackage{graphicx}\n\n\\begin{document}\n",
-      "name": "raw"
-    },
+    "\\documentclass{article}",
+    "\n\n\\begin{document}\n\n",
     {
       "arguments": {},
       "data": "Raw stuff",
@@ -45,9 +43,6 @@
       ],
       "name": "__bold"
     },
-    {
-      "data": "\n\\end{document}",
-      "name": "raw"
-    }
+    "\n\n\\end{document}"
   ]
 }

--- a/packages/latex/tests/test_italic.json
+++ b/packages/latex/tests/test_italic.json
@@ -11,20 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\textit{",
         {
-            "data": "\\textit{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
-        
+        },
+        "}"
     ]
 }

--- a/packages/latex/tests/test_strikethrough.json
+++ b/packages/latex/tests/test_strikethrough.json
@@ -11,20 +11,20 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\sout{",
         {
-            "data": "\\sout{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
-        
+        },
+        "}",
+        {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage[normalem]{ulem}",
+            "name": "set-add"
+        }
     ]
 }

--- a/packages/latex/tests/test_subscript.json
+++ b/packages/latex/tests/test_subscript.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\textsubscript{",
         {
-            "data": "\\textsubscript{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
+        },
+        "}"
     ]
 }

--- a/packages/latex/tests/test_superscript.json
+++ b/packages/latex/tests/test_superscript.json
@@ -11,20 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\textsuperscript{",
         {
-            "data": "\\textsuperscript{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
-        
+        },
+        "}"
     ]
 }

--- a/packages/latex/tests/test_underlined.json
+++ b/packages/latex/tests/test_underlined.json
@@ -11,20 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\underline{",
         {
-            "data": "\\underline{",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "}",
-            "name": "raw"
-          }
-        
+        },
+        "}"
     ]
 }

--- a/packages/latex/tests/test_verbatim.json
+++ b/packages/latex/tests/test_verbatim.json
@@ -11,20 +11,13 @@
     ],
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\\verb|",
         {
-            "data": "\\verb|",
-            "name": "raw"
-          },
-          {
             "arguments": {},
             "data": "Hello, world",
             "inline": true,
             "name": "__text"
-          },
-          {
-            "data": "|",
-            "name": "raw"
-          }
-        
+        },
+        "|"
     ]
 }

--- a/packages/link/src/main.rs
+++ b/packages/link/src/main.rs
@@ -2,6 +2,11 @@ use std::env;
 use std::io::{self, Read};
 
 use serde_json::{json, Value};
+
+macro_rules! import {
+    ($e:expr) => {json!({"name": "set-add", "arguments": {"name": "imports"}, "data": $e})}
+}
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     let action = &args[0];
@@ -29,6 +34,9 @@ fn manifest() {
                     "arguments": [
                         {"name": "label", "default": "", "description": "Label for link"}
                     ],
+                    "variables": {
+                        "imports": {"type": "set", "access": "add"}
+                    }
                 },
                 {
                     "from": "label",
@@ -99,6 +107,7 @@ fn transform_link(to: &str) {
 
             let output = json!([
                 {"name": "raw", "data": data},
+                import![r"\usepackage[hidelinks]{hyperref}"]
             ]);
             print!("{output}");
         }

--- a/packages/link/tests/latex_test_label.json
+++ b/packages/link/tests/latex_test_label.json
@@ -10,6 +10,13 @@
     {
       "data": "\\href{https://google.com}{Google}",
       "name": "raw"
+    },
+    {
+      "arguments": {
+        "name": "imports"
+      },
+      "data": "\\usepackage[hidelinks]{hyperref}",
+      "name": "set-add"
     }
   ]
 }

--- a/packages/link/tests/latex_test_nolabel.json
+++ b/packages/link/tests/latex_test_nolabel.json
@@ -10,6 +10,13 @@
     {
       "data": "\\href{https://google.com}{https://google.com}",
       "name": "raw"
+    },
+    {
+      "arguments": {
+        "name": "imports"
+      },
+      "data": "\\usepackage[hidelinks]{hyperref}",
+      "name": "set-add"
     }
   ]
 }

--- a/packages/list/src/lib.rs
+++ b/packages/list/src/lib.rs
@@ -2,6 +2,10 @@ use std::str::FromStr;
 
 use serde_json::{json, Value};
 
+macro_rules! import {
+    ($e:expr) => {json!({"name": "set-add", "arguments": {"name": "imports"}, "data": $e})}
+}
+
 #[derive(Debug)]
 pub struct InvalidListError;
 
@@ -249,6 +253,7 @@ impl List {
     fn to_latex_vec(&self) -> Vec<Value> {
         let mut json_vec: Vec<Value> = vec![];
 
+        json_vec.push(import!(r"\usepackage{enumitem}"));
         json_vec.push(json!({"name": "raw", "data": self.opening_latex_command()}));
 
         for item in &self.items {

--- a/packages/list/src/main.rs
+++ b/packages/list/src/main.rs
@@ -38,6 +38,9 @@ fn manifest() {
                             "type": "unsigned_integer"
                         }
                     ],
+                    "variables": {
+                        "imports": {"type": "set", "access": "add"}
+                    },
                     "unknown-content": true
                 },
             ]

--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -22,6 +22,10 @@ macro_rules! inline_content {
     }
 }
 
+macro_rules! import {
+    ($e:expr) => {json!({"name": "set-add", "arguments": {"name": "imports"}, "data": $e})}
+}
+
 // Entry point
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -38,8 +42,7 @@ fn main() {
 fn manifest() {
     print!(
         "{}",
-        json!(
-            {
+        json!({
             "name": "table",
             "version": "0.1",
             "description": "This package supports [table] modules",
@@ -58,9 +61,11 @@ fn manifest() {
                     ],
                     "unknown-content": true
                 }
-            ]
+            ],
+            "variables": {
+                "imports": {"type": "set", "access": "add"}
             }
-        )
+        })
     );
 }
 
@@ -272,6 +277,7 @@ impl Table<'_> {
             format!("|{}|", self.alignment.latex_str(self.width, false))
         };
 
+        vec.push(import!(r"\usepackage{float}"));
         vec.push(raw!("\\begin{table}[H]\n"));
         vec.push(raw!("\\centering\n"));
         vec.push(raw!(format!("\\begin{{tabular}} {{ {} }}\n", col_key)));

--- a/packages/table/tests/test_all_border_latex.json
+++ b/packages/table/tests/test_all_border_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_caption_label_latex.json
+++ b/packages/table/tests/test_caption_label_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_caption_latex.json
+++ b/packages/table/tests/test_caption_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_heading_latex.json
+++ b/packages/table/tests/test_heading_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_horizontal_border_latex.json
+++ b/packages/table/tests/test_horizontal_border_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_label_latex.json
+++ b/packages/table/tests/test_label_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_mixed_alignment_latex.json
+++ b/packages/table/tests/test_mixed_alignment_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_outer_border_latex.json
+++ b/packages/table/tests/test_outer_border_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_right_alignment_latex.json
+++ b/packages/table/tests/test_right_alignment_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },

--- a/packages/table/tests/test_vertical_border_latex.json
+++ b/packages/table/tests/test_vertical_border_latex.json
@@ -14,6 +14,13 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage{float}",
+            "name": "set-add"
+        },
+        {
             "data": "\\begin{table}[H]\n",
             "name": "raw"
         },


### PR DESCRIPTION
This PR resolves GH-248 by adding an `imports` set to store what imports are needed. Entries are added to this set via the `[set-add]` module, and a macro was made to simplify the use of this:
```rust
macro_rules! import {
    ($e:expr) => {json!({"name": "set-add", "arguments": {"name": "imports"}, "data": $e})}
}
```
The macro is similar to the `raw!` macro, but generates a `set-add` instead.

The transforms that relies on imports have been updated to push their imports to the set. This applies to all packages.

All previously hardcoded packages are now removed from the prelude in `__document`, and when transforming that, the imports are read and parsed as a JSON array (or as an empty array if the key doesn't exist), and a prelude is created with those imports.

This PR is ready for review immediately.