### PR TITLE
Add ArgumentType

### DIFF
--- a/cli/src/file_access.rs
+++ b/cli/src/file_access.rs
@@ -35,12 +35,12 @@ impl AccessPolicy for CliAccessManager {
         !self.deny_create
     }
 
-    fn allowed_access(&mut self, path: &Path, module_name: &String) -> bool {
+    fn allowed_access(&mut self, path: &Path, module_name: &str) -> bool {
         if self.allow_every_module {
             return true;
         }
 
-        let module = self.modules.entry(module_name.clone()).or_default();
+        let module = self.modules.entry(module_name.to_string()).or_default();
         let path_str = path.to_str().expect("Could not convert path to &str");
 
         if let Some(access) = module.permissions.get(path_str) {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -126,6 +126,14 @@ pub enum CoreError {
     Schedule,
     #[error("Could not flatten structure, internal scheduling error")]
     Flat,
+    #[error("'{0}' may only appear as a module")]
+    ExpectedModule(String),
+    #[error("'{0}' may only be invoked as an inline module")]
+    ExpectedInlineModule(String),
+    #[error("'{0}' may only be invoked as a multiline module")]
+    ExpectedMultilineModule(String),
+    #[error("'{0}' may only appear as a parent")]
+    ExpectedParent(String),
 }
 
 impl From<WasiError> for CoreError {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -268,7 +268,7 @@ mod tests {
 
     use serde_json::Value;
 
-    use crate::package::{ArgType, PrimitiveArgType};
+    use crate::package::{ArgType, PrimitiveArgType, TransformType};
     use crate::package_store::ResolveTask;
 
     use super::*;
@@ -335,7 +335,8 @@ mod tests {
                 ],
                 variables: HashMap::new(),
                 unknown_content: true,
-                evaluate_before_children: false
+                evaluate_before_children: false,
+                r#type: TransformType::Module
             }],
         };
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@ pub trait AccessPolicy: Send + Sync + 'static {
     fn allowed_to_read(&self) -> bool;
     fn allowed_to_write(&self) -> bool;
     fn allowed_to_create(&self) -> bool;
-    fn allowed_access(&mut self, path: &Path, module_name: &String) -> bool;
+    fn allowed_access(&mut self, path: &Path, module_name: &str) -> bool;
 }
 
 pub struct DefaultAccessManager;
@@ -56,7 +56,7 @@ impl AccessPolicy for DefaultAccessManager {
         true
     }
 
-    fn allowed_access(&mut self, _path: &Path, _module_name: &String) -> bool {
+    fn allowed_access(&mut self, _path: &Path, _module_name: &str) -> bool {
         true
     }
 }

--- a/core/src/package_store.rs
+++ b/core/src/package_store.rs
@@ -423,7 +423,7 @@ impl PackageStore {
 }
 
 /// The suffix each local file must have (a dot and the file extension)
-static LOCAL_FILE_EXTENSION: &'static str = ".wasm";
+static LOCAL_FILE_EXTENSION: &str = ".wasm";
 
 impl From<&str> for PackageID {
     fn from(s: &str) -> Self {

--- a/core/src/std_packages_macros.rs
+++ b/core/src/std_packages_macros.rs
@@ -43,7 +43,8 @@ macro_rules! define_native_packages {
                                     arguments: $arg_info,
                                     variables: $vars.into(),
                                     unknown_content: $ukwn,
-                                    evaluate_before_children: false
+                                    evaluate_before_children: false,
+                                    r#type: $crate::package::TransformType::Module
                                 }),
                             )*
                         ]

