### PR TITLE
GH-313: Allow some parents to be invoked as modules

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0.152"}
+serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.93"

--- a/packages/html/tests/test_bold.json
+++ b/packages/html/tests/test_bold.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<strong>"
-        },
+        "<strong>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</strong>"
-        }
+        "</strong>"
     ]
 }

--- a/packages/html/tests/test_italic.json
+++ b/packages/html/tests/test_italic.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<em>"
-        },
+        "<em>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</em>"
-        }
+        "</em>"
     ]
 }

--- a/packages/html/tests/test_strikethrough.json
+++ b/packages/html/tests/test_strikethrough.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<del>"
-        },
+        "<del>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</del>"
-        }
+        "</del>"
     ]
 }

--- a/packages/html/tests/test_subscript.json
+++ b/packages/html/tests/test_subscript.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<sub>"
-        },
+        "<sub>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</sub>"
-        }
+        "</sub>"
     ]
 }

--- a/packages/html/tests/test_superscript.json
+++ b/packages/html/tests/test_superscript.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<sup>"
-        },
+        "<sup>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</sup>"
-        }
+        "</sup>"
     ]
 }

--- a/packages/html/tests/test_underlined.json
+++ b/packages/html/tests/test_underlined.json
@@ -11,19 +11,13 @@
     ],
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "name": "raw",
-            "data": "<u>"
-        },
+        "<u>",
         {
             "name": "__text",
             "data": "Hello, world",
             "arguments": {},
             "inline": true
         },
-        {
-            "name": "raw",
-            "data": "</u>"
-        }
+        "</u>"
     ]
 }

--- a/packages/latex/Cargo.toml
+++ b/packages/latex/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0.152"}
+serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.93"

--- a/packages/latex/tests/test_verbatim.json
+++ b/packages/latex/tests/test_verbatim.json
@@ -12,12 +12,7 @@
     "__test_transform_to": "latex",
     "__test_expected_result": [
         "\\verb|",
-        {
-            "arguments": {},
-            "data": "Hello, world",
-            "inline": true,
-            "name": "__text"
-        },
+        "Hello, world",
         "|"
     ]
 }


### PR DESCRIPTION
This PR resolves GH-313 by changing the type of the following transforms from `Parent` to `Any`:
* `__bold`
* `__italic`
* `__superscript`
* `__subscript`
* `__strikethrough`
* `__underlined`
* `__verbatim`

This applies to both the HTML and LaTeX package. Special care is taken for `__verbatim` so that it becomes `\verb||`/`<code>` when invoked inline, and `\begin{verbatim}`/`<pre>` when invoked multiline. This PR also resolves an issue where too many characters were escaped in `\verb`, so that ` ``hello_world`` ` was rendered `hello\_world`

This PR is ready for review immediately. This behaviour is also needed for writing the thesis.