### PR TITLE
GH-254: Add bibliography package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
     "packages/layout",
     "packages/files",
     "packages/flow",
+    "packages/bibliography",
     "playground/web_bindings"
 ]
 

--- a/core/src/std_packages.rs
+++ b/core/src/std_packages.rs
@@ -29,6 +29,7 @@ define_standard_package_loader! {
     "layout",
     "files",
     "flow",
+    "bibliography",
 }
 
 // Here, all native packages are declared. The macro expands to two functions,

--- a/packages/bibliography/Cargo.toml
+++ b/packages/bibliography/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bibliography"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = {version = "1.0.152", features = ["derive"]}
+serde_json = "1.0.93"
+hayagriva = "0.3.0"

--- a/packages/bibliography/customizing_your_bibliography.md
+++ b/packages/bibliography/customizing_your_bibliography.md
@@ -1,0 +1,58 @@
+# Bibliography package
+This is the Bibliography package. It provides support for inline citations with `[cite]`
+and managing a bibliography database and printing a bibliography with `[bibliography]`.
+The included `[bibliography]` module uses [typst/hayagriva](https://github.com/typst/hayagriva)
+as the backend and supports some styles included within.
+
+## How it all works
+The `[cite]` module is 'dumb' and doesn't control how it is displayed at all. It contains
+very little internal logic, and doesn't have access to the bibliography database. More or less,
+it just pushes its argument and body to the list `inline_citations` which, after evaluating
+all `[cite]`s, contains a list of all citations in the document and their content.
+
+Moreover, `[cite]` generates a module which later on reads the variable `inline_citation_labels`,
+which for each citation contains the JSON data the `[cite]` should be replaced with. This means
+that a `[cite]` acknowledges its existence by pushing itself to `inline_citations`, and then
+reads `inline_citation_labels` and represents itself by whatever content it finds in
+`inline_citation_labels` for that specific label.
+
+The `[bibliography]` module is responsible not only for reading and printing the bibliography,
+but also resolving citations. It reads `inline_citations` and, for each citation, pushes one
+label for each (unique) citation. At the time of evaluating `[bibliography]`, it thus has
+access to the bibliography database and all citations and may format all citations and the
+bibliography at its discretion.
+
+## Configuring `[bibliography]`
+`[bibliography]` has four arguments:
+* `style`, which can be set to `IEEE`/`APA`/`MLA`/`Chicago` to configure the style for inline citations and the bibliography.
+* `file`, which can be set to a file to read a BibLaTeX or Hayagriva YAML database from. If this is empty, the body of the module is used as the database.
+* `visibility`, which can be set to `visible`/`hidden` to show or hide the bibliography. Note that since `[bibliography]` is the module resolving inline citations, a `[bibliography]` must exist - this argument allows the user to hide the bibliography while still using inline citations.
+* `unused-entries`, which can be set to `visible`/`hidden` to show or hide entries which aren't cited in the document.
+
+The bibliography and citations themselves are mainly just text-based, so these modules may be
+used regardless of output format. Some bibliography styles needs styling and links, so 
+`__italic`, `__bold` and `[link]` (in addition to `__text`) is needed for the output format.
+Additionally, for HTML and LaTeX, hyperlinks from inline citations to the bibliography entries
+are inserted.
+
+## Making your own `[bibliography]`
+The built-in bibliography module may not be a perfect fit for all use cases. It may be replaced
+like any other module by doing `import std:bibliography hiding bibliography` and importing your
+own. Since the `[cite]` modules doesn't contain much logic but leverages the scheduler in a
+clever way, they may be re-used in a custom `[bibliography]` implementation.
+
+To leverage the `[cite]` system, the `[bibliography]` should declare these variable accesses:
+* `"inline_citations": {"type": "list", "access": "read"}`
+* `"inline_citation_labels": {"type": "set", "access": "add"}`
+
+Then, the module should read the `inline_citations` list to find out what citations are used in
+the text. Each entry is a JSON object containing the keys `key`, which is the database key cited
+and optionally a `note` which is an additional note. `[cite "p. 10"] foo` would be represented
+by `{"key": "foo", "note": "p. 10"}`. The module should generate a citation for each entry in the
+`inline_citations` list, generate output as a JSON array valid as a module output, and then push
+the original JSON concatenated with the output JSON to the set `inline_citation_labels`. It is of
+highest importance that the original JSON **is identical to the one in the original list**,
+otherwise it may not be picked up. The citation `{"key":"modmark"}` may be resolved by pushing
+`{"key":"modmark"}[{"name":"__text","data":"[1]"}]` to `inline_citation_labels`. Since
+`[bibliography]` is free to push any JSON to `inline_citation_labels`, it is in full control of
+how every citation is rendered in the output format.

--- a/packages/bibliography/src/main.rs
+++ b/packages/bibliography/src/main.rs
@@ -1,12 +1,12 @@
+use std::{env, fs};
 use std::borrow::Cow;
 use std::io::{self, Read};
-use std::{env, fs};
 
+use hayagriva::Entry;
 use hayagriva::style::{
     Apa, BibliographyStyle, ChicagoAuthorDate, Citation, CitationStyle, Database, DisplayString,
     Formatting, Ieee, Mla, Numerical,
 };
-use hayagriva::Entry;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -307,7 +307,7 @@ fn read_bibliography(input: &Value) -> Option<Vec<Entry>> {
         return None;
     };
 
-    let bibliography = hayagriva::io::from_biblatex_str(&input_string)
+    let bibliography = hayagriva::io::from_biblatex_str(&without_latex_comments(&input_string))
         .or_else(|e1| hayagriva::io::from_yaml_str(&input_string).map_err(|e2| (e1, e2)));
 
     match bibliography {
@@ -355,4 +355,11 @@ fn display(string: &DisplayString) -> Vec<Value> {
     }
     values.push(text!(&string.value[last_unformatted..]));
     values
+}
+
+fn without_latex_comments(string: &str) -> String {
+    string.lines()
+        .filter(|line| !line.trim_start().starts_with('%'))
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/packages/bibliography/src/main.rs
+++ b/packages/bibliography/src/main.rs
@@ -1,0 +1,358 @@
+use std::borrow::Cow;
+use std::io::{self, Read};
+use std::{env, fs};
+
+use hayagriva::style::{
+    Apa, BibliographyStyle, ChicagoAuthorDate, Citation, CitationStyle, Database, DisplayString,
+    Formatting, Ieee, Mla, Numerical,
+};
+use hayagriva::Entry;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let action = &args[0];
+    match action.as_str() {
+        "manifest" => manifest(),
+        "transform" => transform(&args[1], &args[2]),
+        other => {
+            eprintln!("Invalid action {other}");
+        }
+    }
+}
+
+macro_rules! module {
+    ($name:expr, $data:expr $(,$($args:tt)*)?) => {json!({"name": $name $(,"arguments":$($args)*)*, "data": $data})}
+}
+
+macro_rules! push_citation {
+    ($e:expr) => {module!("list-push", $e, {"name": "inline_citations"})}
+}
+
+macro_rules! add_citation_label {
+    ($a:expr, $b:expr) => {module!("set-add", format!("{}{}", $a, $b), {"name": "inline_citation_labels"})}
+}
+
+macro_rules! cite_label {
+    ($e:expr) => {
+        module!("cite-internal-do-not-use", $e)
+    };
+}
+
+macro_rules! text {
+    ($e:expr) => {
+        module!("__text", $e)
+    };
+}
+
+fn manifest() {
+    print!(
+        "{}",
+        json!(
+            {
+            "name": "bibliography",
+            "version": "0.1",
+            "description": "This package supports bibliographies and in-text citations.",
+            "transforms": [
+                {
+                    "from": "cite",
+                    "to": ["any"],
+                    "arguments": [
+                        {"name": "note", "default": "", "description": "Note to show after citation, such as p. 3"}
+                    ],
+                    "description": "Add an inline citation to one of the sources defined in the bibliography. Example: [cite] modmark",
+                    // "variables": {
+                        // We really want this, but we can't since it would give cyclic dependencies
+                        // together with unknown-content. So, we disable unknown-content
+                        // "inline_citations": {"type": "list", "access": "push"}
+                    // },
+                    "unknown-content": true // This gives cyclic dependencies if enabled together
+                    // with inline_citations/list-push, see below
+                },
+                {
+                    "from": "cite-internal-do-not-use",
+                    "to": ["any"],
+                    "arguments": [],
+                    "description": "Do not use this module",
+                    "variables": {
+                        "inline_citation_labels": {"type": "set", "access": "read"}
+                    }
+                },
+                {
+                    "from": "bibliography",
+                    "to": ["any"],
+                    "description": "Inserts a bibliography into the document. \
+                    This module needs to exist for [cite]s to work properly. \
+                    The bibliography may be read from the BibLaTeX or Hayagriva YAML format, \
+                    from either the body of this module or a file passed in as the \"file\" argument.",
+                    "arguments": [
+                        {"name": "style", "default": "IEEE", "type": ["IEEE", "APA", "MLA", "CMoS"], "description": "The style to have the bibliography in"},
+                        {"name": "file", "default": "", "description": "A file containing BibLaTeX or Hayagriva YAML with the bibliography"},
+                        {"name": "visibility", "default": "shown", "type": ["shown", "hidden"], "description": "Whether the bibliography is 'shown' or 'hidden'. \
+                        Note that a [bibliography] must exist for [cite]s to work, and if you don't want a bibliography in your document, you can set this argument to 'hidden'."}
+                    ],
+                    "variables": {
+                        "inline_citations": {"type": "list", "access": "read"},
+                        "inline_citation_labels": {"type": "set", "access": "add"},
+                        "imports": {"type": "set", "access": "add"}
+                    }
+                }
+            ]
+            }
+        )
+    );
+}
+
+// Cyclic dependencies.
+// Consider this document
+// [cite] a
+// [cite] b
+// If cite is both unknown_content and push access to the list, it means a must happen before
+// b (due to the order they appear in the document, list access is granular).
+// a would expand to one [list-push] and something else, but then we have a [list-push] which is
+// above b, which also requires list pushing to the same list. the [list-push] from a must thus
+// occur before b, but also, b is unknown-content and so it must happen before a. Thus, we have
+// a cyclic dependency.
+
+fn transform(from: &str, to: &str) {
+    let input: Value = {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).unwrap();
+        serde_json::from_str(&buffer).unwrap()
+    };
+
+    match from {
+        "cite" => transform_cite(to, &input),
+        "cite-internal-do-not-use" => transform_cite_label(to, &input),
+        "bibliography" => transform_bibliography(to, &input),
+        other => {
+            eprintln!("Package does not support {other}");
+        }
+    }
+}
+
+// The name Citation clashes with Hayagriva
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InlineCitation<'a> {
+    key: &'a str,
+    note: Option<&'a str>,
+}
+
+fn transform_cite(_to: &str, input: &Value) {
+    let citation = {
+        let key = input["data"].as_str().unwrap();
+        let note = {
+            let arg = input["arguments"]["note"].as_str().unwrap();
+            (!arg.is_empty()).then_some(arg)
+        };
+        let citation = InlineCitation { key, note };
+        serde_json::to_string(&citation).unwrap()
+    };
+
+    let output = json!([push_citation!(&citation), cite_label!(&citation)]);
+
+    println!("{output}");
+}
+
+fn transform_cite_label(_to: &str, input: &Value) {
+    let citation = input["data"].as_str().unwrap();
+
+    let labels: Vec<String> = {
+        let var = env::var("inline_citation_labels").unwrap_or("[]".to_string());
+        serde_json::from_str(&var).unwrap()
+    };
+
+    if let Some(label) = labels.iter().find_map(|s| s.strip_prefix(citation)) {
+        println!("{label}");
+    } else {
+        eprintln!("You must add a [bibliography] for [cite]s to work. If you don't want it visible, do [bibliography visibility=hidden]");
+    }
+}
+
+fn transform_bibliography(_to: &str, input: &Value) {
+    let Some(bibliography) = read_bibliography(input) else { return; };
+
+    // This is the citations (i.e [cite]s) used in the text
+    let citations: Vec<String> = {
+        let var = env::var("inline_citations").unwrap_or("[]".to_string());
+        serde_json::from_str(&var).unwrap()
+    };
+
+    // This is our database of all entries (like a db containing all biblatex-entries)
+    let mut database = Database::from_entries(bibliography.iter());
+
+    // What style to use (IEEE, APA etc)
+    let style_arg = input["arguments"]["style"].as_str().unwrap();
+
+    // Unwrap is safe since Core has checked enums already
+    let (bibliography_style, mut citation_style) = get_styles(style_arg).unwrap();
+
+    let mut output: Vec<Value> = vec![];
+
+    for citation_str in &citations {
+        // We parse the citation (which is a JSON obj)
+        let citation: InlineCitation = serde_json::from_str(citation_str).unwrap();
+
+        // We find the record by the key
+        let entry = if let Some(record) = database.records.get(citation.key) {
+            record.entry
+        } else {
+            eprintln!(
+                "Missing citation {0}, mentioned in [cite] {0} but not defined in the bibliography",
+                citation.key
+            );
+            output.push(add_citation_label!(
+                citation_str,
+                format!(
+                    "[{}]",
+                    text!(format!("[Missing citation '{}']", citation.key))
+                )
+            ));
+            continue;
+        };
+
+        // We construct a new citation (representing [cite] in Hayagravia)
+        let hayagriva_citation: Citation = Citation::new(entry, citation.note);
+
+        // We cite that entry from our db
+        let database_citation = database.citation(citation_style.as_mut(), &[hayagriva_citation]);
+
+        // From this, we construct our citation string (what the [cite] should be turned into).
+        // We pass this as JSON format to let Hayagravia apply formatting if needed (which it
+        // doesn't, in this version at least). We encase it in [] for IEE and () for others
+        let json_citation = if style_arg == "IEEE" {
+            let mut vec = vec![text!("[")];
+            vec.append(&mut display(&database_citation.display));
+            vec.push(text!("]"));
+            Value::Array(vec)
+        } else {
+            let mut vec = vec![text!("(")];
+            vec.append(&mut display(&database_citation.display));
+            vec.push(text!(")"));
+            Value::Array(vec)
+        };
+
+        // Then, we are adding that citation as the label (that the [cite], now [cite-internal],
+        // will turn into). Note, since we are doing string-matching later on (not value-based
+        // matching), we want to make sure not to parse citation_str and re-stringify it since
+        // object kv-pairs may change order. The string must match exactly to be picked up again
+        output.push(add_citation_label!(
+            citation_str,
+            format!("{json_citation}")
+        ));
+    }
+
+    let visibility = input["arguments"]["visibility"].as_str().unwrap();
+
+    // If the bibliography should be shown, show it!
+    if visibility == "shown" {
+        for entry in database.bibliography(bibliography_style.as_ref(), None) {
+            if let Some(prefix) = &entry.prefix {
+                // If we have a prefix (which is the number in [] for IEEE), encase it in brackets
+                output.push(text!("["));
+                output.append(&mut display(prefix));
+                output.push(text!("] "));
+            }
+            output.append(&mut display(&entry.display));
+            output.push(module!("newline", ""));
+        }
+    }
+
+    println!("{}", Value::Array(output));
+}
+
+/// Gets the styles for the given key, as a pair of the bibliography style and citation style. If
+/// the key has no style mappings, None is returned. For the keys IEEE, APA, MLA and CMoS, Some is
+/// always returned, and for any other key, None is returned.
+fn get_styles(key: &str) -> Option<(Box<dyn BibliographyStyle>, Box<dyn CitationStyle>)> {
+    let bibliography_style: Box<dyn BibliographyStyle> = match key {
+        "IEEE" => Box::new(Ieee::new()),
+        "APA" => Box::new(Apa::new()),
+        "MLA" => Box::new(Mla::new()),
+        "CMoS" => Box::new(ChicagoAuthorDate::new()),
+        _ => return None,
+    };
+
+    let citation_style: Box<dyn CitationStyle> = match key {
+        "IEEE" => Box::new(Numerical::new()),
+        "APA" => Box::new(ChicagoAuthorDate::new()),
+        "MLA" => Box::new(ChicagoAuthorDate::new()),
+        "CMoS" => Box::new(ChicagoAuthorDate::new()),
+        _ => return None,
+    };
+
+    Some((bibliography_style, citation_style))
+}
+
+/// This function reads the bibliography by first:
+/// * Checking the 'file' argument, and if it is non-empty, reads that file
+/// * Otherwise, checking the body of the module
+///
+/// Then, it parses the bibliography by first:
+/// * Trying to parse it as a BibLaTeX file
+/// * If that doesn't work, try to parse it as a Hayagriva Yaml file
+///
+/// If everything succeeds, the list of entries is returned, otherwise errors are
+/// printed to stderr and None is returned. Parsing errors will print both BibLaTeX
+/// and Yaml errors.
+fn read_bibliography(input: &Value) -> Option<Vec<Entry>> {
+    let filename = input["arguments"]["file"].as_str().unwrap();
+    let input_string: Cow<'_, str> = if filename.is_empty() {
+        Cow::Borrowed(input["data"].as_str().unwrap())
+    } else if let Ok(content) = fs::read_to_string(filename) {
+        Cow::Owned(content)
+    } else {
+        eprintln!("Could not read file {filename}");
+        return None;
+    };
+
+    let bibliography = hayagriva::io::from_biblatex_str(&input_string)
+        .or_else(|e1| hayagriva::io::from_yaml_str(&input_string).map_err(|e2| (e1, e2)));
+
+    match bibliography {
+        Ok(b) => Some(b),
+        Err((e1, e2)) => {
+            eprintln!(
+                "Could not parse bibliography as BibLaTeX: {}",
+                e1.into_iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            eprintln!("Could not parse bibliography as Yaml: {e2}");
+            None
+        }
+    }
+}
+
+/// This function displays a `DisplayString` by converting its formatting rules/spans
+/// to JSON representations that can be picked up by `ModMark` again. It uses
+/// __text for all text, wrapped in __bold and __italic for those rules, and uses
+/// the `[link]` package for URLs
+fn display(string: &DisplayString) -> Vec<Value> {
+    let mut values = vec![];
+    let mut last_unformatted = 0usize;
+    for (range, rule) in &string.formatting {
+        assert!(range.start >= last_unformatted);
+        if range.start != last_unformatted {
+            values.push(text!(
+                string.value[last_unformatted..range.start].to_string()
+            ));
+        }
+        last_unformatted = range.end;
+        let substring = &string.value[range.clone()];
+        let value = match rule {
+            Formatting::Bold => {
+                json!({"name": "__bold", "arguments": {}, "children": [text!(substring)]})
+            }
+            Formatting::Italic => {
+                json!({"name": "__italic", "arguments": {}, "children": [text!(substring)]})
+            }
+            Formatting::Link(url) => module!("link", url, { "label": substring }),
+        };
+        values.push(value);
+    }
+    values.push(text!(&string.value[last_unformatted..]));
+    values
+}

