### PR TITLE
GH-331: Move label and caption for tables

### DIFF
--- a/packages/table/src/main.rs
+++ b/packages/table/src/main.rs
@@ -307,6 +307,16 @@ impl Table<'_> {
         vec.push(import!(r"\usepackage{float}"));
         vec.push(json!("\\begin{table}[H]\n"));
         vec.push(json!("\\centering\n"));
+        
+        if let Some(caption) = self.caption {
+            vec.push(json!("\\caption{"));
+            vec.push(inline_content!(caption));
+            vec.push(json!("}\n"));
+        }
+        if let Some(label) = self.label {
+            vec.push(json!(format!("\\label{{{label}}}\n")));
+        }
+
         vec.push(json!(format!("\\begin{{tabular}} {{ {} }}\n", col_key)));
 
         // Only "None" borders should not have top row
@@ -349,14 +359,6 @@ impl Table<'_> {
             vec.push(json!("\\hline\n"))
         }
         vec.push(json!("\\end{tabular}\n"));
-        if let Some(caption) = self.caption {
-            vec.push(json!("\\caption{"));
-            vec.push(inline_content!(caption));
-            vec.push(json!("}\n"));
-        }
-        if let Some(label) = self.label {
-            vec.push(json!(format!("\\label{{{label}}}\n")));
-        }
         vec.push(json!(r"\end{table}"));
         json!(vec)
     }

--- a/packages/table/tests/test_caption_label_latex.json
+++ b/packages/table/tests/test_caption_label_latex.json
@@ -22,6 +22,13 @@
         },
         "\\begin{table}[H]\n",
         "\\centering\n",
+        "\\caption{",
+        {
+            "data": "Test caption",
+            "name": "inline_content"
+        },
+        "}\n",
+        "\\label{table:label}\n",
         "\\begin{tabular} { |l|l| }\n",
         "\\hline\n",
         {
@@ -47,13 +54,6 @@
         " \\\\\n",
         "\\hline\n",
         "\\end{tabular}\n",
-        "\\caption{",
-        {
-            "data": "Test caption",
-            "name": "inline_content"
-        },
-        "}\n",
-        "\\label{table:label}\n",
         "\\end{table}"
     ]
 }

--- a/packages/table/tests/test_caption_latex.json
+++ b/packages/table/tests/test_caption_latex.json
@@ -22,6 +22,12 @@
         },
         "\\begin{table}[H]\n",
         "\\centering\n",
+        "\\caption{",
+        {
+            "data": "Test caption",
+            "name": "inline_content"
+        },
+        "}\n",
         "\\begin{tabular} { |l|l| }\n",
         "\\hline\n",
         {
@@ -47,12 +53,6 @@
         " \\\\\n",
         "\\hline\n",
         "\\end{tabular}\n",
-        "\\caption{",
-        {
-            "data": "Test caption",
-            "name": "inline_content"
-        },
-        "}\n",
         "\\end{table}"
     ]
 }

--- a/packages/table/tests/test_label_latex.json
+++ b/packages/table/tests/test_label_latex.json
@@ -22,6 +22,7 @@
         },
         "\\begin{table}[H]\n",
         "\\centering\n",
+        "\\label{table:label}\n",
         "\\begin{tabular} { |l|l| }\n",
         "\\hline\n",
         {
@@ -47,7 +48,6 @@
         " \\\\\n",
         "\\hline\n",
         "\\end{tabular}\n",
-        "\\label{table:label}\n",
         "\\end{table}"
     ]
 }


### PR DESCRIPTION
Resolves: #331 

As the PR name indicates it also moves the label, because it seems to be more common that way.