### PR TITLE
GH-350: Support loading multiple files from Gist

### DIFF
--- a/website/src/Gist.tsx
+++ b/website/src/Gist.tsx
@@ -12,26 +12,53 @@ type GistFile = {
     content: string
 }
 
-async function getGistById(id: string): Promise<string | null> {
-    let api_result: GistResp;
-    try {
-        let res = await fetch("https://api.github.com/gists/" + id);
-        if (res.status !== 200) {
-            return null;
-        }
-        let content = await res.text();
-        api_result = JSON.parse(content) as GistResp;
-    } catch {
-        return null;
+// This function tries to load a Gist with the given ID, and returns the appropriate entry point as a string, or if
+// the Gist format is invalid, a string describing the error will be returned. If something goes wrong with the actual
+// web requests, this function throws. If it finds a Gist, one of these cases will happen:
+// * If it contains 0 files, the string "No files found in Gist" will be returned
+// * If it contains 1 file ending in .mdm, that file will be returned
+// * If it contains 1 file not ending in .mdm, the string "No .mdm file found" will be returned
+// * If it contains multiple files, all files (but the one named "main.mdm") will be sent to otherFileHandler
+// * If a "main.mdm" file is found, it is returned, otherwise the error message
+//   "Gist contains multiple files but none named main.mdm" will be returned. Note that all files will still be sent
+//   to otherFileHandler
+async function getGistById(id: string, otherFileHandler: (path: string, bytes: Uint8Array) => Promise<void>): Promise<string> {
+    let res = await fetch("https://api.github.com/gists/" + id);
+    if (res.status !== 200) {
+        throw `Error fetching Gist with id ${id}: status code ${res.status}`;
     }
+    let content = await res.text();
+    let api_result = JSON.parse(content) as GistResp;
 
-    for (let [filename, file] of Object.entries(api_result.files)) {
+    let entries = Object.entries(api_result.files);
+    if (entries.length === 0) {
+        return "No files found in Gist";
+    }
+    if (entries.length === 1) {
+        let [filename, file] = entries[0];
         if (filename.endsWith(".mdm")) {
             return file.content;
+        } else {
+            return "No .mdm file found";
         }
     }
 
-    return null;
+    let mainFile: string | null = null;
+    let textEncoder = new TextEncoder();
+    for (let [filename, file] of Object.entries(api_result.files)) {
+        if (filename.toLowerCase() === "main.mdm") {
+            mainFile = file.content;
+        } else {
+            let array = textEncoder.encode(file.content);
+            await otherFileHandler(filename, array);
+        }
+    }
+
+    if (mainFile === null) {
+        return "Gist contains multiple files but none named main.mdm";
+    } else {
+        return mainFile;
+    }
 }
 
 export default getGistById;

--- a/website/src/Gist.tsx
+++ b/website/src/Gist.tsx
@@ -22,7 +22,7 @@ type GistFile = {
 // * If a "main.mdm" file is found, it is returned, otherwise the error message
 //   "Gist contains multiple files but none named main.mdm" will be returned. Note that all files will still be sent
 //   to otherFileHandler
-async function getGistById(id: string, otherFileHandler: (path: string, bytes: Uint8Array) => Promise<void>): Promise<string> {
+async function getGistById(id: string, otherFileHandler: (path: string, bytes: Uint8Array) => void): Promise<string> {
     let res = await fetch("https://api.github.com/gists/" + id);
     if (res.status !== 200) {
         throw `Error fetching Gist with id ${id}: status code ${res.status}`;
@@ -50,7 +50,7 @@ async function getGistById(id: string, otherFileHandler: (path: string, bytes: U
             mainFile = file.content;
         } else {
             let array = textEncoder.encode(file.content);
-            await otherFileHandler(filename, array);
+            otherFileHandler(filename, array);
         }
     }
 

--- a/website/src/Playground.tsx
+++ b/website/src/Playground.tsx
@@ -6,7 +6,7 @@ import Editor from '@monaco-editor/react';
 import {editor} from 'monaco-editor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import {Link, useSearchParams} from "react-router-dom";
-import getGistById from "./Gist.tsx";
+import getGistById from "./gist.ts";
 import {Mode, Preview} from "./Preview";
 import {FiBook, FiClock, FiFolder, FiPackage} from "react-icons/fi";
 import {MdOutlineAutoAwesome, MdOutlineDownloading, MdOutlineKeyboardAlt} from "react-icons/md";

--- a/website/src/Playground.tsx
+++ b/website/src/Playground.tsx
@@ -249,6 +249,9 @@ function Playground() {
         // If we query a gist => load it
         // If not => check local storage
         // If local storage is empty => load the welcome document (welcomeGist)
+        // Note that getGistById returns appropriate errors as strings, and only throws
+        // on HTTP errors. Also note that getGistById may load other files as well, if
+        // the gist contains other files.
 
         let welcomeGist = "dd61a53d832c8e6674190252d49606e7";
         let gist = searchParams.get("gist");
@@ -262,12 +265,8 @@ function Playground() {
         }
 
         let gistToLoad = gist ?? welcomeGist;
-        let gistContent = await getGistById(gistToLoad);
-        if (gistContent !== null) {
-            editor.setValue(gistContent);
-        } else {
-            editor.setValue("Could not load gist with ID " + gist);
-        }
+        let gistContent = await getGistById(gistToLoad, compiler.add_file);
+        editor.setValue(gistContent);
     }
 
     const handleEditorChange = (value: string | undefined) => {
@@ -513,4 +512,3 @@ function openInOverleaf(content: string){
     form.submit();
     document.body.removeChild(form);
 }
-

--- a/website/src/gist.ts
+++ b/website/src/gist.ts
@@ -23,12 +23,18 @@ type GistFile = {
 //   "Gist contains multiple files but none named main.mdm" will be returned. Note that all files will still be sent
 //   to otherFileHandler
 async function getGistById(id: string, otherFileHandler: (path: string, bytes: Uint8Array) => void): Promise<string> {
-    let res = await fetch("https://api.github.com/gists/" + id);
-    if (res.status !== 200) {
-        throw `Error fetching Gist with id ${id}: status code ${res.status}`;
+    let api_result: GistResp;
+    try {
+        let res = await fetch("https://api.github.com/gists/" + id);
+        if (res.status !== 200) {
+            // noinspection ExceptionCaughtLocallyJS
+            throw `Error fetching Gist with id ${id}: status code ${res.status}`;
+        }
+        let content = await res.text();
+        api_result = JSON.parse(content) as GistResp;
+    } catch (e) {
+        return `Error loading Gist: ${e}`;
     }
-    let content = await res.text();
-    let api_result = JSON.parse(content) as GistResp;
 
     let entries = Object.entries(api_result.files);
     if (entries.length === 0) {


### PR DESCRIPTION
Resolves GH-350

This PR supports loading gists with multiple files. If the gist only contains 1 file (and the filename ends with .mdm), that file will be loaded (as previous), but if it contains multiple files, the file named `main.mdm` is loaded while the others are added to the virtual file system.

This PR also changes some logic within `getGistById`. That function previously returned the Gist as a string and if any errors occur, returns `null`. Now, it can't return `null` but rather throws on network errors. If a logic error occurs, let's say that there are no `.mdm` files or that the gist contains multiple files but no one named `main.mdm`, it will rather return an appropriate error string to be loaded into the editor (and not throw).

Previous gists will be unaffected. When the PR preview is active, you can try it out with an example gist [here](https://modmark.org/pr-preview/pr-351/#/playground?gist=6f939c7b780ae4b668ccf20753c61260), and if this PR is merged, you can try it out [here](https://modmark.org/#/playground?gist=6f939c7b780ae4b668ccf20753c61260)