### PR TITLE
GH-58: Fix typo in textbackslash

### DIFF
--- a/packages/latex/src/main.rs
+++ b/packages/latex/src/main.rs
@@ -308,7 +308,7 @@ fn escape_text(module: Value) -> String {
             .split('\\')
             .map(|t| t.replace('{', r"\{").replace('}', r"\}"))
             .collect::<Vec<String>>()
-            .join(r"\textbacklash{}")
+            .join(r"\textbackslash{}")
             .replace('#', r"\#")
             .replace('$', r"\$")
             .replace('%', r"\%")


### PR DESCRIPTION
`\textbackslash{}` is currently `\textbacklash{}`. This PR fixes that typo.