--- a/packages/bibliography/tests/test_bibliography.json
+++ b/packages/bibliography/tests/test_bibliography.json
@@ -1,0 +1,70 @@
+{
+    "name": "bibliography",
+    "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
+    "arguments": {
+        "style": "IEEE",
+        "visibility": "shown",
+        "file": ""
+    },
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "J. MacFarlane, “Djot.” ",
+            "name": "__text"
+        },
+        {
+            "arguments": {
+                "label": "https://djot.net/"
+            },
+            "data": "https://djot.net/",
+            "name": "link"
+        },
+        {
+            "data": " (accessed: Jan. 23, 2023).",
+            "name": "__text"
+        },
+        {
+            "data": "",
+            "name": "newline"
+        },
+        {
+            "data": "Eclipse Foundation, “AsciiDoc.” ",
+            "name": "__text"
+        },
+        {
+            "arguments": {
+                "label": "http://asciidoc.org/"
+            },
+            "data": "http://asciidoc.org/",
+            "name": "link"
+        },
+        {
+            "data": " (accessed: Jan. 23, 2023).",
+            "name": "__text"
+        },
+        {
+            "data": "",
+            "name": "newline"
+        },
+        {
+            "data": "J. MacFarlane, “Commonmark spec.” ",
+            "name": "__text"
+        },
+        {
+            "arguments": {
+                "label": "https://spec.commonmark.org/0.30/"
+            },
+            "data": "https://spec.commonmark.org/0.30/",
+            "name": "link"
+        },
+        {
+            "data": " (accessed: Mar. 21, 2023).",
+            "name": "__text"
+        },
+        {
+            "data": "",
+            "name": "newline"
+        }
+    ]
+}

