### PR TITLE
GH-210: Change label in LaTex to raw to avoid escaping

### DIFF
--- a/packages/files/src/main.rs
+++ b/packages/files/src/main.rs
@@ -244,7 +244,7 @@ fn transform_image(input: Value, to: &str) {
             }
             if !label.is_empty() {
                 v.push(json!("\\label{"));
-                v.push(json!({"name": "inline_content", "data": label}));
+                v.push(json!({"name": "raw", "data": label}));
                 v.push(json!("}\n"))
             }
             v.push(json!("\\end{figure}\n"));


### PR DESCRIPTION
Simple fix, labels like `modmark_example` were getting converted to `modmark\_example` due to inline_content instead of raw.