### PR TITLE
GH-356: Add empty brackets after item in LaTeX

### DIFF
--- a/packages/list/src/lib.rs
+++ b/packages/list/src/lib.rs
@@ -118,7 +118,7 @@ impl ListItem {
         match self {
             Content(content) => {
                 let mut json_vec = vec![];
-                json_vec.push(Value::from(r"\item "));
+                json_vec.push(Value::from(r"\item{} "));
                 json_vec.push(inline_content!(content));
                 json_vec.push(Value::from("\n"));
                 json_vec


### PR DESCRIPTION
This PR resolves GH-356 by adding empty brackets after the `\item` command in LaTeX.

Now, this example compiles to valid LaTeX code, whereas it didn't previously:
```
[list]
* foo
* \[bar]
```