--- a/packages/bibliography/tests/test_bibliography.json
+++ b/packages/bibliography/tests/test_bibliography.json
@@ -3,7 +3,7 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "shown",
+        "visibility": "visible",
         "file": ""
     },
     "inline": false,

--- a/packages/bibliography/tests/test_bibliography_hidden.json
+++ b/packages/bibliography/tests/test_bibliography_hidden.json
@@ -1,0 +1,14 @@
+{
+    "name": "bibliography",
+    "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
+    "arguments": {
+        "style": "IEEE",
+        "visibility": "hidden",
+        "file": "",
+        "unused-entries": "hidden"
+    },
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+    ]
+}

--- a/packages/bibliography/tests/test_bibliography_unused_hidden.json
+++ b/packages/bibliography/tests/test_bibliography_unused_hidden.json
@@ -1,0 +1,14 @@
+{
+    "name": "bibliography",
+    "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
+    "arguments": {
+        "style": "IEEE",
+        "visibility": "visible",
+        "file": "",
+        "unused-entries": "hidden"
+    },
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+    ]
+}

--- a/packages/bibliography/tests/test_bibliography_unused_shown.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown.json
@@ -4,7 +4,8 @@
     "arguments": {
         "style": "IEEE",
         "visibility": "visible",
-        "file": ""
+        "file": "",
+        "unused-entries": "visible"
     },
     "inline": false,
     "__test_transform_to": "html",

