### PR TITLE
GH-264: Add `[hide]` and `[comment]` modules

### DIFF
--- a/packages/flow/src/main.rs
+++ b/packages/flow/src/main.rs
@@ -26,6 +26,18 @@ fn manifest() {
             "description": "This package provides modules to control flow during compilation.",
             "transforms": [
                 {
+                    "from": "hide",
+                    "to": ["any"],
+                    "description": "Does not include its content in the output.",
+                    "arguments": []
+                },
+                {
+                    "from": "comment",
+                    "to": ["any"],
+                    "description": "Does not include its content in the output.",
+                    "arguments": []
+                },
+                {
                     "from": "if",
                     "to": ["any"],
                     "description": "Conditionally compile content based on output format.",
@@ -176,6 +188,7 @@ fn transform(from: &str, to: &str) {
     };
 
     match from {
+        "hide" | "comment" => transform_hide(),
         "if" => transform_if(to, input),
         "if-const" => transform_if_const(input),
         "if-set" => transform_if_collection(input, true),
@@ -184,6 +197,10 @@ fn transform(from: &str, to: &str) {
             eprintln!("Package does not support {other}");
         }
     }
+}
+
+fn transform_hide() {
+    print!("[]");
 }
 
 fn transform_if_const(input: Value) {

--- a/packages/flow/tests/test_comment.json
+++ b/packages/flow/tests/test_comment.json
@@ -1,0 +1,9 @@
+{
+    "name": "comment",
+    "data": "This should not be parsed",
+    "arguments": {
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}

--- a/packages/flow/tests/test_hide.json
+++ b/packages/flow/tests/test_hide.json
@@ -1,0 +1,9 @@
+{
+    "name": "hide",
+    "data": "This should not be parsed",
+    "arguments": {
+    },
+    "inline": true,
+    "__test_transform_to": "html",
+    "__test_expected_result": []
+}


### PR DESCRIPTION
Resolves GH-264 by adding `[hide]` and `[comment]` modules, both of which just doesn't do anything with its input