### PR TITLE
GH-266: Set alternative out dir for package-tests

### DIFF
--- a/package-tests/tests/package_tests.rs
+++ b/package-tests/tests/package_tests.rs
@@ -29,6 +29,11 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
         .parent()
         .and_then(Path::parent)
         .expect("Popping two components should give package path");
+    let package_name = package_path
+        .components()
+        .last()
+        .expect("Folder name should give package name");
+    let out_path = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(package_name);
 
     // We now need to synchronize so that we wait until other threads operating on the same package
     // is done. Since we want multiple tests in parallel but only one per package, we have a map
@@ -67,6 +72,7 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
             "--manifest-path={}",
             manifest_path.to_string_lossy()
         ))
+        .arg(format!("--target-dir={}", out_path.to_string_lossy()))
         .arg("-q")
         .arg("--")
         .arg("transform")
@@ -112,6 +118,11 @@ fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
     let package_path = file
         .parent()
         .expect("Popping one component should give package path");
+    let package_name = package_path
+        .components()
+        .last()
+        .expect("Folder name should give package name");
+    let out_path = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(package_name);
 
     // We now need to synchronize so that we wait until other threads operating on the same package
     // is done. Since we want multiple tests in parallel but only one per package, we have a map
@@ -132,6 +143,7 @@ fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
         let cmd = Command::new(env!("CARGO"))
             .arg("run")
             .arg(format!("--manifest-path={}", file.to_string_lossy()))
+            .arg(format!("--target-dir={}", out_path.to_string_lossy()))
             .arg("-q")
             .arg("--")
             .arg("manifest")

--- a/package-tests/tests/package_tests.rs
+++ b/package-tests/tests/package_tests.rs
@@ -20,6 +20,8 @@ use serde_json::Value;
 // lock after we have done everything.
 static LOCK: Lazy<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = Lazy::new(Mutex::default);
 
+// Return value must be datatest_stable::Result
+#[allow(clippy::unnecessary_wraps)]
 fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
     // path is ../packages/package-name/tests/file-name.json
     // to get the path to the package, we pop last 2 components
@@ -84,7 +86,7 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
         .expect("Spawn `cargo run` process");
     // This gets the stdin for the child, and writes the entire input file to it
     let mut stdin = cmd.stdin.as_ref().unwrap();
-    write!(stdin, "{}", input_file).expect("Expected stdin to be writable");
+    write!(stdin, "{input_file}").expect("Expected stdin to be writable");
 
     // Step 4: Get the result and compare
     let result = String::from_utf8(cmd.wait_with_output().unwrap().stdout)
@@ -113,6 +115,8 @@ fn test_package_input(file: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
+// Return value must be datatest_stable::Result
+#[allow(clippy::unnecessary_wraps)]
 fn test_package_conventions(file: &Path) -> datatest_stable::Result<()> {
     // path is ../packages/package-name/Cargo.toml
     let package_path = file
@@ -303,10 +307,9 @@ fn check_transform(transform: &Transform) {
         transform.arguments.iter().all(|arg| arg
             .default
             .as_ref()
-            .map(|d| arg.r#type.can_be_parsed_from(d))
-            .unwrap_or(true)),
+            .map_or(true, |d| arg.r#type.can_be_parsed_from(d))),
         "Argument default values should be of the same type as the specified type"
-    )
+    );
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
Resolves GH-266 by placing build output in `$CARGO_TARGET_TMPDIR/<package name>` rather than inside the `packages` folder. `CARGO_TARGET_TMPDIR` is, according to cargo docs, "only set when building [integration test](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#integration-tests) or benchmark code. This is a path to a directory inside the target directory where integration tests or benchmarks are free to put any data needed by the tests/benches. Cargo initially creates this directory but doesn’t manage its content in any way, this is the responsibility of the test code". This means that it is fine to use that as the out directory for packages.

Running the tests the first time may take a little longer than previously, since it has to re-build everything the first time, but in consecutive tests it will probably go faster (assuming `tmp` isn't cleared). Incremental builds will also be improved. A tip is to delete all `target` subdirs of `packages` after pulling this commit.

One additional benefit this has is that these builds also get cleaned with `cargo clean`.