### PR TITLE
GH-315: Add big-table

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -292,52 +292,94 @@ mod tests {
             version: "0.1".to_string(),
             description: "This package supports [table] modules".to_string(),
             transforms: vec![Transform {
-                from: "table".to_string(),
-                to: vec![OutputFormat::new("html"), OutputFormat::new("latex")],
-                description: None,
-                arguments: vec![
-                    ArgInfo {
-                        name: "caption".to_string(),
-                        default: Some(Value::String("".to_string())),
-                        description: "The caption for the table".to_string(),
-                        r#type: PrimitiveArgType::String.into()
-                    }, ArgInfo {
-                        name: "label".to_string(),
-                        default: Some(Value::String("".to_string())),
-                        description: "The label to use for the table, to be able to refer to it from the document".to_string(),
-                        r#type: PrimitiveArgType::String.into()
-                    }, ArgInfo {
-                        name: "header".to_string(),
-                        default: Some(Value::String("none".to_string())),
-                        description: "Style to apply to heading, none/bold".to_string(),
-                        r#type: ArgType::Enum(vec!["none".to_string(), "bold".to_string()])
-                    }, ArgInfo {
-                        name: "alignment".to_string(),
-                        default: Some(Value::String("left".to_string())),
-                        description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
-                        r#type: PrimitiveArgType::String.into()
-                    }, ArgInfo {
-                        name: "borders".to_string(),
-                        default: Some(Value::String("all".to_string())),
-                        description: "Which borders to draw".to_string(),
-                        r#type: ArgType::Enum(vec!["all".to_string(), "horizontal".to_string(), "vertical".to_string(), "outer".to_string(), "none".to_string()])
-                    }, ArgInfo {
-                        name: "delimiter".to_string(),
-                        default: Some(Value::String("|".to_string())),
-                        description: "The delimiter between cells".to_string(),
-                        r#type: PrimitiveArgType::String.into()
-                    }, ArgInfo {
-                        name: "strip_whitespace".to_string(),
-                        default: Some(Value::String("true".to_string())),
-                        description: "true/false to strip/don't strip whitespace in cells".to_string(),
-                        r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()]),
-                    },
-                ],
-                variables: HashMap::new(),
-                unknown_content: true,
-                evaluate_before_children: false,
-                r#type: TransformType::Module
-            }],
+                    from: "table".to_string(),
+                    to: vec![OutputFormat::new("html"), OutputFormat::new("latex")],
+                    description: Some("Makes a table. Use one row for each row in the table, and separate the columns by the delimiter (default = |)".to_string()),
+                    arguments: vec![
+                        ArgInfo {
+                            name: "caption".to_string(),
+                            default: Some(Value::String("".to_string())),
+                            description: "The caption for the table".to_string(),
+                            r#type: PrimitiveArgType::String.into(),
+                        }, ArgInfo {
+                            name: "label".to_string(),
+                            default: Some(Value::String("".to_string())),
+                            description: "The label to use for the table, to be able to refer to it from the document".to_string(),
+                            r#type: PrimitiveArgType::String.into(),
+                        }, ArgInfo {
+                            name: "header".to_string(),
+                            default: Some(Value::String("none".to_string())),
+                            description: "Style to apply to heading, none/bold".to_string(),
+                            r#type: ArgType::Enum(vec!["none".to_string(), "bold".to_string()]),
+                        }, ArgInfo {
+                            name: "alignment".to_string(),
+                            default: Some(Value::String("left".to_string())),
+                            description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
+                            r#type: PrimitiveArgType::String.into(),
+                        }, ArgInfo {
+                            name: "borders".to_string(),
+                            default: Some(Value::String("all".to_string())),
+                            description: "Which borders to draw".to_string(),
+                            r#type: ArgType::Enum(vec!["all".to_string(), "horizontal".to_string(), "vertical".to_string(), "outer".to_string(), "none".to_string()]),
+                        }, ArgInfo {
+                            name: "delimiter".to_string(),
+                            default: Some(Value::String("|".to_string())),
+                            description: "The delimiter between cells".to_string(),
+                            r#type: PrimitiveArgType::String.into(),
+                        }, ArgInfo {
+                            name: "strip_whitespace".to_string(),
+                            default: Some(Value::String("true".to_string())),
+                            description: "true/false to strip/don't strip whitespace in cells".to_string(),
+                            r#type: ArgType::Enum(vec!["true".to_string(), "false".to_string()]),
+                        },
+                    ],
+                    variables: HashMap::new(),
+                    unknown_content: true,
+                    evaluate_before_children: false,
+                    r#type: TransformType::Module,
+                }, Transform {
+                     from: "big-table".to_string(),
+                     to: vec![OutputFormat::new("html"), OutputFormat::new("latex")],
+                     description: Some("Large variant of the table, which accepts block content. Write the content of each cell on multiple lines, and use column-delimiter between cells on the same row. Then, use row-delimiter between rows.".to_string()),
+                     arguments: vec![
+                         ArgInfo {
+                             name: "caption".to_string(),
+                             default: Some(Value::String("".to_string())),
+                             description: "The caption for the table".to_string(),
+                             r#type: PrimitiveArgType::String.into(),
+                         }, ArgInfo {
+                             name: "label".to_string(),
+                             default: Some(Value::String("".to_string())),
+                             description: "The label to use for the table, to be able to refer to it from the document".to_string(),
+                             r#type: PrimitiveArgType::String.into(),
+                         }, ArgInfo {
+                             name: "alignment".to_string(),
+                             default: Some(Value::String("left".to_string())),
+                             description: "Horizontal alignment in cells, left/center/right or l/c/r for each column".to_string(),
+                             r#type: PrimitiveArgType::String.into(),
+                         }, ArgInfo {
+                             name: "borders".to_string(),
+                             default: Some(Value::String("all".to_string())),
+                             description: "Which borders to draw".to_string(),
+                             r#type: ArgType::Enum(vec!["all".to_string(), "horizontal".to_string(), "vertical".to_string(), "outer".to_string(), "none".to_string()]),
+                         }, ArgInfo {
+                             name: "column-delimiter".to_string(),
+                             default: Some(Value::String("[next-column]".to_string())),
+                             description: "The delimiter between columns".to_string(),
+                             r#type: PrimitiveArgType::String.into(),
+                         }, ArgInfo {
+                             name: "row-delimiter".to_string(),
+                             default: Some(Value::String("[next-row]".to_string())),
+                             description: "The delimiter between rows".to_string(),
+                             r#type: PrimitiveArgType::String.into(),
+                         },
+                     ],
+                     variables: HashMap::new(),
+                     unknown_content: true,
+                     evaluate_before_children: false,
+                     r#type: TransformType::Module,
+                }
+            ],
         };
 
         assert_eq!(info.as_ref(), &foo);

