### PR TITLE
GH-280: Append `.wasm` to local packages in modmark-core

### DIFF
--- a/cli/src/package.rs
+++ b/cli/src/package.rs
@@ -140,16 +140,12 @@ impl PackageManager {
     }
 
     fn fetch_local(&self, package_path: &str) -> Result<Vec<u8>, CliError> {
-        let mut package_path = package_path.to_string();
-        package_path.push_str(".wasm");
+        let path = current_dir()?.join(package_path);
 
-        let mut local_path = current_dir()?;
-        local_path.push(PathBuf::from(&package_path));
-
-        if !local_path.exists() {
-            return Err(CliError::Local(package_path));
+        if !path.exists() {
+            return Err(CliError::Local(package_path.to_string()));
         }
 
-        Ok(fs::read(local_path)?)
+        Ok(fs::read(path)?)
     }
 }


### PR DESCRIPTION
This PR resolves GH-280 by making Core check if the file name ends in `.wasm` and, if it doesn't, append it to the file name. This means that regardless if the user specifies `import foo` or `import foo.wasm`, Core will give a `ResolveTask` saying "*Resolve the file `foo.wasm`*" and the resolvers themselves doesn't have to add the extension. This means that more logic has been moved from the split-up resolvers to the same Core they both use, making unsynchronized behaviour more unlikely.