### PR TITLE
GH-311: Run wasm-opt on bundled packages

### DIFF
--- a/.github/workflows/DeployMain.yml
+++ b/.github/workflows/DeployMain.yml
@@ -34,6 +34,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, wasm32-wasi
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+          mkdir $(dirname $(which wasm-opt))/bin
+          ln -s $(which wasm-opt) $(dirname $(which wasm-opt))/bin/wasm-opt
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Build website

--- a/.github/workflows/DeployPreview.yml
+++ b/.github/workflows/DeployPreview.yml
@@ -18,7 +18,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "preview-${{ github.event.number }}"
+  group: preview-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
@@ -35,6 +35,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, wasm32-wasi
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+          mkdir $(dirname $(which wasm-opt))/bin
+          ln -s $(which wasm-opt) $(dirname $(which wasm-opt))/bin/wasm-opt
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Build website

--- a/.github/workflows/RustCI.yml
+++ b/.github/workflows/RustCI.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+          mkdir $(dirname $(which wasm-opt))/bin
+          ln -s $(which wasm-opt) $(dirname $(which wasm-opt))/bin/wasm-opt
       - name: Install toolchain (minimal, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -29,6 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+          mkdir $(dirname $(which wasm-opt))/bin
+          ln -s $(which wasm-opt) $(dirname $(which wasm-opt))/bin/wasm-opt
       - name: Install toolchain (minimal, stable, wasm32-wasi)
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To invoke the ModMark compiler, you can run
 
 > cargo run -- compile in.mdm out.html
 
-This will compile the input document `in.mdm` transforming it to HTML, and saving the output as `out.html`. In addition to the host platform target, the `wasm32-wasi` target is needed; `rustup target add wasm32-wasi`. See more information about the CLI tool at [cli/readme](cli/README.md).
+This will compile the input document `in.mdm` transforming it to HTML, and saving the output as `out.html`. In addition to the host platform target, the `wasm32-wasi` target is needed; `rustup target add wasm32-wasi`. See more information about the CLI tool at [cli/readme](cli/README.md). Compiling this project requires that `cargo` is installed, and to optimize the bundled wasm files, `wasm-opt` needs to be installed (`npm i wasm-opt -g`). To not use `wasm-opt`, the `optimize_bundled_packages` feature must be disabled.
 
 ## Overview
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,4 +26,4 @@ notify =  { version = "5.1.0", default-features = false, features = ["macos_kque
 walkdir = "2"
 
 [features]
-default = ["modmark_core/bundle_std_packages"]
+default = ["modmark_core/bundle_std_packages", "modmark_core/optimize_bundled_packages", "modmark_core/precompile_wasm"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ topological-sort = "0.2.2"
 [build-dependencies]
 wasmer-compiler-cranelift = "3.1.1"
 wasmer-compiler = "3.1.1"
+which = "4.4.0"
 
 # native feature configures wasmer to target desktop platform
 # web feature configures wasmer to target web/js
@@ -38,9 +39,12 @@ wasmer-compiler = "3.1.1"
 # precompile_wasm is an addition to bundle_std_packages, which also pre-compiles the wasm files using wasmer/cranelift,
 # so startup times are reduced by ≈98%
 # default is native, bundle_std_packages and precompile_wasm
+# optimize_bundled_packages is a feature which runs wasm-opt on the bundled packages before including them in the
+# binary. It is compatible both on native and web targets, but does require wasm-opt to be installed
 [features]
-default = ["native", "bundle_std_packages", "precompile_wasm"]
+default = ["native", "bundle_std_packages", "precompile_wasm", "optimize_bundled_packages"]
 native = ["wasmer/sys-default", "wasmer-wasi/sys-default", "wasmer-vfs/host-fs"]
 web = ["wasmer/js-default", "wasmer-wasi/js", "wasmer-vfs/mem-fs"]
 bundle_std_packages = []
+optimize_bundled_packages = []
 precompile_wasm = []

--- a/website/web_bindings/Cargo.toml
+++ b/website/web_bindings/Cargo.toml
@@ -11,17 +11,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 parser = { version = "*", path = "../../parser/" }
 thiserror = "1.0.38"
-modmark_core = { version = "*", path = "../../core/", default-features = false, features = ["web", "bundle_std_packages"] }
-
-# See issue #301
+modmark_core = { version = "*", path = "../../core/", default-features = false, features = ["web", "bundle_std_packages", "optimize_bundled_packages"] }
 wasm-bindgen = "=0.2.84"
-
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6" }
-
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.93"
 serde-wasm-bindgen = "0.5.0"


### PR DESCRIPTION
This PR resolves GH-311, and enables both optimizing bundled packages and precompiling bundled packages when building CLI by default. Previously, the packages weren't pre-compiled by default hehe...

Anyhow, these are the binary sizes, compiled on macOS 13.3.1 on M1:
| Type | Size (bytes) |
|-----|-------------|
| No optimization, no precompilation | 49 703 189 |
| Optimized, no precompilation | 44 337 653 |
| No optimization, precompiled | 65 218 869 |
| Optimized, precompiled (default) | 58 531 509 |

These features can be turned on and off with features, for example `cargo build --release --no-default-features --features modmark_core/optimize_bundled_packages` will run wasm-opt but not pre-compile the packages with Cranelift. The wasm-opt feature is available for both web and native builds.