### PR TITLE
GH-258: Add `{}` to not consume arguments to newline `\\`

### DIFF
--- a/packages/layout/src/main.rs
+++ b/packages/layout/src/main.rs
@@ -107,7 +107,7 @@ fn transform_newline(to: &str, input: Value) {
     }
 
     match to {
-        "latex" => println!("[{}]", json!({"name": "raw", "data": "\\\\"})),
+        "latex" => println!("[{}]", json!({"name": "raw", "data": "\\\\{}"})),
         "html" => println!("[{}]", json!({"name": "raw", "data": "<br/>"})),
         other => eprintln!("Cannot convert to '{other}' format."),
     }

--- a/packages/layout/tests/newline_latex.json
+++ b/packages/layout/tests/newline_latex.json
@@ -7,7 +7,7 @@
     "__test_expected_result": [
         {
             "name": "raw",
-            "data": "\\\\"
+            "data": "\\\\{}"
         }
     ]
 }


### PR DESCRIPTION
Resolves GH-258