### PR TITLE
Variable based conditional compilation

### DIFF
--- a/packages/flow/src/main.rs
+++ b/packages/flow/src/main.rs
@@ -40,6 +40,7 @@ fn manifest() {
                                 "
                         },
                     ],
+                    "unknown-content": true
                 },
                 {
                     "from": "if-const",
@@ -76,7 +77,8 @@ fn manifest() {
                     ],
                     "variables": {
                         "$constant": {"type": "constant", "access": "read"}
-                    }
+                    },
+                    "unknown-content": true
                 },
                 {
                     "from": "if-set",
@@ -116,7 +118,8 @@ fn manifest() {
                     ],
                     "variables": {
                         "$set": {"type": "set", "access": "read"}
-                    }
+                    },
+                    "unknown-content": true
                 },
                 {
                     "from": "if-list",
@@ -156,7 +159,8 @@ fn manifest() {
                     ],
                     "variables": {
                         "$list": {"type": "list", "access": "read"}
-                    }
+                    },
+                    "unknown-content": true
                 }
             ]
             }

--- a/packages/flow/src/main.rs
+++ b/packages/flow/src/main.rs
@@ -78,6 +78,86 @@ fn manifest() {
                         "$constant": {"type": "constant", "access": "read"}
                     }
                 },
+                {
+                    "from": "if-set",
+                    "to": ["any"],
+                    "description": "Conditionally compile content based on a set. Example: [if-set imports contains-all foo,bar,baz]",
+                    "arguments": [
+                        {
+                            "name": "set",
+                            "description":
+                                "The set to use for conditional compilation"
+                        },
+                        {
+                            "name": "check",
+                            "description": "Specifies the check to do to the value. \
+                            does-not-contain: compile the content if the set does not contain the given string. \
+                            contains: compile the content if the set contains the given string. \
+                            contains-all: compile the content if the set contains all of the comma-separated strings. \
+                            contains-any: compile the content if the set contains any of the comma-separated strings. \
+                            contains-none: compile the content if the set contains none of the comma-separated strings. \
+                            non-empty: compile the content if the set is defined and has at least one string. \
+                            empty-or-undefined: compile the content if the set is undefined or is empty
+                            ",
+                            "default": "non-empty",
+                            "type": ["does-not-contain", "contains", "contains-all", "contains-any", "contains-none", "non-empty", "empty-or-undefined"]
+                        },
+                        {
+                            "name": "value",
+                            "description": "Specifies the value to compare to. If the operation allows for multiple values, they should be comma-separated",
+                            "default": ""
+                        },
+                        {
+                            "name": "case-sensitive",
+                            "description": "Specifies if 'equals/differs' checks are case sensitive.",
+                            "default": "case-sensitive",
+                            "type": ["case-sensitive", "case-insensitive"]
+                        }
+                    ],
+                    "variables": {
+                        "$set": {"type": "set", "access": "read"}
+                    }
+                },
+                {
+                    "from": "if-list",
+                    "to": ["any"],
+                    "description": "Conditionally compile content based on a list. Example: [if-list authors contains Jonathan]",
+                    "arguments": [
+                        {
+                            "name": "list",
+                            "description":
+                                "The list to use for conditional compilation"
+                        },
+                        {
+                            "name": "check",
+                            "description": "Specifies the check to do to the value. \
+                            does-not-contain: compile the content if the list does not contain the given string. \
+                            contains: compile the content if the list contains the given string. \
+                            contains-all: compile the content if the list contains all of the comma-separated strings. \
+                            contains-any: compile the content if the list contains any of the comma-separated strings. \
+                            contains-none: compile the content if the list contains none of the comma-separated strings. \
+                            non-empty: compile the content if the list is defined and has at least one string. \
+                            empty-or-undefined: compile the content if the list is undefined or is empty
+                            ",
+                            "default": "non-empty",
+                            "type": ["does-not-contain", "contains", "contains-all", "contains-any", "contains-none", "non-empty", "empty-or-undefined"]
+                        },
+                        {
+                            "name": "value",
+                            "description": "Specifies the value to compare to. If the operation allows for multiple values, they should be comma-separated",
+                            "default": ""
+                        },
+                        {
+                            "name": "case-sensitive",
+                            "description": "Specifies if 'equals/differs' checks are case sensitive.",
+                            "default": "case-sensitive",
+                            "type": ["case-sensitive", "case-insensitive"]
+                        }
+                    ],
+                    "variables": {
+                        "$list": {"type": "list", "access": "read"}
+                    }
+                }
             ]
             }
         )
