### PR TITLE
GH-275: Add `evaluate-before-children` option to transforms

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -209,6 +209,7 @@ where
 pub struct Dependencies {
     pub var_accesses: Vec<((String, VarType), VarAccess)>,
     pub has_unknown_content: bool,
+    pub evaluate_before_children: bool,
 }
 
 impl<T, U> Context<T, U> {
@@ -255,6 +256,7 @@ impl<T, U> Context<T, U> {
                     .map(|(name, access)| ((name, access.get_type()), access))
                     .collect(),
                 has_unknown_content: transform.unknown_content,
+                evaluate_before_children: transform.evaluate_before_children,
             });
         }
 
@@ -330,6 +332,7 @@ impl<T, U> Context<T, U> {
                 .map(|(name, access)| ((name, access.get_type()), access))
                 .collect(),
             has_unknown_content: transform.unknown_content,
+            evaluate_before_children: transform.evaluate_before_children,
         })
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -264,8 +264,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde_json::Value;
     use std::collections::HashMap;
+
+    use serde_json::Value;
 
     use crate::package::{ArgType, PrimitiveArgType};
     use crate::package_store::ResolveTask;
@@ -273,6 +274,7 @@ mod tests {
     use super::*;
 
     struct UnimplementedResolver;
+
     impl Resolve for UnimplementedResolver {
         fn resolve_all(&self, _: Vec<ResolveTask>) {
             unimplemented!()
@@ -328,11 +330,12 @@ mod tests {
                         name: "strip_whitespace".to_string(),
                         default: Some(Value::String("true".to_string())),
                         description: "true/false to strip/don't strip whitespace in cells".to_string(),
-                        r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()])
+                        r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()]),
                     },
                 ],
                 variables: HashMap::new(),
-                unknown_content: true
+                unknown_content: true,
+                evaluate_before_children: false
             }],
         };
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -24,6 +24,9 @@ pub struct Transform {
     #[serde(default)]
     #[serde(rename = "unknown-content")]
     pub unknown_content: bool,
+    #[serde(default)]
+    #[serde(rename = "evaluate-before-children")]
+    pub evaluate_before_children: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -42,7 +42,8 @@ macro_rules! define_native_packages {
                                     description: Some($tdesc.to_string()),
                                     arguments: $arg_info,
                                     variables: $vars.into(),
-                                    unknown_content: $ukwn
+                                    unknown_content: $ukwn,
+                                    evaluate_before_children: false
                                 }),
                             )*
                         ]

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -264,6 +264,7 @@ fn manifest() -> String {
                     "from": "__math",
                     "to": ["html"],
                     "arguments": [],
+                    "evaluate-before-children": true
                 },
                 {
                     "from": "__paragraph",

--- a/packages/latex/src/main.rs
+++ b/packages/latex/src/main.rs
@@ -271,6 +271,7 @@ fn manifest() -> String {
                     "from": "__math",
                     "to": ["latex"],
                     "arguments": [],
+                    "evaluate-before-children": true
                 },
                 {
                     "from": "__document",
@@ -294,6 +295,7 @@ fn manifest() -> String {
                     "from": "__verbatim",
                     "to": ["latex"],
                     "arguments": [],
+                    "evaluate-before-children": true
                 },
                 {
                   "from": "__heading",


### PR DESCRIPTION
This PR resolves GH-275. The problem was that `$$x^2$$` gets represented as `__math { __text "x^2" }`, and if `__text` is evaluated before `__math`, it won't work since `__text` will be replaced with just a raw string. The core issue is that we have no dependency saying that `__math` must be evaluated before `__text`, as is the case here to get correct output (and it is also the case with `__verbatim`). This PR adds an option to the transforms in the manifest `evaluate-before-children`, default to `false`, that when true, if a parent is detected with the corresponding name, it will be guaranteed to be evaluated before its children. This PR also sets this flag for `__math` for HTML/LaTeX and `__verbatim` for LaTeX (unimplemented in HTML). This flag should only be used when the parent captures its children and changes them (doesn't necessarily include its children in its own output).

This PR is ready for review immediately.