--- a/packages/files/src/main.rs
+++ b/packages/files/src/main.rs
@@ -49,6 +49,7 @@ fn manifest() {
                 {
                     "from": "image",
                     "to": ["html", "latex"],
+                    "type": "multiline-module",
                     "arguments": [
                         {"name": "alt", "default": "", "description": "Alternative text for the image"},
                         {

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -225,41 +225,49 @@ fn manifest() -> String {
                     "from": "__bold",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__italic",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__superscript",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__subscript",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__strikethrough",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__underlined",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__verbatim",
                     "to": ["html"],
-                    "arguments": []
+                    "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__document",
                     "to": ["html"],
                     "arguments": [],
+                   "type": "parent"
                 },
                 {
                     "from": "__text",
@@ -270,36 +278,38 @@ fn manifest() -> String {
                     "from": "__math",
                     "to": ["html"],
                     "arguments": [],
-                    "evaluate-before-children": true
+                    "evaluate-before-children": true,
+                    "type": "parent"
                 },
                 {
                     "from": "__paragraph",
                     "to": ["html"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__error",
                     "to": ["html"],
                     "arguments": [
-                    {
-                        "name":"source",
-                        "description":"Source for the error",
-                        "default":"<unknown>"
-                    },
-                    {
-                        "name":"target",
-                        "description":"Target for the error",
-                        "default":"<unknown>"
-                    },
-                    {
-                        "name":"input",
-                        "description":"Input for the error",
-                        "default":"<unknown>"
-                    },
-                ],
+                        {
+                            "name":"source",
+                            "description":"Source for the error",
+                            "default":"<unknown>"
+                        },
+                        {
+                            "name":"target",
+                            "description":"Target for the error",
+                            "default":"<unknown>"
+                        },
+                        {
+                            "name":"input",
+                            "description":"Input for the error",
+                            "default":"<unknown>"
+                        },
+                    ],
                 },
                 {
-                  "from": "__heading",
+                    "from": "__heading",
                     "to": ["html"],
                     "arguments": [
                         {
@@ -308,8 +318,8 @@ fn manifest() -> String {
                             "default": "1"
                         }
                     ],
-                },
-
+                    "type": "parent"
+                }
             ]
         }
     ))

--- a/packages/html/src/main.rs
+++ b/packages/html/src/main.rs
@@ -225,49 +225,49 @@ fn manifest() -> String {
                     "from": "__bold",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__italic",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__superscript",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__subscript",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__strikethrough",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__underlined",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__verbatim",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__document",
                     "to": ["html"],
                     "arguments": [],
-                   "type": "parent"
+                    "type": "parent"
                 },
                 {
                     "from": "__text",

--- a/packages/latex/src/main.rs
+++ b/packages/latex/src/main.rs
@@ -238,21 +238,25 @@ fn manifest() -> String {
                     "from": "__bold",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__italic",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__superscript",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__subscript",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__strikethrough",
@@ -260,18 +264,21 @@ fn manifest() -> String {
                     "arguments": [],
                     "variables": {
                         "imports": {"type": "set", "access": "add"}
-                    }
+                    },
+                    "type": "parent"
                 },
                 {
                     "from": "__underlined",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__math",
                     "to": ["latex"],
                     "arguments": [],
-                    "evaluate-before-children": true
+                    "evaluate-before-children": true,
+                    "type": "parent"
                 },
                 {
                     "from": "__document",
@@ -279,26 +286,29 @@ fn manifest() -> String {
                     "arguments": [],
                     "variables": {
                         "imports": {"type": "set", "access": "read"}
-                    }
+                    },
+                    "type": "parent"
                 },
                 {
                     "from": "__text",
                     "to": ["latex"],
-                    "arguments": [],
+                    "arguments": []
                 },
                 {
                     "from": "__paragraph",
                     "to": ["latex"],
                     "arguments": [],
+                    "type": "parent"
                 },
                 {
                     "from": "__verbatim",
                     "to": ["latex"],
                     "arguments": [],
-                    "evaluate-before-children": true
+                    "evaluate-before-children": true,
+                    "type": "parent"
                 },
                 {
-                  "from": "__heading",
+                    "from": "__heading",
                     "to": ["latex"],
                     "arguments": [
                         {
@@ -307,6 +317,7 @@ fn manifest() -> String {
                             "default": "1"
                         }
                     ],
+                    "type": "parent"
                 },
 
             ]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -30,6 +30,19 @@ pub struct ModuleArguments {
     pub named: Option<HashMap<String, String>>,
 }
 
+impl<P, T> From<P> for ModuleArguments
+where
+    HashMap<String, String>: FromIterator<T>,
+    P: IntoIterator<Item = T>,
+{
+    fn from(value: P) -> Self {
+        Self {
+            positioned: None,
+            named: Some(value.into_iter().collect()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum MaybeArgs {
     ModuleArguments(ModuleArguments),

--- a/website/src/Buttons.tsx
+++ b/website/src/Buttons.tsx
@@ -17,7 +17,7 @@ export const Button = styled.button<{ active?: boolean }>`
     ${(props) => props.active && `
         background-color: rgb(219, 219, 219);
         box-shadow: 0 0 1px rgba(0, 0, 0, 0.637);`
-    }
+}
 
     &:hover {
         background-color: rgb(206, 206, 206);

--- a/website/src/FsTree.tsx
+++ b/website/src/FsTree.tsx
@@ -1,10 +1,10 @@
-import { FiDownload, FiFolder, FiFolderPlus, FiUpload } from "react-icons/fi";
-import { MdDriveFileRenameOutline, MdOutlineDelete } from "react-icons/md";
-import { IoMdArrowBack, IoMdCheckmark, IoMdClose } from "react-icons/io";
+import {FiDownload, FiFolder, FiFolderPlus, FiUpload} from "react-icons/fi";
+import {MdDriveFileRenameOutline, MdOutlineDelete} from "react-icons/md";
+import {IoMdArrowBack, IoMdCheckmark, IoMdClose} from "react-icons/io";
 import styled from "styled-components";
 import Button from "./Buttons";
-import { useEffect, useState } from "react";
-import { FileUploader } from "react-drag-drop-files";
+import {useEffect, useState} from "react";
+import {FileUploader} from "react-drag-drop-files";
 
 
 const Container = styled.div`
@@ -124,7 +124,7 @@ type EntryProps = {
     onMove: () => void,
 }
 
-function Entry({ name, isDir, onRemove, onDownload, onRename, onMove }: EntryProps) {
+function Entry({name, isDir, onRemove, onDownload, onRename, onMove}: EntryProps) {
     const [renaming, setRenaming] = useState(false);
     const [newName, setNewName] = useState(name);
 
@@ -150,39 +150,39 @@ function Entry({ name, isDir, onRemove, onDownload, onRename, onMove }: EntryPro
             renaming ?
                 <>
                     <Name>
-                        {isDir && <FiFolder />}
+                        {isDir && <FiFolder/>}
                         <input autoFocus type="text" onKeyDown={(e) => {
                             if (e.key === "Enter") rename();
                             else if (e.key === "Escape") cancelRename();
-                        }} value={newName} onChange={(e) => setNewName(e.target.value)} />
+                        }} value={newName} onChange={(e) => setNewName(e.target.value)}/>
                     </Name>
 
                     <Actions>
                         <Action onClick={rename}>
-                            <IoMdCheckmark />
+                            <IoMdCheckmark/>
                         </Action>
                         <Action
                             onClick={cancelRename}
                         >
-                            <IoMdClose />
+                            <IoMdClose/>
                         </Action>
                     </Actions>
                 </> :
                 <>
 
-                    <Name style={isDir ? { cursor: "pointer" } : {}} onClick={nameClick}>
-                        {isDir && <FiFolder />}
-                        <span className={isDir ? "clickable" : ""} >{name}</span>
+                    <Name style={isDir ? {cursor: "pointer"} : {}} onClick={nameClick}>
+                        {isDir && <FiFolder/>}
+                        <span className={isDir ? "clickable" : ""}>{name}</span>
                     </Name>
 
                     <Actions>
-                        <Action onClick={() => setRenaming(true)}> <MdDriveFileRenameOutline /></Action>
-                        {!isDir && <Action onClick={onDownload}><FiDownload /></Action>}
-                        <Action onClick={onRemove}><MdOutlineDelete /></Action>
+                        <Action onClick={() => setRenaming(true)}> <MdDriveFileRenameOutline/></Action>
+                        {!isDir && <Action onClick={onDownload}><FiDownload/></Action>}
+                        <Action onClick={onRemove}><MdOutlineDelete/></Action>
                     </Actions>
                 </>
         }
-    </EntryContainer >
+    </EntryContainer>
 }
 
 
@@ -199,7 +199,17 @@ export type FsTreeProps = {
 };
 
 
-export default function FsTree({ listFiles, addFile, readFile, removeFolder, removeFile, renameEntry, addFolder, incFolderCounter, folderCounter }: FsTreeProps) {
+export default function FsTree({
+                                   listFiles,
+                                   addFile,
+                                   readFile,
+                                   removeFolder,
+                                   removeFile,
+                                   renameEntry,
+                                   addFolder,
+                                   incFolderCounter,
+                                   folderCounter
+                               }: FsTreeProps) {
     const [workingDir, setWorkingDir] = useState("/");
     const [entries, setEntries] = useState<[string, boolean][]>([]);
 
@@ -272,13 +282,13 @@ export default function FsTree({ listFiles, addFile, readFile, removeFolder, rem
         <Top>
             <strong>Current directory: {workingDir}</strong>
             <Buttons>
-                <Button onClick={handleBack} disabled={workingDir === "/"}><IoMdArrowBack /> Back</Button>
+                <Button onClick={handleBack} disabled={workingDir === "/"}><IoMdArrowBack/> Back</Button>
                 <Button onClick={() => {
                     addFolder(workingDir + "Folder" + folderCounter);
                     incFolderCounter();
                     updateList();
                 }}>
-                    <FiFolderPlus /> New folder
+                    <FiFolderPlus/> New folder
                 </Button>
             </Buttons>
             <FileUploader
@@ -288,7 +298,7 @@ export default function FsTree({ listFiles, addFile, readFile, removeFolder, rem
                 label="Upload or drag and drop a file here"
             >
                 <Upload>
-                    <FiUpload size={30} /> Click or drag and drop to upload a file
+                    <FiUpload size={30}/> Click or drag and drop to upload a file
                 </Upload>
             </FileUploader>
         </Top>
@@ -305,5 +315,5 @@ export default function FsTree({ listFiles, addFile, readFile, removeFolder, rem
                 />)
             }
         </Entries>
-    </Container >
+    </Container>
 }

--- a/website/src/Homepage.tsx
+++ b/website/src/Homepage.tsx
@@ -1,8 +1,7 @@
-
-import { Link, useNavigate } from 'react-router-dom';
+import {Link, useNavigate} from 'react-router-dom';
 import styled from 'styled-components';
-import { Button } from "./Buttons";
-import { FiGithub, FiExternalLink, FiPackage, FiBook, FiCode, FiDownload, FiPlay } from 'react-icons/fi';
+import {Button} from "./Buttons";
+import {FiBook, FiCode, FiDownload, FiExternalLink, FiGithub, FiPackage, FiPlay} from 'react-icons/fi';
 
 const PAGEWIDTH = 1300;
 
@@ -34,16 +33,16 @@ const MenuContainer = styled.nav`
 `;
 
 export const ActionButton = styled(Button)`
-    font-size: 1.1rem;
-    gap: 0.5rem;
-    background: none;
-    color: inherit;
+  font-size: 1.1rem;
+  gap: 0.5rem;
+  background: none;
+  color: inherit;
 
-    & > * {
-      position: relative;
-      width: 1.3rem;
-      top: 2px;
-    }
+  & > * {
+    position: relative;
+    width: 1.3rem;
+    top: 2px;
+  }
 
 `;
 
@@ -53,10 +52,10 @@ const Hero = styled.div`
   width: 100%;
   padding-bottom: 10rem;
   box-sizing: border-box;
-  background:  #f1f1f1;
+  background: #f1f1f1;
   color: #161413;
 
-  &>div {
+  & > div {
     padding: 2rem;
     max-width: ${PAGEWIDTH}px;
     margin-left: auto;
@@ -138,172 +137,186 @@ const Footer = styled.footer`
 
 const CodeFont = styled.span`
   font-family: 'JetBrains Mono', monospace;
+
   & > * {
     font-family: 'JetBrains Mono', monospace;
   }
 `;
 
 type FeatureProps = {
-  color: string,
-  action: React.ReactNode,
-  children: React.ReactNode,
-  gridStart?: GridLine,
-  gridEnd?: GridLine,
+    color: string,
+    action: React.ReactNode,
+    children: React.ReactNode,
+    gridStart?: GridLine,
+    gridEnd?: GridLine,
 };
 
 type GridLine = "start" | "left" | "right" | "end";
 
 const FeatureContainer = styled.div<{ color: string, gridStart?: GridLine, gridEnd?: GridLine }>`
-display: relative;
-padding: 1rem;
-box-sizing: border-box;
-position: relative;
-border-radius: 1rem;
-background: ${props => props.color};
-color: white;
-display: flex;
-align-items: top;
-justify-content: center;
-box-shadow: 0 1px 5px #0000001c;
-${props => props.gridStart ? `grid-column-start: ${props.gridStart};` : ""}
-${props => props.gridEnd ? `grid-column-end: ${props.gridEnd};` : ""}
+  display: relative;
+  padding: 1rem;
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 1rem;
+  background: ${props => props.color};
+  color: white;
+  display: flex;
+  align-items: top;
+  justify-content: center;
+  box-shadow: 0 1px 5px #0000001c;
+  ${props => props.gridStart ? `grid-column-start: ${props.gridStart};` : ""}
+  ${props => props.gridEnd ? `grid-column-end: ${props.gridEnd};` : ""}
 `;
 
 const FeatureAction = styled.div`
-position: absolute;
-bottom: 0;
-left:0;
-padding: 1.5rem;
-font-size: 1.1rem;
-box-sizing: border-box;
-border-top: 2px dashed #ffffff2f;
-width: 100%;
-text-align: right;
-grid-row-start: left-start;
-grid-row-end: end;
-z-index: 100;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 1.5rem;
+  font-size: 1.1rem;
+  box-sizing: border-box;
+  border-top: 2px dashed #ffffff2f;
+  width: 100%;
+  text-align: right;
+  grid-row-start: left-start;
+  grid-row-end: end;
+  z-index: 100;
 `;
 
 const FeatureChildren = styled.div`
-margin-bottom: 2.5rem;
-padding: 1.5rem;
-box-sizing: border-box;
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  box-sizing: border-box;
 
-& p {
-  max-width: 60ch;
-}
+  & p {
+    max-width: 60ch;
+  }
 
-& img {
-  max-width: 100%;
-  
-}
+  & img {
+    max-width: 100%;
+
+  }
 `;
 
-function Feature({ color, children, action, gridStart, gridEnd }: FeatureProps) {
-  return <FeatureContainer color={color} gridStart={gridStart} gridEnd={gridEnd}>
-    <FeatureChildren>{children}</FeatureChildren>
-    <FeatureAction>{action}</FeatureAction>
-  </FeatureContainer>
+function Feature({color, children, action, gridStart, gridEnd}: FeatureProps) {
+    return <FeatureContainer color={color} gridStart={gridStart} gridEnd={gridEnd}>
+        <FeatureChildren>{children}</FeatureChildren>
+        <FeatureAction>{action}</FeatureAction>
+    </FeatureContainer>
 }
-
-
 
 
 export default function Homepage() {
-  const navigate = useNavigate();
-  const menu = <MenuContainer>
-    <Link to="playground">Playground</Link>
-    <Link to="guide">Guide</Link>
-    <Link to="package-docs">Package docs</Link>
-    <a href="https://github.com/modmark-org/modmark"> GitHub</a>
-  </MenuContainer >;
+    const navigate = useNavigate();
+    const menu = <MenuContainer>
+        <Link to="playground">Playground</Link>
+        <Link to="guide">Guide</Link>
+        <Link to="package-docs">Package docs</Link>
+        <a href="https://github.com/modmark-org/modmark"> GitHub</a>
+    </MenuContainer>;
 
-  return <Container>
-    <Hero>
-      <div>
-        {menu}
-        <Logo>
-          <img src="./logo.svg" alt="ModMark logo" />
-          <div>
-            <h1>ModMark</h1>
-            <h2>Modular Markup Language</h2>
-          </div>
-        </Logo>
+    return <Container>
+        <Hero>
+            <div>
+                {menu}
+                <Logo>
+                    <img src="./logo.svg" alt="ModMark logo"/>
+                    <div>
+                        <h1>ModMark</h1>
+                        <h2>Modular Markup Language</h2>
+                    </div>
+                </Logo>
 
-        <About>
-          <p>
-            ModMark is a modular markup language. It has a lightweight syntax akin to Markdown but also offers a lot more flexibility and expressive power. Import packages and use modules to add extra functionality in your document or even add support for a new output format.
-          </p>
-          <p>
-            ModMark comes bundled with multiple useful packages and can by default output both HTML and LaTeX documents. It is still a early protype but you can use it both on the web and in your terminal.
-          </p>
-        </About>
-        <ActionButton onClick={(_e) => navigate("/playground")}>Try it in your browser <FiPlay /></ActionButton>
-      </div>
-    </Hero >
-    <Features>
-      <Feature
-        action={<Link to="/guide">Getting started guide <FiBook /></Link>}
-        color="#816796"
-      >
-        <h1>
-          <span style={{ opacity: 0.4 }}>#</span> Familiar and <span style={{ opacity: 0.4 }}>**</span>powerful<span style={{ opacity: 0.4 }}>**</span>
-        </h1>
-        <p>
-          If you have used Markdown before you will quickly feel right at home.
-        </p>
-        <p>
-          Read the getting started guide to learn more about different ways to <CodeFont>**style** ==text==</CodeFont> and include other elements in your document like a <CodeFont>[cite](modmark)</CodeFont> or a <CodeFont>[link](https://modmark.org)</CodeFont>.
-        </p>
-      </Feature>
+                <About>
+                    <p>
+                        ModMark is a modular markup language. It has a lightweight syntax akin to Markdown but also
+                        offers a lot more flexibility and expressive power. Import packages and use modules to add extra
+                        functionality in your document or even add support for a new output format.
+                    </p>
+                    <p>
+                        ModMark comes bundled with multiple useful packages and can by default output both HTML and
+                        LaTeX documents. It is still a early protype but you can use it both on the web and in your
+                        terminal.
+                    </p>
+                </About>
+                <ActionButton onClick={(_e) => navigate("/playground")}>Try it in your browser <FiPlay/></ActionButton>
+            </div>
+        </Hero>
+        <Features>
+            <Feature
+                action={<Link to="/guide">Getting started guide <FiBook/></Link>}
+                color="#816796"
+            >
+                <h1>
+                    <span style={{opacity: 0.4}}>#</span> Familiar and <span
+                    style={{opacity: 0.4}}>**</span>powerful<span style={{opacity: 0.4}}>**</span>
+                </h1>
+                <p>
+                    If you have used Markdown before you will quickly feel right at home.
+                </p>
+                <p>
+                    Read the getting started guide to learn more about different ways to <CodeFont>**style**
+                    ==text==</CodeFont> and include other elements in your document like
+                    a <CodeFont>[cite](modmark)</CodeFont> or a <CodeFont>[link](https://modmark.org)</CodeFont>.
+                </p>
+            </Feature>
 
-      <Feature
-        action={<Link to="/package-docs">Explore package docs <FiPackage /> </Link>}
-        color="#7392B7"
+            <Feature
+                action={<Link to="/package-docs">Explore package docs <FiPackage/> </Link>}
+                color="#7392B7"
 
-      >
-        <h1>Packages and modules add extra capabilities to your documents.</h1>
-        <p>
-          Want to add a citations? Plot a math function? Or render a chess board? There is a package for that.
-        </p>
-      </Feature>
+            >
+                <h1>Packages and modules add extra capabilities to your documents.</h1>
+                <p>
+                    Want to add a citations? Plot a math function? Or render a chess board? There is a package for that.
+                </p>
+            </Feature>
 
-      <Feature
-        action={<a href="https://github.com/modmark-org/modmark">GitHub <FiExternalLink /> </a>}
-        color="#C1666B"
-      >
-        <h1>Free and open source</h1>
-        <p>
-          The ModMark compiler is free and open source software, learn more on the GitHub page. Feel free to report issues or contribute too.
-        </p>
-        <FiGithub size={80} style={{ marginTop: "0.3rem", float: "right" }} />
-      </Feature>
-      <Feature
-        action={<a href=""><del>Read developer guide</del>TODO <FiCode /></a>}
-        color="#748E54"
-        gridStart="start"
-        gridEnd="right"
-      >
-        <h1>
-          Develop packages using your favourite language
-        </h1>
-        <p>
-          ModMark packages are <a href="https://webassembly.org/">WebAssembly (WASM)</a> programs that use the <a href="https://wasi.dev/">WebAssembly System Interface (WASI)</a>. This means that you can develop packages using many different languages.
-        </p>
-        <img width="70%" src="./languages.svg" />
+            <Feature
+                action={<a href="https://github.com/modmark-org/modmark">GitHub <FiExternalLink/> </a>}
+                color="#C1666B"
+            >
+                <h1>Free and open source</h1>
+                <p>
+                    The ModMark compiler is free and open source software, learn more on the GitHub page. Feel free to
+                    report issues or contribute too.
+                </p>
+                <FiGithub size={80} style={{marginTop: "0.3rem", float: "right"}}/>
+            </Feature>
+            <Feature
+                action={<a href="">
+                    <del>Read developer guide</del>
+                    TODO <FiCode/></a>}
+                color="#748E54"
+                gridStart="start"
+                gridEnd="right"
+            >
+                <h1>
+                    Develop packages using your favourite language
+                </h1>
+                <p>
+                    ModMark packages are <a href="https://webassembly.org/">WebAssembly (WASM)</a> programs that use
+                    the <a href="https://wasi.dev/">WebAssembly System Interface (WASI)</a>. This means that you can
+                    develop packages using many different languages.
+                </p>
+                <img width="70%" src="./languages.svg"/>
 
-      </Feature>
-      <Feature action={<><del>Download thesis</del> TODO <FiDownload /></>} color="#0F8B8D">
-        <h1>Learn more</h1>
-        <p>
-          ModMark was created as a bachelor's thesis project at Chalmers University of Technology in Gothenburg, Sweden.
-        </p>
-      </Feature>
-    </Features>
-    <Footer>
-      <h2>ModMark</h2>
-      {menu}
-    </Footer>
+            </Feature>
+            <Feature action={<>
+                <del>Download thesis</del>
+                TODO <FiDownload/></>} color="#0F8B8D">
+                <h1>Learn more</h1>
+                <p>
+                    ModMark was created as a bachelor's thesis project at Chalmers University of Technology in
+                    Gothenburg, Sweden.
+                </p>
+            </Feature>
+        </Features>
+        <Footer>
+            <h2>ModMark</h2>
+            {menu}
+        </Footer>
 
-  </Container >
+    </Container>
 }

--- a/website/src/PackageDocs.tsx
+++ b/website/src/PackageDocs.tsx
@@ -1,15 +1,14 @@
-import { useState } from "react";
-import { FiPackage } from "react-icons/fi";
-import { MdExpandLess, MdExpandMore } from "react-icons/md";
+import {useState} from "react";
+import {FiPackage} from "react-icons/fi";
+import {MdExpandLess, MdExpandMore} from "react-icons/md";
 import styled from "styled-components";
-import Button from "./Buttons";
-import { PackageInfo, Transform as TransformType } from "./compilerTypes";
+import {PackageInfo, Transform as TransformType} from "./compilerTypes";
 
 
 const PackageContainer = styled.div`
-    padding: 0.5rem;
-    width: 100%;
-    box-sizing: border-box;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
 const PackageName = styled.h1`
@@ -84,7 +83,13 @@ const To = styled.div`
 const TransformHeading = styled.div`
     display: flex;  
     justify-content: space-between;
+    align-items: center;
     user-select: none;
+  
+    & > div {
+      gap: 1rem;
+      display: flex;
+    }
 `;
 
 const TransformList = styled.div`
@@ -105,8 +110,11 @@ const Default = styled.code`
     opacity: 0.7;
 `
 
-const ArgTypeContainer = styled.code<{ color: string }>`
+const TypeContainer = styled.code<{ color: string }>`
     background: ${(props) => props.color};
+    display:inline-flex;
+    justify-content: center;
+    align-items: center;
     padding: 0.1rem 0.3rem;
     border-radius: 0.3rem;
     color: white;
@@ -138,20 +146,50 @@ function ArgType({ type }: { type: string | string[] }) {
         str = type;
     }
 
-    return <ArgTypeContainer color={color ?? "#748e54"}>{str}</ArgTypeContainer>
+    return <TypeContainer color={color ?? "#748e54"}>{str}</TypeContainer>
 }
 
-function Transform({ transform }: { transform: TransformType }) {
+function TransformTypeLabel({type}: { type: string }) {
+    let color = "";
+    let text = "";
+    switch (type) {
+        case "module":
+            color = "#831fa4";
+            text = "Module";
+            break;
+        case "inline-module":
+            color = "#372cd3";
+            text = "Inline-only module";
+            break;
+        case "multiline-module":
+            color = "#bf2ccb";
+            text = "Multiline-only module";
+            break;
+        case "parent":
+            color = "#b0962e"
+            text = "Parent"
+            break;
+        case "any":
+            color = "#fa6606";
+            text = "Any";
+            break;
+    }
+
+    return <TypeContainer color={color ?? "#123456"} >{text}</TypeContainer>;
+}
+
+
+function Transform({transform}: { transform: TransformType }) {
     const [expanded, SetExpanded] = useState(false);
     return <TransformContainer onClick={() => SetExpanded((expanded) => !expanded)}>
         <TransformHeading>
             <div>
                 {
                     expanded ?
-                        <MdExpandLess style={{ marginRight: 5 }} /> : <MdExpandMore style={{ marginRight: 5 }} />
+                        <MdExpandLess style={{marginRight: 5}}/> : <MdExpandMore style={{marginRight: 5}}/>
                 }
-
                 <From>{transform.from}</From>
+                <TransformTypeLabel type={transform.type} />
             </div>
             <To>supports {transform.to.length === 0 && "any"} {transform.to.map((to) => <span key={to}>{to}</span>)}</To>
         </TransformHeading>

--- a/website/src/PackageDocs.tsx
+++ b/website/src/PackageDocs.tsx
@@ -12,121 +12,121 @@ const PackageContainer = styled.div`
 `;
 
 const PackageName = styled.h1`
-    font-size: 1.5rem;
-    line-height: 1.5rem;
-    margin:0;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
+  font-size: 1.5rem;
+  line-height: 1.5rem;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 `;
 
 const Version = styled.span`
-    font-size: 0.8rem;
-    opacity: 0.7;
+  font-size: 0.8rem;
+  opacity: 0.7;
 `;
 
 const PackageHeader = styled.div`
-    display: flex;
-    gap: 1rem;
-    align-items: flex-end;
-    justify-content: space-between;
-    padding-bottom: 0.5rem;
-    border-bottom: solid 2px #0000005e;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+  border-bottom: solid 2px #0000005e;
 `;
 
 const PackageDescription = styled.p`
-    font-size: 1rem;
+  font-size: 1rem;
 `;
 
 const Subheading = styled.h2`
-    margin-top: 1.2rem;
-    font-size: 1rem;
-    font-family: "Inter", sans-serif;
+  margin-top: 1.2rem;
+  font-size: 1rem;
+  font-family: "Inter", sans-serif;
 `
 
 const PackageDocsContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    padding: 1rem;
-    width: 100%;
-    box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1rem;
+  width: 100%;
+  box-sizing: border-box;
 
-    & code {
-        font-family: "JetBrains Mono", monospace;
-    }
+  & code {
+    font-family: "JetBrains Mono", monospace;
+  }
 
-    & p {
-        max-width: 60ch;
-    }
+  & p {
+    max-width: 60ch;
+  }
 `;
 
 const TransformContainer = styled.div`
-    border-radius: 0.5rem;
-    box-sizing: border-box;
-    padding: 0.5rem;
-    background: #f8f8f8;
-    transition: all 0.2s ease-in-out;
-    cursor: pointer;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+  padding: 0.5rem;
+  background: #f8f8f8;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
 `;
 
 const From = styled.code`
-    font-size: 1.2rem;
+  font-size: 1.2rem;
 `;
 
 const To = styled.div`
-    display: flex;
-    gap: 0.3rem;
-    opacity: 0.7;
+  display: flex;
+  gap: 0.3rem;
+  opacity: 0.7;
 `;
 
 const TransformHeading = styled.div`
-    display: flex;  
-    justify-content: space-between;
-    align-items: center;
-    user-select: none;
-  
-    & > div {
-      gap: 1rem;
-      display: flex;
-    }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  user-select: none;
+
+  & > div {
+    gap: 1rem;
+    display: flex;
+  }
 `;
 
 const TransformList = styled.div`
-    & > * {
-        margin-top: 0.5rem;
-    }
+  & > * {
+    margin-top: 0.5rem;
+  }
 `;
 
 const TransformDetails = styled.div`
-    margin-top: 1rem;
+  margin-top: 1rem;
 `;
 
 const VarName = styled.code`
-    font-weight: bold;
+  font-weight: bold;
 `;
 
 const Default = styled.code`
-    opacity: 0.7;
+  opacity: 0.7;
 `
 
 const TypeContainer = styled.code<{ color: string }>`
-    background: ${(props) => props.color};
-    display:inline-flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0.1rem 0.3rem;
-    border-radius: 0.3rem;
-    color: white;
-    font-size: 0.8rem;
+  background: ${(props) => props.color};
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.3rem;
+  color: white;
+  font-size: 0.8rem;
 `;
 
 const Arg = styled.div`
   border-bottom: solid 1px #0000001c;
-  padding:0.5rem;  
+  padding: 0.5rem;
 `;
 
-function ArgType({ type }: { type: string | string[] }) {
+function ArgType({type}: { type: string | string[] }) {
     let str;
     let color;
     if (Array.isArray(type)) {
@@ -175,7 +175,7 @@ function TransformTypeLabel({type}: { type: string }) {
             break;
     }
 
-    return <TypeContainer color={color ?? "#123456"} >{text}</TypeContainer>;
+    return <TypeContainer color={color ?? "#123456"}>{text}</TypeContainer>;
 }
 
 
@@ -189,25 +189,28 @@ function Transform({transform}: { transform: TransformType }) {
                         <MdExpandLess style={{marginRight: 5}}/> : <MdExpandMore style={{marginRight: 5}}/>
                 }
                 <From>{transform.from}</From>
-                <TransformTypeLabel type={transform.type} />
+                <TransformTypeLabel type={transform.type}/>
             </div>
-            <To>supports {transform.to.length === 0 && "any"} {transform.to.map((to) => <span key={to}>{to}</span>)}</To>
+            <To>supports {transform.to.length === 0 && "any"} {transform.to.map((to) => <span
+                key={to}>{to}</span>)}</To>
         </TransformHeading>
         {expanded &&
             <TransformDetails>
                 {transform.description && <p>{transform.description}</p>}
-                {transform.arguments.length === 0 ? <Subheading>No arguments</Subheading> : <Subheading>Arguments</Subheading>}
+                {transform.arguments.length === 0 ? <Subheading>No arguments</Subheading> :
+                    <Subheading>Arguments</Subheading>}
                 {transform.arguments.map((arg) => <Arg key={arg.name}>
-                    <div style={{ display: "flex", gap: "1rem", marginBottom: "0.5rem" }}>
+                    <div style={{display: "flex", gap: "1rem", marginBottom: "0.5rem"}}>
                         <VarName>{arg.name}</VarName>
                         <Default>{arg.default !== null ? `default = ${JSON.stringify(arg.default)}` : "required"}</Default>
                     </div>
 
-                    <ArgType type={arg.type} />
+                    <ArgType type={arg.type}/>
                     <p>{arg.description}</p>
                 </Arg>)}
 
-                {Object.entries(transform.variables).length === 0 ? <Subheading>No variables</Subheading> : <Subheading>Variables</Subheading>}
+                {Object.entries(transform.variables).length === 0 ? <Subheading>No variables</Subheading> :
+                    <Subheading>Variables</Subheading>}
                 {Object.entries(transform.variables).map(([name, info]) => <div key={name}>
                     <VarName>{name}</VarName>
                     <p>Type: {info.type}</p>
@@ -220,16 +223,16 @@ function Transform({transform}: { transform: TransformType }) {
 
 }
 
-function Package({ pkg }: { pkg: PackageInfo }) {
+function Package({pkg}: { pkg: PackageInfo }) {
     return <PackageContainer>
         <PackageHeader>
-            <PackageName><FiPackage /> {pkg.name}</PackageName>
+            <PackageName><FiPackage/> {pkg.name}</PackageName>
             <Version>version {pkg.version}</Version>
         </PackageHeader>
         <PackageDescription>{pkg.description}</PackageDescription>
         <Subheading>Transforms</Subheading>
         <TransformList>
-            {pkg.transforms.map((transform) => <Transform key={transform.from + transform.to} transform={transform} />)}
+            {pkg.transforms.map((transform) => <Transform key={transform.from + transform.to} transform={transform}/>)}
         </TransformList>
     </PackageContainer>
 }
@@ -238,8 +241,8 @@ type PackageDocsProps = {
     packages: PackageInfo[],
 }
 
-export default function PackageDocs({ packages }: PackageDocsProps) {
-    const packagesElem = packages.map((pkg) => <Package key={pkg.name} pkg={pkg} />);
+export default function PackageDocs({packages}: PackageDocsProps) {
+    const packagesElem = packages.map((pkg) => <Package key={pkg.name} pkg={pkg}/>);
     return <PackageDocsContainer>
         {packagesElem}
     </PackageDocsContainer>

--- a/website/src/PackageDocsPage.tsx
+++ b/website/src/PackageDocsPage.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 import PackageDocs from "./PackageDocs";
-import { CompilationException, Compiler, PackageInfo, handleException } from "./compilerTypes";
-import { useEffect, useState, useMemo } from "react";
+import {CompilationException, Compiler, handleException, PackageInfo} from "./compilerTypes";
+import {useEffect, useMemo, useState} from "react";
 import * as Comlink from "comlink";
-import { Link } from "react-router-dom";
-import { FileUploader } from "react-drag-drop-files";
+import {Link} from "react-router-dom";
+import {FileUploader} from "react-drag-drop-files";
 
 const Container = styled.div`
 `;
@@ -124,7 +124,7 @@ export default function PackageDocsPage() {
         <Hero>
             <div>
                 <Link to="../">
-                    <img src="./logo.svg" alt="Logo" width="80" />
+                    <img src="./logo.svg" alt="Logo" width="80"/>
                 </Link>
                 <h1>Package documentation</h1>
                 <p>Read documentation for the standard library, or drag and drop one of your own packages.</p>
@@ -137,10 +137,14 @@ export default function PackageDocsPage() {
                 {
                     error !== null && <Errors>
                         {
-                            error.type === "compilationError" && error.data.map((e, i) => <div key={i}><p>{e.message}</p><pre>{e.raw}</pre></div>)
+                            error.type === "compilationError" && error.data.map((e, i) => <div key={i}><p>{e.message}</p>
+                                <pre>{e.raw}</pre>
+                            </div>)
                         }
                         {
-                            error.type === "parsingError" && <div><p>{error.data.message}</p><pre>{error.data.raw}</pre></div>
+                            error.type === "parsingError" && <div><p>{error.data.message}</p>
+                                <pre>{error.data.raw}</pre>
+                            </div>
                         }
                     </Errors>
                 }
@@ -149,9 +153,9 @@ export default function PackageDocsPage() {
         </Hero>
         <Main>
             {
-                loaded ? <PackageDocs packages={packages} /> : <p>Loading compiler...</p>
+                loaded ? <PackageDocs packages={packages}/> : <p>Loading compiler...</p>
             }
         </Main>
 
-    </Container >
+    </Container>
 }

--- a/website/src/Preview.tsx
+++ b/website/src/Preview.tsx
@@ -1,11 +1,18 @@
 import styled from "styled-components"
-import { useRef, useEffect } from "react";
 import Editor from '@monaco-editor/react';
-import { editor } from 'monaco-editor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
 type Monaco = typeof monaco;
 
-export type Mode = "ast" | "ast-debug" | "json-output" | "html" | "render-html" | "render-html-iframe" | "latex" | "transpile-other";
+export type Mode =
+    "ast"
+    | "ast-debug"
+    | "json-output"
+    | "html"
+    | "render-html"
+    | "render-html-iframe"
+    | "latex"
+    | "transpile-other";
 
 export type PreviewProps = {
     content: string,
@@ -14,54 +21,54 @@ export type PreviewProps = {
 }
 
 const PreviewContainer = styled.div<{ valid: boolean }>`
-    width: 100%;
-    height: 100%;
-    opacity: ${props => props.valid ? 1 : 0.4};
+  width: 100%;
+  height: 100%;
+  opacity: ${props => props.valid ? 1 : 0.4};
 `;
 
 const Iframe = styled.iframe`
-    border: none;
-    width: 100%;
-    height: 100%;
+  border: none;
+  width: 100%;
+  height: 100%;
 `;
 
 const HtmlPreview = styled.div`
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    padding: 1rem;  
-    overflow: auto;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 1rem;
+  overflow: auto;
 `
 
-function CodeEditor({ content, language }: { content: string, language: string }) {
+function CodeEditor({content, language}: { content: string, language: string }) {
     return <Editor
         height="100%"
         language={language}
         value={content}
-        options={{ readOnly: true }}
+        options={{readOnly: true}}
     />
 }
 
-export function Preview({ content, mode, valid }: PreviewProps) {
+export function Preview({content, mode, valid}: PreviewProps) {
 
     let main;
 
     if (mode === "ast") {
-        main = <CodeEditor content={content} language="text" />
+        main = <CodeEditor content={content} language="text"/>
     } else if (mode === "ast-debug") {
-        main = <CodeEditor content={content} language="rust" />
+        main = <CodeEditor content={content} language="rust"/>
     } else if (mode === "json-output") {
-        main = <CodeEditor content={content} language="json" />
+        main = <CodeEditor content={content} language="json"/>
     } else if (mode === "html") {
-        main = <CodeEditor content={content} language="html" />
+        main = <CodeEditor content={content} language="html"/>
     } else if (mode === "render-html") {
-        main = <HtmlPreview dangerouslySetInnerHTML={{ __html: content }} />
+        main = <HtmlPreview dangerouslySetInnerHTML={{__html: content}}/>
     } else if (mode === "render-html-iframe") {
-        main = <Iframe srcDoc={content} />
+        main = <Iframe srcDoc={content}/>
     } else if (mode === "latex") {
-        main = <CodeEditor content={content} language="text" />
+        main = <CodeEditor content={content} language="text"/>
     } else if (mode === "transpile-other") {
-        main = <CodeEditor content={content} language="text" />
+        main = <CodeEditor content={content} language="text"/>
     }
 
     return <PreviewContainer valid={valid}>

--- a/website/src/compilerTypes.ts
+++ b/website/src/compilerTypes.ts
@@ -30,11 +30,11 @@ export type CompilationException = {
     type: "compilationError",
     data: { message: string, raw: string }[]
 } |
-{
-    type: "parsingError",
-    data: { message: string, raw: string }
-} |
-{ type: "noResult" }
+    {
+        type: "parsingError",
+        data: { message: string, raw: string }
+    } |
+    { type: "noResult" }
 
 export function handleException(expection: string): CompilationException {
     return JSON.parse(expection) as CompilationException

--- a/website/src/compilerTypes.ts
+++ b/website/src/compilerTypes.ts
@@ -48,6 +48,7 @@ export type Transform = {
     variables: Record<string, VarInfo>,
     "unknown-content": boolean,
     "evaluate-before-children": boolean,
+    type: string
 }
 
 export type PackageInfo = {

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,16 +1,12 @@
 import ReactDOM from 'react-dom/client'
-import {
-  createHashRouter,
-  RouterProvider,
-  Outlet,
-} from "react-router-dom";
+import {createHashRouter, Outlet, RouterProvider,} from "react-router-dom";
 import Playground from "./Playground";
 import Homepage from './Homepage.tsx'
 import "normalize.css";
 import "./main.css"
 import styled from "styled-components";
-import { useState } from 'react';
-import { Button } from './Buttons.tsx';
+import {useState} from 'react';
+import {Button} from './Buttons.tsx';
 import PackageDocsPage from './PackageDocsPage.tsx';
 import Guide from './Guide.tsx';
 
@@ -31,51 +27,51 @@ color: ${(props) => props.color ?? "inherit"};
 `;
 
 function PrPrompt() {
-  const [hidden, setHidden] = useState(false);
+    const [hidden, setHidden] = useState(false);
 
-  const location = window.location;
-  const regex = /pr-preview\/pr-(\d+)/;
-  console.log(location.href);
-  const match = location.href.match(regex);
-  if (match !== null) {
-    return hidden ? <></> : <DebugMessage>
-      <a href={`https://github.com/modmark-org/modmark/pull/${match[1]}`}>Preview of PR #{match[1]}</a>
-      <Button onClick={() => setHidden(true)}>Close</Button>
-    </ DebugMessage >
-  }
+    const location = window.location;
+    const regex = /pr-preview\/pr-(\d+)/;
+    console.log(location.href);
+    const match = location.href.match(regex);
+    if (match !== null) {
+        return hidden ? <></> : <DebugMessage>
+            <a href={`https://github.com/modmark-org/modmark/pull/${match[1]}`}>Preview of PR #{match[1]}</a>
+            <Button onClick={() => setHidden(true)}>Close</Button>
+        </ DebugMessage>
+    }
 
-  return <></>
+    return <></>
 }
 
 // TODO: replace this with a browser router once we have replaced ace and have a proper server
 // it would also be possible to only have the playground as a react SPA and use another static site for the rest
 const router = createHashRouter([
-  {
-    path: "/",
-    element: <><PrPrompt /><Outlet /></>,
-    children: [
-      {
+    {
         path: "/",
-        element: <Homepage />,
-      },
-      {
-        path: "/playground",
-        element: <Playground />,
-      },
-      {
-        path: "/package-docs",
-        element: <PackageDocsPage />,
-      },
-      {
-        path: "/guide",
-        element: <Guide />,
-      },
-    ],
-  },
+        element: <><PrPrompt/><Outlet/></>,
+        children: [
+            {
+                path: "/",
+                element: <Homepage/>,
+            },
+            {
+                path: "/playground",
+                element: <Playground/>,
+            },
+            {
+                path: "/package-docs",
+                element: <PackageDocsPage/>,
+            },
+            {
+                path: "/guide",
+                element: <Guide/>,
+            },
+        ],
+    },
 
 
 ]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <RouterProvider router={router} />
+    <RouterProvider router={router}/>
 )


### PR DESCRIPTION
This PR resolves GH-307 and resolves GH-208 by adding an enum keyed `type` to `Transform`:
```rust
#[serde(rename_all = "kebab-case")]
pub enum TransformType {
    #[default]
    Module,
    InlineModule,
    MultilineModule,
    Parent,
    #[serde(alias = "*")]
    Any,
}
```
Then, before executing a transform, the element type is checked such that if Module is specified and the element is a Parent, it will be transformed to an error node instead. This is in line with argument type checks, whereas the compiler sometimes doesn't execute a transform if it is doomed to fail, but rather early returns a nicer error message.

It is unclear which of the current transforms should have what type, but since `Module` is default, all the language packages have been changed so many transforms (such as `__document`, `__strikethrough` etc) are of type `Parent`. Also, the thing that started the discussion which led to this change was that `[image]` can't reasonably produce in-line content, so `[image]` is changed to type `MultilineModule`.

You can test this out by going to the playground and testing this document:
```
[__document]
This should fail since __document should be a parent

Bla bla bla [image] foo.jpg this should fail since ``[image]`` produces a figure (block)

[image]
foo.jpg

[comment]
This should work tho
```

This PR is ready for review immediately