@@ -94,6 +174,8 @@ fn transform(from: &str, to: &str) {
     match from {
         "if" => transform_if(to, input),
         "if-const" => transform_if_const(input),
+        "if-set" => transform_if_collection(input, true),
+        "if-list" => transform_if_collection(input, false),
         other => {
             eprintln!("Package does not support {other}");
         }
@@ -123,6 +205,57 @@ fn transform_if_const(input: Value) {
         (cmp_val == var_val) == (check == "equals")
     } else {
         false
+    };
+
+    if compile {
+        let inline = input["inline"].as_bool().unwrap();
+        let body = input["data"].as_str().unwrap();
+        let json = if inline {
+            json!({"name": "inline_content", "data": body}).to_string()
+        } else {
+            json!({"name": "block_content", "data": body}).to_string()
+        };
+        print!("[{json}]")
+    } else {
+        print!("[]")
+    }
+}
+
+fn transform_if_collection(input: Value, is_set: bool) {
+    let key = input["arguments"][if is_set { "set" } else { "list" }]
+        .as_str()
+        .unwrap();
+    let mut env_values: Vec<String> =
+        serde_json::from_str(&env::var(key).unwrap_or("[]".to_string())).unwrap();
+    let case_sensitive = input["arguments"]["case-sensitive"].as_str() == Some("case-sensitive");
+    if !case_sensitive {
+        env_values.iter_mut().for_each(|x| *x = x.to_lowercase())
+    }
+
+    let check = input["arguments"]["check"].as_str().unwrap();
+    let value = input["arguments"]["value"].as_str().unwrap();
+
+    let compile = if check == "non-empty" || check == "empty-or-undefined" {
+        env_values.is_empty() == (check == "empty-or-undefined")
+    } else if check == "contains" || check == "does-not-contain" {
+        // cannot use .contains here due to coercion rules
+        env_values.iter().any(|v| v == value) == (check == "contains")
+    } else {
+        let split_values: Vec<_> = if case_sensitive {
+            value
+                .split_terminator(",")
+                .map(ToString::to_string)
+                .collect()
+        } else {
+            value.split_terminator(",").map(str::to_lowercase).collect()
+        };
+
+        match check {
+            "contains-all" => split_values.iter().all(|v| env_values.contains(v)),
+            "contains-any" => split_values.iter().any(|v| env_values.contains(v)),
+            "contains-none" => split_values.iter().all(|v| !env_values.contains(v)),
+            _ => unreachable!("Invalid check {check}"),
+        }
     };
 
     if compile {

--- a/packages/flow/src/main.rs
+++ b/packages/flow/src/main.rs
@@ -56,12 +56,12 @@ fn manifest() {
                             "name": "check",
                             "description": "Specifies the check to do to the value. \
                             equals: compile the content if the variable equals the given value. \
-                            differs-to: compile the content if the variable differs from the given value. \
+                            differs-from: compile the content if the variable differs from the given value. \
                             defined: compile the content if the variable is defined. \
                             undefined: compile the content if the variable is undefined.
                             ",
                             "default": "defined",
-                            "type": ["equals", "differs-to", "defined", "undefined"]
+                            "type": ["equals", "differs-from", "defined", "undefined"]
                         },
                         {
                             "name": "value",

--- a/packages/flow/tests/test_list_contains.json
+++ b/packages/flow/tests/test_list_contains.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-list",
+    "data": "This should not be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "contains",
+        "value": "bar",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_list_contains_all.json
+++ b/packages/flow/tests/test_list_contains_all.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-list",
+    "data": "This should not be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "contains-all",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_list_contains_any.json
+++ b/packages/flow/tests/test_list_contains_any.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-list",
+    "data": "This should not be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "contains-any",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_list_contains_none.json
+++ b/packages/flow/tests/test_list_contains_none.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-list",
+    "data": "This should be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "contains-none",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}

--- a/packages/flow/tests/test_list_defined.json
+++ b/packages/flow/tests/test_list_defined.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-list",
+    "data": "This should not be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "non-empty",
+        "value": "",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_list_does_not_contain.json
+++ b/packages/flow/tests/test_list_does_not_contain.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-list",
+    "data": "This should be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "does-not-contain",
+        "value": "bar",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}

--- a/packages/flow/tests/test_list_undefined.json
+++ b/packages/flow/tests/test_list_undefined.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-list",
+    "data": "This should be parsed",
+    "arguments": {
+        "list": "foo",
+        "check": "empty-or-undefined",
+        "value": "",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}

--- a/packages/flow/tests/test_set_contains.json
+++ b/packages/flow/tests/test_set_contains.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-set",
+    "data": "This should not be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "contains",
+        "value": "bar",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_set_contains_all.json
+++ b/packages/flow/tests/test_set_contains_all.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-set",
+    "data": "This should not be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "contains-all",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_set_contains_any.json
+++ b/packages/flow/tests/test_set_contains_any.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-set",
+    "data": "This should not be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "contains-any",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_set_contains_none.json
+++ b/packages/flow/tests/test_set_contains_none.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-set",
+    "data": "This should be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "contains-none",
+        "value": "bar,baz",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}

--- a/packages/flow/tests/test_set_defined.json
+++ b/packages/flow/tests/test_set_defined.json
@@ -1,0 +1,13 @@
+{
+    "name": "if-set",
+    "data": "This should not be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "non-empty",
+        "value": "",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_set_does_not_contain.json
+++ b/packages/flow/tests/test_set_does_not_contain.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-set",
+    "data": "This should be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "does-not-contain",
+        "value": "bar",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}

--- a/packages/flow/tests/test_set_undefined.json
+++ b/packages/flow/tests/test_set_undefined.json
@@ -1,0 +1,18 @@
+{
+    "name": "if-set",
+    "data": "This should be parsed",
+    "arguments": {
+        "set": "foo",
+        "check": "empty-or-undefined",
+        "value": "",
+        "case-sensitive": "case-sensitive"
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "inline_content",
+            "data": "This should be parsed"
+        }
+    ]
+}


### PR DESCRIPTION
This PR resolves #250 by adding three new modules, `[if-const]`, `[if-list]` and `[if-set]`. They all have he same general syntax, `[if-<type> <variable> [check] [value] [case-sensitive]]` where `<type>` is the type (`const`/`list`/`set`), `<variable>` is the name of the variable to check, `[check]` is the way to check the variable (like the operator) and `[value]` is the value to check against. `[case-sensitive]` is set to `case-sensitive` by default and affects all string comparisons.

`[if-const]` has these checks:
* **defined** succeeds if the constant is defined (default)
* **undefined** succeeds if the constant is undefined
* **equals** succeeds if the constant value equals *value*
* ~~differs-to~~ **differs-from** succeeds if the constant value differs from *value*

Here are some examples:
```
[const-declare foo] abc
[const-declare bar] def

[if-const foo]
Foo is defined!

[if-const foo equals abc]
Foo is 'abc'!

[if-const bar differs-from abc]
Bar differs to 'abc'

[if-const bar equals abc]
This isn't going to be compiled

[if-const xyz undefined]
xyz is undefined
```

`[if-list]` and `[if-set]` has the same checks, and for all intents and purposes the set is just treated as a list. These are the checks available:
* **does-not-contain** succeeds if *value* isn't in the list/set
* **contains** succeed if *value* is in the list/set
* **contains-all** succeed if all comma-separated values is in the list/set
* **contains-any** succeed if any of the comma-separated values are in the list/set
* **contains-none** succeed if none of the comma-separated values is in the list/set
* **non-empty** succeed if the list/set is non-empty (and thus defined, this is default)
* **empty-or-undefined** succeed if the list/set is either empty or undefined

Since it was decided beforehand that it is important to have a distinction between a list/set being undefined and being empty, I am using the term `empty-or-undefined` to signal any of these states.

Here are some examples:
```
[list-push authors] Jonathan
[list-push authors] Eli
[list-push authors] Hugo
[list-push authors] Gustav
[list-push authors] Axel
[list-push authors] Carl

[if-list authors contains-all jonathan,eli,hugo]
This is a case-sensitive search by default so this won't be compiled

[if-list authors contains-all jonathan,eli,hugo case-insensitive]
We have set the authors field correctly!

[if-list authors contains-none Isak,Lars,Fredrik]
There are no authors named Isak, Lars or Fredrik
```

One larger example document:
```
[const-decl theme] dark

[if-const theme equals dark]
This is **//dark theme//**

[if-const theme undefined]
[warning]
Please define theme

[list-push authors] Jonathan
[list-push authors] Eli
[list-push authors] Hugo
[list-push authors] Gustav
[list-push authors] Axel
[list-push authors] Carl

[if-list authors contains Jonathan]
Hi, im Jonathan

[if-list authors contains-all jonathan,hugo,eli]
This is a case-sensitive search by default so this won't be compiled

[if-list authors contains-all jonathan,hugo,eli case-insensitive]
We have set the authors field correctly!

[if-list authors contains-none Isak,Lars,Fredrik]
There are no authors named Isak, Lars or Fredrik

[if-list authors contains-any Isak,Lars,Fredrik,Eli]
(At least) one of Isak, Lars, Fredrik or Eli are mentioned as authors

[if-list foo empty-or-undefined]
List foo is empty!
```