### PR TITLE
Use proxy to fetch packages from catalog in playground

### DIFF
--- a/playground/web_bindings/src/web_resolver.rs
+++ b/playground/web_bindings/src/web_resolver.rs
@@ -166,6 +166,9 @@ async fn fetch_catalog(url: &str) -> Result<Catalog, WebResolveError> {
 }
 
 async fn fetch_url(url: &str) -> Result<Response, WebResolveError> {
+    // Use a proxy to set the Access-Control-Allow-Origin header (otherwise CORS is blocked)
+    let proxy_url = format!("https://proxy.modmark.workers.dev/?apiurl={url}");
+
     // Since this is interfacing with JS api:s, we have to use dynamic casting and refer to
     // API docs for knowing when it is safe or not. Comments will be added when appropriate.
     let mut opts = RequestInit::new();
@@ -174,7 +177,7 @@ async fn fetch_url(url: &str) -> Result<Response, WebResolveError> {
     // it here as well
 
     // This only fails if we have credentials (user:password@url.com) in FF
-    let request = Request::new_with_str_and_init(url, &opts)
+    let request = Request::new_with_str_and_init(&proxy_url, &opts)
         .map_err(|_| WebResolveError::Url(url.to_string()))?;
 
     // This only fails if we have an invalid header name

--- a/playground/web_bindings/src/web_resolver.rs
+++ b/playground/web_bindings/src/web_resolver.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::Ordering::Release;
 
-use js_sys::{ArrayBuffer, JsString};
+use js_sys::{encode_uri_component, ArrayBuffer, JsString};
 use modmark_core::package_store::Resolve;
 use modmark_core::package_store::{PackageSource, ResolveTask};
 use once_cell::sync::OnceCell;
@@ -167,7 +167,10 @@ async fn fetch_catalog(url: &str) -> Result<Catalog, WebResolveError> {
 
 async fn fetch_url(url: &str) -> Result<Response, WebResolveError> {
     // Use a proxy to set the Access-Control-Allow-Origin header (otherwise CORS is blocked)
-    let proxy_url = format!("https://proxy.modmark.workers.dev/?apiurl={url}");
+    let proxy_url = format!(
+        "https://proxy.modmark.workers.dev/?apiurl={}",
+        encode_uri_component(url)
+    );
 
     // Since this is interfacing with JS api:s, we have to use dynamic casting and refer to
     // API docs for knowing when it is safe or not. Comments will be added when appropriate.


### PR DESCRIPTION
Resolves: #294 

This PR solves the CORS problem by using a CloudFlare worker as a proxy, which adds the necessary `Access-Control-Allow-Origin` header. I used the code at https://developers.cloudflare.com/workers/examples/cors-header-proxy with the addition of manually sending another request to a new URL if the response status was 302.