### PR TITLE
GH-296: Add space after '\item'

### DIFF
--- a/packages/list/src/lib.rs
+++ b/packages/list/src/lib.rs
@@ -118,7 +118,7 @@ impl ListItem {
         match self {
             Content(content) => {
                 let mut json_vec = vec![];
-                json_vec.push(Value::from(r"\item"));
+                json_vec.push(Value::from(r"\item "));
                 json_vec.push(inline_content!(content));
                 json_vec.push(Value::from("\n"));
                 json_vec


### PR DESCRIPTION
#297 accidentally removed a space here after `\item`. This PR adds that space back =)