--- a/packages/table/tests/test_big_table.json
+++ b/packages/table/tests/test_big_table.json
@@ -1,0 +1,92 @@
+{
+    "name": "big-table",
+    "arguments": {
+        "caption": "Comparison between programming^TM languages - which is best?",
+        "label": "",
+        "row-delimiter": "[next-row]",
+        "column-delimiter": "[next-column]",
+        "alignment": "left",
+        "borders": "none"
+    },
+    "data": "[big-table]\n## Python\n[code py]\ndef foo():\n    print(\"bar\");\n[next-column]\n## Rust\n[code rs]\nfn foo() {\n    println!(\"bar\");\n}\n[next-row]\n## Java\n[code java]\npublic static void foo() {\n    System.out.println(\"bar\");\n}\n[next-column]\n## ModMark\n[code txt]\nbar\n",
+    "inline": false,
+    "__test_transform_to": "html",
+    "__test_expected_result": [
+        {
+            "data": "<table>",
+            "name": "raw"
+        },
+        {
+            "data": "<caption>Comparison between programming^TM languages - which is best?</caption>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "[big-table]\n## Python\n[code py]\ndef foo():\n    print(\"bar\");\n",
+            "name": "block_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "\n## Rust\n[code rs]\nfn foo() {\n    println!(\"bar\");\n}\n",
+            "name": "block_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<tr>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "\n## Java\n[code java]\npublic static void foo() {\n    System.out.println(\"bar\");\n}\n",
+            "name": "block_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "<td style=\"text-align: left;\">",
+            "name": "raw"
+        },
+        {
+            "data": "\n## ModMark\n[code txt]\nbar\n",
+            "name": "block_content"
+        },
+        {
+            "data": "</td>",
+            "name": "raw"
+        },
+        {
+            "data": "</tr>",
+            "name": "raw"
+        },
+        {
+            "data": "</table>",
+            "name": "raw"
+        }
+    ]
+}


### PR DESCRIPTION
This PR resolves GH-315 by adding a new `big-table` module. The PR also adds descriptions to the table modules. It also includes a test for the new module, and even though it would be nice with even more tests with higher coverage, I think the main focus should be the thesis right now and this module is needed there.

Here is an example document you can test out:
```
[big-table "Comparison between programming^TM languages - which is best?"]
## Python
[code py]
def foo():
    print("bar");
[next-column]
## Rust
[code rs]
fn foo() {
    println!("bar");
}
[next-row]
## Java
[code java]
public static void foo() {
    System.out.println("bar");
}
[next-column]
## ModMark
[code txt]
bar
```