### PR TITLE
GH-252: Add `<meta charset="UTF-8">` to html template

### DIFF
--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -70,6 +70,7 @@ fn transform_document(doc: Value) -> String {
 
     write!(result, "{},", raw!("<!DOCTYPE html>")).unwrap();
     write!(result, "{},", raw!("<html><head><title>Document</title>")).unwrap();
+    write!(result, "{},", raw!("<meta charset=\"UTF-8\">")).unwrap();
 
     write!(result, "{},", raw!("<style>")).unwrap();
     write!(result, "{},", raw!(include_str!("templates/html.css"))).unwrap();

--- a/packages/html/tests/test_document.json
+++ b/packages/html/tests/test_document.json
@@ -32,6 +32,10 @@
       "name": "raw"
     },
     {
+      "data": "<meta charset=\"UTF-8\">",
+      "name": "raw"
+    },
+    {
       "data": "<style>",
       "name": "raw"
     },


### PR DESCRIPTION
Resolves GH-252.