--- a/packages/bibliography/tests/test_bibliography_unused_shown_html.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown_html.json
@@ -8,8 +8,12 @@
         "unused-entries": "visible"
     },
     "inline": false,
-    "__test_transform_to": "random_format",
+    "__test_transform_to": "html",
     "__test_expected_result": [
+        {
+            "data": "<span id=\"bibentry:djot\">",
+            "name": "raw"
+        },
         {
             "data": "J. MacFarlane, “Djot.” ",
             "name": "__text"
@@ -26,8 +30,16 @@
             "name": "__text"
         },
         {
+            "data": "</span>",
+            "name": "raw"
+        },
+        {
             "data": "",
             "name": "newline"
+        },
+        {
+            "data": "<span id=\"bibentry:AsciiDoc\">",
+            "name": "raw"
         },
         {
             "data": "Eclipse Foundation, “AsciiDoc.” ",
@@ -45,8 +57,16 @@
             "name": "__text"
         },
         {
+            "data": "</span>",
+            "name": "raw"
+        },
+        {
             "data": "",
             "name": "newline"
+        },
+        {
+            "data": "<span id=\"bibentry:Commonmark\">",
+            "name": "raw"
         },
         {
             "data": "J. MacFarlane, “Commonmark spec.” ",
@@ -62,6 +82,10 @@
         {
             "data": " (accessed: Mar. 21, 2023).",
             "name": "__text"
+        },
+        {
+            "data": "</span>",
+            "name": "raw"
         },
         {
             "data": "",

--- a/packages/bibliography/tests/test_bibliography_unused_shown_latex.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown_latex.json
@@ -8,8 +8,19 @@
         "unused-entries": "visible"
     },
     "inline": false,
-    "__test_transform_to": "random_format",
+    "__test_transform_to": "latex",
     "__test_expected_result": [
+        {
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage[hidelinks]{hyperref}",
+            "name": "set-add"
+        },
+        {
+            "data": "\\hypertarget{bibentry:djot}{",
+            "name": "raw"
+        },
         {
             "data": "J. MacFarlane, “Djot.” ",
             "name": "__text"
@@ -26,8 +37,16 @@
             "name": "__text"
         },
         {
+            "data": "}",
+            "name": "raw"
+        },
+        {
             "data": "",
             "name": "newline"
+        },
+        {
+            "data": "\\hypertarget{bibentry:AsciiDoc}{",
+            "name": "raw"
         },
         {
             "data": "Eclipse Foundation, “AsciiDoc.” ",
@@ -45,8 +64,16 @@
             "name": "__text"
         },
         {
+            "data": "}",
+            "name": "raw"
+        },
+        {
             "data": "",
             "name": "newline"
+        },
+        {
+            "data": "\\hypertarget{bibentry:Commonmark}{",
+            "name": "raw"
         },
         {
             "data": "J. MacFarlane, “Commonmark spec.” ",
@@ -62,6 +89,10 @@
         {
             "data": " (accessed: Mar. 21, 2023).",
             "name": "__text"
+        },
+        {
+            "data": "}",
+            "name": "raw"
         },
         {
             "data": "",

--- a/packages/bibliography/tests/test_cite_no_note.json
+++ b/packages/bibliography/tests/test_cite_no_note.json
@@ -1,0 +1,22 @@
+{
+    "name": "cite",
+    "data": "modmark",
+    "arguments": {
+        "note": ""
+    },
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "list-push",
+            "arguments": {
+                "name": "inline_citations"
+            },
+            "data": "{\"key\":\"modmark\",\"note\":null}"
+        },
+        {
+            "name": "cite-internal-do-not-use",
+            "data": "{\"key\":\"modmark\",\"note\":null}"
+        }
+    ]
+}

--- a/packages/bibliography/tests/test_cite_with_note.json
+++ b/packages/bibliography/tests/test_cite_with_note.json
@@ -1,0 +1,22 @@
+{
+    "name": "cite",
+    "data": "modmark",
+    "arguments": {
+        "note": "p. 10"
+    },
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "name": "list-push",
+            "arguments": {
+                "name": "inline_citations"
+            },
+            "data": "{\"key\":\"modmark\",\"note\":\"p. 10\"}"
+        },
+        {
+            "name": "cite-internal-do-not-use",
+            "data": "{\"key\":\"modmark\",\"note\":\"p. 10\"}"
+        }
+    ]
+}


### PR DESCRIPTION
This PR resolves GH-254 by adding a bibliography package. The package generates bibliographies, surprise surprise.

I think I am more or less done with this package, but it may have some rough edges, so please come with comments if you have any. There are two new modules intended for use; `[cite [note]] <name>`  will cite a source from the bibliography by its name, optionally allowing a note such as page numbers, and `[bibliography [style] [file]] <database>` which imports a BibTeX or Hayagravia Yaml file and uses that to create a bibliography and resolve previous citations. The BibLaTeX (or Yaml) content may be in a file (where the filename is passed as argument), or inserted as the body of the module.

Example document:
```
## Chapter 1

John MacFarlane [cite "p. 22"] djot released a product
called djot, after releasing Commonmark [cite] Commonmark in 2021.
AsciiDoc by Eclipse Foundation [cite] AsciiDoc is also intersting.

## Bibliography

[bibliography IEEE]<<
@online{djot,
title = {djot and the books that actually works bla bla it is nice. This is nice},
author = {John MacFarlane},
url = {https://djot.net},
urldate = {2023-01-23}
}

@online{AsciiDoc,
author = {{Eclipse Foundation}},
title = {{AsciiDoc}},
url = {http://asciidoc.org/},
urldate = {2023-01-23}
}

@online{Commonmark,
author = {John MacFarlane},
title = {CommonMark Spec},
year = {2021},
month = {6},
url = {https://spec.commonmark.org/0.30/},
urldate = {2023-03-21}
}
>>
```