### PR TITLE
GH-363: Improve bibliography

### DIFF
--- a/packages/bibliography/Cargo.toml
+++ b/packages/bibliography/Cargo.toml
@@ -8,4 +8,6 @@ edition = "2021"
 [dependencies]
 serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.93"
-hayagriva = "0.3.0"
+# Use git-dependency for now, since we need the abbreviate_journals field added in my PR at typst/hayagriva#45, which
+# isn't in a release yet
+hayagriva = {git = "https://github.com/typst/hayagriva"}

--- a/packages/bibliography/src/main.rs
+++ b/packages/bibliography/src/main.rs
@@ -4,9 +4,10 @@ use std::io::{self, Read};
 use std::{env, fs};
 
 use hayagriva::style::{
-    Apa, BibliographyStyle, ChicagoAuthorDate, Citation, CitationStyle, Database, DisplayString,
-    Formatting, Ieee, Mla, Numerical,
+    Apa, BibliographyStyle, ChicagoAuthorDate, Citation, CitationStyle, Database, DisplayReference,
+    DisplayString, Formatting, Ieee, Mla, Numerical,
 };
+use hayagriva::types::EntryType::{Article, Web};
 use hayagriva::Entry;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -29,7 +30,7 @@ macro_rules! module {
 
 macro_rules! raw {
     ($content:expr) => {
-        module!("raw", $content)
+        json!($content)
     };
 }
 
@@ -57,13 +58,23 @@ macro_rules! text {
     };
 }
 
+macro_rules! text_or_reparse {
+    ($e:expr, $reparse:expr) => {
+        if $reparse {
+            module!("inline_content", $e.replace("[Online]", r"\[Online]"))
+        } else {
+            module!("__text", $e)
+        }
+    };
+}
+
 fn manifest() {
     print!(
         "{}",
         json!(
             {
             "name": "bibliography",
-            "version": "0.1",
+            "version": "0.2",
             "description": "This package supports bibliographies and in-text citations.",
             "transforms": [
                 {
@@ -102,7 +113,12 @@ fn manifest() {
                         {"name": "file", "default": "", "description": "A file containing BibLaTeX or Hayagriva YAML with the bibliography"},
                         {"name": "visibility", "default": "visible", "type": ["visible", "hidden"], "description": "Whether the bibliography is 'visible' or 'hidden'. \
                         Note that a [bibliography] must exist for [cite]s to work, and if you don't want a bibliography in your document, you can set this argument to 'hidden'."},
-                        {"name": "unused-entries", "default": "hidden", "type": ["visible", "hidden"], "description": "Whether unused entries in the database should be hidden or visible"}
+                        {"name": "unused-entries", "default": "hidden", "type": ["visible", "hidden"], "description": "Whether unused entries in the database should be hidden or visible"},
+                        {"name": "insertion-type", "default": "reparse", "type": ["reparse", "plain"], "description": "Whether to reparse the content in the bibliography using inline_content"},
+                        {"name": "output", "default": "plain", "type": ["plain", "table"], "description": "Whether to output the result in plain text or in a [table]. Note that for a [table] to work, there must exist a [table] module with support for custom delimiters for the target language"},
+                        {"name": "specialization", "default": "enable", "type": ["enable", "disable"], "description": "Enabling specialization will render the result more nicely in HTML and LaTeX"},
+                        {"name": "styling", "default": "all", "description": "What styling options are available for the target language, as a comma-separated list, available: \
+                        'bold', 'italic', 'url' (via the [link] module), 'target' (via [target]/[link]) to enable references within the document"}
                     ],
                     "variables": {
                         "inline_citations": {"type": "list", "access": "read"},
@@ -181,8 +197,93 @@ fn transform_cite_label(_to: &str, input: &Value) {
     }
 }
 
+macro_rules! clone_field {
+    ($name:expr, $from:expr, $to:expr) => {
+        if let Some(result) = $from.get($name) {
+            $to.set($name, result.clone())
+                .expect(concat!("Expected to be able to set the field ", $name));
+        }
+    };
+}
+
+macro_rules! clone_fields {
+    ($from:expr => $to:expr,) => {};
+    ($from:expr => $to:expr, $f1:expr, $($fs:expr,)*) => {{
+        clone_field!($f1, $from, $to);
+        clone_fields!($from => $to, $($fs,)*);
+    }}
+}
+
+/// Configuration of how styling should be applied
+struct StylingConfig<'a> {
+    bib_style: Box<dyn BibliographyStyle<'a>>,
+    cit_style: Box<dyn CitationStyle<'a>>,
+    bold: bool,
+    italic: bool,
+    url: bool,
+    target: bool,
+    reparse: bool,
+}
+
+impl StylingConfig<'_> {
+    /// This parses a `StylingConfig` from the `style`, `styling` and `reparse` arguments.
+    fn from(style: &str, styling: &str, reparse: &str) -> Option<Self> {
+        let (bs, cs) = get_styles(style)?;
+        let reparse = &reparse.to_ascii_lowercase() == "reparse";
+
+        let s = styling.to_ascii_lowercase();
+        let res = if s.trim() == "all" {
+            Self {
+                bib_style: bs,
+                cit_style: cs,
+                bold: true,
+                italic: true,
+                url: true,
+                target: true,
+                reparse,
+            }
+        } else {
+            Self {
+                bib_style: bs,
+                cit_style: cs,
+                bold: s.contains("bold"),
+                italic: s.contains("italic"),
+                url: s.contains("url"),
+                target: s.contains("target"),
+                reparse,
+            }
+        };
+        Some(res)
+    }
+}
+
 fn transform_bibliography(to: &str, input: &Value) {
-    let Some(bibliography) = read_bibliography(input) else { return; };
+    // Read the bibliography, and if it fails, read_bibliography() has already printed an error
+    let Some(mut bibliography) = read_bibliography(input) else { return; };
+
+    // Replace 'web' with 'article'
+    bibliography.iter_mut().for_each(|x| {
+        if x.kind() == Web {
+            let mut new = Entry::new(x.key(), Article);
+            clone_fields!(x => new,
+                "parent",
+                "title",
+                "location", "publisher" , "archive" , "archive-location",
+                "author", "editor",
+                "date",
+                "affiliated",
+                "organization" , "issn" , "isbn" , "doi" , "serial-number" , "note" ,
+                "issue" , "edition",
+                "volume" , "page-range",
+                "volume-total" , "page-total" ,
+                "time-range" ,
+                "runtime" ,
+                "url",
+                "language",
+            );
+            *x = new;
+        }
+    });
 
     // This is the citations (i.e [cite]s) used in the text
     let citations: Vec<String> = {
@@ -193,21 +294,28 @@ fn transform_bibliography(to: &str, input: &Value) {
     // This is our database of all entries
     let mut database = Database::from_entries(bibliography.iter());
 
-    // What style to use (IEEE, APA etc)
-    let style_arg = input["arguments"]["style"].as_str().unwrap();
+    // Check what styling options are available for us
+    // Style has bib/cite style (IEEE, APA etc)
+    // Styling has the features available, like bold, italics etc
+    // OK to unwrap since MMCore checks enum
+    let mut styling = StylingConfig::from(
+        input["arguments"]["style"].as_str().unwrap(),
+        input["arguments"]["styling"].as_str().unwrap(),
+        input["arguments"]["insertion-type"].as_str().unwrap(),
+    )
+    .unwrap();
 
-    // Unwrap is safe since Core has checked enums already
-    let (bibliography_style, mut citation_style) = get_styles(style_arg).unwrap();
+    // This is true if we fall back to table
+    let fallback_table = input["arguments"]["output"].as_str().unwrap() == "table";
+    // This is true if we allow specialization
+    let specialization = input["arguments"]["specialization"].as_str().unwrap() == "enable";
+
+    // This is true if we should show unused keys
+    let unused_keys_is_visible =
+        input["arguments"]["unused-entries"].as_str().unwrap() == "visible";
 
     let mut output: Vec<Value> = vec![];
     let mut used_keys: HashSet<&str> = HashSet::new();
-
-    if to == "latex" {
-        output.push(import!(r"\usepackage[hidelinks]{hyperref}"));
-    }
-
-    let unused_keys_is_visible =
-        input["arguments"]["unused-entries"].as_str().unwrap() == "visible";
 
     for citation_str in &citations {
         // We parse the citation (which is a JSON obj)
@@ -241,39 +349,20 @@ fn transform_bibliography(to: &str, input: &Value) {
         let hayagriva_citation: Citation = Citation::new(entry, citation.note);
 
         // We cite that entry from our db
-        let database_citation = database.citation(citation_style.as_mut(), &[hayagriva_citation]);
+        let database_citation =
+            database.citation(styling.cit_style.as_mut(), &[hayagriva_citation]);
 
-        // From this, we construct our citation string (what the [cite] should be turned into).
-        // We pass this as JSON format to let Hayagravia apply formatting if needed (which it
-        // doesn't, in this version at least). We encase it in [] for IEEE and () for others
-        let mut json_citation_content = if style_arg == "IEEE" {
-            let mut vec = vec![text!("[")];
-            vec.append(&mut display(&database_citation.display));
-            vec.push(text!("]"));
-            vec
+        // json_citation will be the thing that [cite-internal-do-not-use] will be turned into.
+        // We either to it as a [link label=...] (if we support link/target) or
+        // as just formatted text
+        let json_citation = if styling.target {
+            let citation_content =
+                display_inline_content(&database_citation.display, &styling, true);
+            vec![module!("link", format!("bibentry:{}", entry.key()), {
+                "label": &citation_content
+            })]
         } else {
-            let mut vec = vec![text!("(")];
-            vec.append(&mut display(&database_citation.display));
-            vec.push(text!(")"));
-            vec
-        };
-
-        // Apply nicer formatting for the note depending on the
-        // output format
-        let json_citation = match to {
-            "latex" => {
-                let mut vec = vec![raw!(format!(r"\hyperlink{{bibentry:{}}}{{", entry.key()))];
-                vec.append(&mut json_citation_content);
-                vec.push(raw!("}"));
-                Value::Array(vec)
-            }
-            "html" => {
-                let mut vec = vec![raw!(format!(r##"<a href="#bibentry:{}">"##, entry.key()))];
-                vec.append(&mut json_citation_content);
-                vec.push(raw!("</a>"));
-                Value::Array(vec)
-            }
-            _ => Value::Array(json_citation_content),
+            display_to_ast(&database_citation.display, &styling, true)
         };
 
         // Then, we are adding that citation as the label (that the [cite], now [cite-internal],
@@ -282,7 +371,7 @@ fn transform_bibliography(to: &str, input: &Value) {
         // object kv-pairs may change order. The string must match exactly to be picked up again
         output.push(add_citation_label!(
             citation_str,
-            format!("{json_citation}")
+            serde_json::to_string(&json_citation).unwrap()
         ));
     }
 
@@ -290,212 +379,208 @@ fn transform_bibliography(to: &str, input: &Value) {
 
     // If the bibliography should be shown, show it!
     if is_visible {
-        output.append(&mut generate_bibliography(
-            &database,
-            bibliography_style.as_ref(),
-            unused_keys_is_visible,
-            &used_keys,
-            to,
-        ))
+        // We filter out keys, if we should, and get the prefix and content
+        let entries: Vec<(Option<DisplayString>, DisplayReference)> = database
+            .bibliography(styling.bib_style.as_ref(), None)
+            .into_iter()
+            // Remove any unused keys if they shouldn't be visible
+            .filter(|entry| unused_keys_is_visible || used_keys.contains(&entry.entry.key()))
+            // Extract the prefix and content of the reference
+            .map(|entry| (entry.prefix.clone(), entry))
+            .collect();
+
+        // Now to generating the actual bib. We check what type of bib we want to generate,
+        // if we have specialization enabled and we target HTML or LaTeX, then generate
+        // specialized, otherwise check fallback_table arg to see the fallback
+        if !entries.is_empty() {
+            let mut bib_out = if specialization && to == "html" {
+                generate_specialized_html(&entries, &styling)
+            } else if specialization && to == "latex" {
+                generate_specialized_latex(&entries, &styling)
+            } else if fallback_table {
+                generate_table(&entries, &styling)
+            } else {
+                generate_plain(&entries, &styling)
+            };
+            output.append(&mut bib_out);
+        }
     }
 
     println!("{}", Value::Array(output));
 }
 
-/// Generate the bibliography that should be displayed
-fn generate_bibliography<'a>(
-    database: &Database<'a>,
-    bibliography_style: &dyn BibliographyStyle<'a>,
-    unused_keys_is_visible: bool,
-    used_keys: &HashSet<&str>,
-    to: &str,
+fn generate_plain(
+    entries: &[(Option<DisplayString>, DisplayReference)],
+    styling: &StylingConfig,
 ) -> Vec<Value> {
-    let entries = database
-        .bibliography(bibliography_style, None)
-        .into_iter()
-        // Remove any unused keys if they shouldn't be visible
-        .filter(|entry| unused_keys_is_visible || used_keys.contains(&entry.entry.key()))
-        // If we have a prefix (which is the number in [] for IEEE), encase it in brackets
-        .map(|entry| {
-            let prefix = entry.prefix.as_ref().map(|p| {
-                let mut vec = vec![text!("[")];
-                vec.append(&mut display(p));
-                vec.push(text!("]"));
-                vec
-            });
-            (prefix, entry)
-        });
-
-    match to {
-        // The bibliography is diplayed inside a tabularx table
-        // when using latex
-        "latex" => {
-            let mut using_prefix = false;
-            let bibitems: Vec<(Vec<Value>, Vec<Value>)> = entries
-                .map(|(prefix, entry)| {
-                    let mut item = vec![];
-                    let mut styled_prefix = vec![];
-
-                    if let Some(mut prefix) = prefix {
-                        using_prefix = true;
-                        styled_prefix.append(&mut prefix);
-                    }
-
-                    item.push(raw!(format!(
-                        r"\leavevmode \hypertarget{{bibentry:{}}}{{",
-                        entry.entry.key()
-                    )));
-                    item.append(&mut display(&entry.display));
-                    item.push(raw!("}".to_string()));
-                    item.push(module!("newline", ""));
-                    item.push(raw!("\n"));
-
-                    (styled_prefix, item)
-                })
-                .collect();
-
-            // If the we have nothing to show, return early with an empty vec
-            if bibitems.is_empty() {
-                return vec![];
-            }
-
-            let mut output = Vec::new();
-            output.push(raw!("\n"));
-            output.push(import!("\\usepackage{tabularx}"));
-
-            // If we have a prefix, use two columns otherwise one
-            if using_prefix {
-                output.push(raw!(
-                    r"\renewcommand{\arraystretch}{1.5}
-\begin{tabularx}{\textwidth}{p{0.3cm} >{\raggedright\arraybackslash} X}
-"
-                ));
-            } else {
-                output.push(raw!(
-                    r"\renewcommand{\arraystretch}{1.5}
-\begin{tabularx}{\textwidth}{>{\raggedright\arraybackslash} X}
-"
-                ));
-            }
-
-            output.extend(
-                bibitems
-                    .into_iter()
-                    .map(|(mut prefix, mut item)| {
-                        let mut result = vec![];
-                        if using_prefix {
-                            result.append(&mut prefix);
-                            result.push(raw!("&"));
-                        }
-                        result.append(&mut item);
-                        result
-                    })
-                    .flatten(),
-            );
-
-            output.push(raw!(
-                r"\end{tabularx}
-\renewcommand{\arraystretch}{1}
-"
+    let mut rows: Vec<Value> = vec![];
+    for (prefix, entry) in entries {
+        if let Some(x) = prefix {
+            rows.append(&mut display_to_ast(x, styling, true));
+            rows.push(text!(" "));
+        }
+        if styling.target {
+            rows.push(module!(
+                "target",
+                display_inline_content(&entry.display, styling, false),
+                { "name": format!("bibentry:{}", entry.entry.key()) }
             ));
-            output
+        } else {
+            rows.append(&mut display_to_ast(&entry.display, styling, false));
         }
-        // For html output we use a simple css flex or grid layout
-        "html" => {
-            let mut using_prefix = false;
-            let bibitems: Vec<Vec<Value>> = entries
-                .map(|(prefix, entry)| {
-                    let mut item = Vec::new();
-                    if let Some(mut prefix) = prefix {
-                        using_prefix = true;
-                        item.push(raw!(r#"<span class="modmark-bibliography-prefix">"#));
-                        item.append(&mut prefix);
-                        item.push(raw!("</span>"));
-                    }
-
-                    item.push(raw!(format!(
-                        r#" <span class="modmark-bibliography-bibitem" id="bibentry:{}">"#,
-                        entry.entry.key()
-                    )));
-                    item.append(&mut display(&entry.display));
-                    item.push(raw!("</span>"));
-                    item.push(module!("newline", ""));
-                    item
-                })
-                .collect();
-
-            // If the we have nothing to show, return early with an empty vec
-            if bibitems.is_empty() {
-                return vec![];
-            }
-
-            let mut output = Vec::new();
-
-            // Use css grid to get a two coloumn layout if we have a prefix (like [3]).
-            if using_prefix {
-                output.push(raw!(
-                    r#"
-<style>
-    .modmark-bibliography {
-        display: grid;
-        grid-template-columns: [start] auto [center] 1fr [end];
-        gap: 0.5rem;
+        rows.push(module!("newline", ""));
     }
-        
-    .modmark-bibliography>.modmark-bibliography-prefix {
-        grid-column-start: start;
-        grid-column-end: center;
-    }
-        
-    .modmark-bibliography>.modmark-bibliography-bibitem {
-        grid-column-start: center;
-        grid-column-end: end;
-    }
-</style>"#
+    rows
+}
+
+fn generate_table(
+    entries: &[(Option<DisplayString>, DisplayReference)],
+    styling: &StylingConfig,
+) -> Vec<Value> {
+    let has_prefix = entries.iter().any(|(x, _)| x.is_some());
+    let delimiter = "!!!!TaBlE_dElImItEr!!!!";
+    let mut rows: Vec<String> = vec![];
+    if has_prefix {
+        for (prefix, entry) in entries {
+            let content = if styling.target {
+                format!(
+                    "[target name=\"bibentry:{}\"]!{}!",
+                    entry.entry.key(),
+                    display_inline_content(&entry.display, styling, false)
+                )
+            } else {
+                display_inline_content(&entry.display, styling, false)
+            };
+            if let Some(prefix) = prefix.as_ref() {
+                rows.push(format!(
+                    r"{}{delimiter}{content}",
+                    display_inline_content(prefix, styling, true)
                 ));
             } else {
-                output.push(raw!(
-                    r#"
-<style>
-    .modmark-bibliography {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
+                rows.push(format!(r"{delimiter}{content}"));
+            }
+        }
+    } else {
+        for (_, entry) in entries {
+            rows.push(display_inline_content(&entry.display, styling, false))
+        }
     }
-</style>"#
-                ));
+
+    vec![module!("table", rows.join("\n"), {
+        "delimiter": delimiter,
+        "borders": "none"
+    })]
+}
+
+fn generate_specialized_html(
+    entries: &[(Option<DisplayString>, DisplayReference)],
+    styling: &StylingConfig,
+) -> Vec<Value> {
+    let mut using_prefix = false;
+    let mut bibitems: Vec<Value> = entries
+        .iter()
+        .flat_map(|(prefix, entry)| {
+            let mut item = Vec::new();
+            if let Some(prefix) = prefix.as_ref() {
+                using_prefix = true;
+                item.push(raw!(r#"<span class="modmark-bibliography-prefix">"#));
+                item.append(&mut display_to_ast(prefix, styling, true));
+                item.push(raw!("</span>"));
             }
 
-            output.push(raw!(r#"<div class="modmark-bibliography">"#));
+            item.push(raw!(r#"<span class="modmark-bibliography-bibitem">"#));
+            item.push(module!(
+                "target",
+                display_inline_content(&entry.display, styling, false),
+                { "name": format!("bibentry:{}", entry.entry.key()) }
+            ));
+            item.push(raw!("</span>"));
+            item.push(module!("newline", ""));
+            item
+        })
+        .collect();
 
-            output.extend(bibitems.into_iter().flatten());
+    let mut output = Vec::new();
 
-            output.push(raw!("</div>"));
+    // Use css grid to get a two column layout if we have a prefix (like [3]).
+    output.push(raw!("<style>"));
+    output.push(raw!(if using_prefix {
+        include_str!("multicolumn.css")
+    } else {
+        include_str!("singlecolumn.css")
+    }));
+    output.push(raw!("</style>"));
 
-            output
-        }
-        // if we don't have any special formatting, just fallback to some basic styling
-        _ => {
-            let mut output = Vec::new();
-            entries.for_each(|(prefix, entry)| {
-                if let Some(mut prefix) = prefix {
-                    output.append(&mut prefix);
-                    output.push(text!(" "));
-                }
-                output.append(&mut display(&entry.display));
-                output.push(module!("newline", ""));
-            });
-            output
-        }
-    }
+    output.push(raw!(r#"<div class="modmark-bibliography">"#));
+    output.append(&mut bibitems);
+    output.push(raw!("</div>"));
+
+    output
+}
+
+fn generate_specialized_latex(
+    entries: &[(Option<DisplayString>, DisplayReference)],
+    styling: &StylingConfig,
+) -> Vec<Value> {
+    let default_ds = DisplayString::default();
+
+    let mut longest_prefix = 0;
+    let mut bibitems: Vec<Value> = entries
+        .iter()
+        .flat_map(|(prefix, entry)| {
+            longest_prefix = longest_prefix.max(prefix.as_ref().map_or(0, |x| x.value.len()));
+            let mut item = vec![];
+
+            item.push(raw!("\\item[{"));
+            item.append(&mut display_to_ast(
+                prefix.as_ref().unwrap_or(&default_ds),
+                styling,
+                true,
+            ));
+            item.push(raw!("}]\n"));
+
+            if styling.target {
+                item.push(import!("\\usepackage[hidelinks]{hyperref}"));
+                item.push(raw!(format!(
+                    "\\hypertarget{{bibentry:{}}}{{",
+                    entry.entry.key()
+                )));
+            }
+            item.append(&mut display_to_ast(&entry.display, styling, false));
+            if styling.target {
+                item.push(raw!("}\n\n"));
+            }
+
+            item
+        })
+        .collect();
+
+    let mut output = vec![
+        raw!("\n"),
+        raw!("\\begin{thebibliography}{"),
+        raw!("9".repeat(longest_prefix)),
+        raw!("}\n"),
+        raw!("\\phantomsection\\addcontentsline{toc}{chapter}{Bibliography}\n"),
+        raw!("\\raggedright\n"),
+    ];
+    output.append(&mut bibitems);
+    output.push(raw!("\n\\centering\n"));
+    output.push(raw!("\\end{thebibliography}"));
+    output
 }
 
 /// Gets the styles for the given key, as a pair of the bibliography style and citation style. If
 /// the key has no style mappings, None is returned. For the keys IEEE, APA, MLA and Chicago, Some is
 /// always returned, and for any other key, None is returned.
-fn get_styles(key: &str) -> Option<(Box<dyn BibliographyStyle>, Box<dyn CitationStyle>)> {
+fn get_styles<'a>(
+    key: &str,
+) -> Option<(Box<dyn BibliographyStyle<'a>>, Box<dyn CitationStyle<'a>>)> {
     let bibliography_style: Box<dyn BibliographyStyle> = match key {
-        "IEEE" => Box::new(Ieee::new()),
+        "IEEE" => Box::new({
+            let mut x = Ieee::new();
+            x.abbreviate_journals = false;
+            x
+        }),
         "APA" => Box::new(Apa::new()),
         "MLA" => Box::new(Mla::new()),
         "Chicago" => Box::new(ChicagoAuthorDate::new()),
@@ -558,36 +643,153 @@ fn read_bibliography(input: &Value) -> Option<Vec<Entry>> {
 }
 
 /// This function displays a `DisplayString` by converting its formatting rules/spans
-/// to JSON representations that can be picked up by `ModMark` again. It uses
-/// __text for all text, wrapped in __bold and __italic for those rules, and uses
-/// the `[link]` package for URLs
-fn display(string: &DisplayString) -> Vec<Value> {
-    let mut values = vec![];
+/// to `ModMark` source representations that can be picked up by `[inline_content]` again. It
+/// returns the text, wrapped in ** and // for those rules, and uses `[link]` for URLs.
+/// Note that the uses of these are conditional, based on the `StylingConfig` passed
+/// If citation_brackets is set, and the string is non-empty, styling.cit_style.brackets() are
+/// added (if they exist). Special care is taken to intersperse link labels with `\` so nothing is
+/// re-parsed there.
+fn display_inline_content(
+    string: &DisplayString,
+    styling: &StylingConfig,
+    citation_brackets: bool,
+) -> String {
+    if string.is_empty() {
+        return "".to_string();
+    }
+
+    // We know that this is going to be re-parsed. If we don't want it re-parsed, however, we
+    // intersperse with \, since foo = \f\o\o in mdm
+    let escape_if_needed = |s: &str| {
+        // If we are to reparse the text, we don't really want to escape stuff, but we manually
+        // escape [Online] since that is a common thing that we actually don't want reparsed
+        if styling.reparse {
+            s.replace("[Online]", r"\[Online]")
+        } else {
+            escape_by_interspersion(s)
+        }
+    };
+
+    let mut accumulated = String::new();
+
+    if citation_brackets {
+        if let Some(lb) = styling.cit_style.brackets().left() {
+            accumulated.push_str(&format!(r"\{lb}"));
+        }
+    }
+
     let mut last_unformatted = 0usize;
     for (range, rule) in &string.formatting {
         assert!(range.start >= last_unformatted);
         if range.start != last_unformatted {
-            values.push(text!(
-                string.value[last_unformatted..range.start].to_string()
+            accumulated.push_str(&escape_if_needed(
+                &string.value[last_unformatted..range.start],
             ));
         }
         last_unformatted = range.end;
         let substring = &string.value[range.clone()];
         let value = match rule {
-            Formatting::Bold => {
-                json!({"name": "__bold", "arguments": {}, "children": [text!(substring)]})
+            Formatting::Bold if styling.bold => format!("**{}**", escape_if_needed(substring)),
+            Formatting::Italic if styling.italic => format!("//{}//", escape_if_needed(substring)),
+            Formatting::Link(url) if styling.url => format!(
+                "[link label=\"{}\"][{url}]",
+                escape_by_interspersion(substring)
+            ),
+            _ => escape_if_needed(substring),
+        };
+        accumulated.push_str(value.as_str());
+    }
+    accumulated.push_str(&escape_if_needed(&string.value[last_unformatted..]));
+
+    if citation_brackets {
+        if let Some(rb) = styling.cit_style.brackets().right() {
+            accumulated.push_str(&format!(r"\{rb}"));
+        }
+    }
+
+    accumulated
+}
+
+/// This function displays a `DisplayString` by converting its formatting rules/spans
+/// to JSON representations that can be picked up by `ModMark` again. It uses
+/// __text for all text, wrapped in __bold and __italic for those rules, and uses
+/// the `[link]` package for URLs
+/// Note that the uses of these are conditional, based on the `StylingConfig` passed.
+/// If citation_brackets is set, and the string is non-empty, styling.cit_style.brackets() are
+/// added (if they exist). Special care is taken to intersperse link labels with `\` so nothing is
+/// re-parsed there.
+fn display_to_ast(
+    string: &DisplayString,
+    styling: &StylingConfig,
+    citation_brackets: bool,
+) -> Vec<Value> {
+    if string.is_empty() {
+        return vec![];
+    }
+
+    let mut values = vec![];
+
+    if citation_brackets {
+        if let Some(lb) = styling.cit_style.brackets().left() {
+            values.push(text!(lb));
+        }
+    }
+
+    let mut last_unformatted = 0usize;
+    for (range, rule) in &string.formatting {
+        assert!(range.start >= last_unformatted);
+        if range.start != last_unformatted {
+            values.push(text_or_reparse!(
+                string.value[last_unformatted..range.start].to_string(),
+                styling.reparse
+            ));
+        }
+        last_unformatted = range.end;
+        let substring = &string.value[range.clone()];
+        let value = match rule {
+            Formatting::Bold if styling.bold => {
+                json!({"name": "__bold", "arguments": {}, "children": [text_or_reparse!(substring, styling.reparse)]})
             }
-            Formatting::Italic => {
-                json!({"name": "__italic", "arguments": {}, "children": [text!(substring)]})
+
+            Formatting::Italic if styling.italic => {
+                json!({"name": "__italic", "arguments": {}, "children": [text_or_reparse!(substring, styling.reparse)]})
             }
-            Formatting::Link(url) => module!("link", url, { "label": substring }),
+
+            Formatting::Link(url) if styling.italic => {
+                module!("link", url, { "label": escape_by_interspersion(substring) })
+            }
+            _ => text_or_reparse!(substring, styling.reparse),
         };
         values.push(value);
     }
-    values.push(text!(&string.value[last_unformatted..]));
+    values.push(text_or_reparse!(
+        &string.value[last_unformatted..],
+        styling.reparse
+    ));
+
+    if citation_brackets {
+        if let Some(rb) = styling.cit_style.brackets().right() {
+            values.push(text!(rb));
+        }
+    }
+
     values
 }
 
+/// This function escapes a string that is going to be parsed by ModMark again by interspersing it
+/// with backslashes (\). This means that the backslash escapes the next character, making it
+/// impossible to have it be a part of a module, tag or smart punctuation
+fn escape_by_interspersion(s: &str) -> String {
+    let mut res = String::new();
+    for c in s.chars() {
+        res.push('\\');
+        res.push(c);
+    }
+    res
+}
+
+/// This function returns its input with LaTeX comments removed (i.e, all lines starting with %
+/// removed)
 fn without_latex_comments(string: &str) -> String {
     string
         .lines()

--- a/packages/bibliography/src/multicolumn.css
+++ b/packages/bibliography/src/multicolumn.css
@@ -1,0 +1,15 @@
+.modmark-bibliography {
+    display: grid;
+    grid-template-columns: [start] auto [center] 1fr [end];
+    gap: 0.5rem;
+}
+
+.modmark-bibliography>.modmark-bibliography-prefix {
+    grid-column-start: start;
+    grid-column-end: center;
+}
+
+.modmark-bibliography>.modmark-bibliography-bibitem {
+    grid-column-start: center;
+    grid-column-end: end;
+}

--- a/packages/bibliography/src/singlecolumn.css
+++ b/packages/bibliography/src/singlecolumn.css
@@ -1,0 +1,5 @@
+.modmark-bibliography {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}

--- a/packages/bibliography/tests/test_bibliography_hidden.json
+++ b/packages/bibliography/tests/test_bibliography_hidden.json
@@ -3,9 +3,13 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "hidden",
         "file": "",
-        "unused-entries": "hidden"
+        "visibility": "hidden",
+        "unused-entries": "hidden",
+        "insertion-type": "reparse",
+        "output": "plain",
+        "specialization": "enable",
+        "styling": "all"
     },
     "inline": false,
     "__test_transform_to": "html",

--- a/packages/bibliography/tests/test_bibliography_unused_hidden.json
+++ b/packages/bibliography/tests/test_bibliography_unused_hidden.json
@@ -3,9 +3,13 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "visible",
         "file": "",
-        "unused-entries": "hidden"
+        "visibility": "visible",
+        "unused-entries": "hidden",
+        "insertion-type": "reparse",
+        "output": "plain",
+        "specialization": "enable",
+        "styling": "all"
     },
     "inline": false,
     "__test_transform_to": "html",

--- a/packages/bibliography/tests/test_bibliography_unused_shown.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown.json
@@ -3,65 +3,45 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "visible",
         "file": "",
-        "unused-entries": "visible"
+        "visibility": "visible",
+        "unused-entries": "visible",
+        "insertion-type": "reparse",
+        "output": "plain",
+        "specialization": "enable",
+        "styling": "all"
     },
     "inline": false,
     "__test_transform_to": "random_format",
     "__test_expected_result": [
         {
-            "data": "J. MacFarlane, “Djot.” ",
-            "name": "__text"
-        },
-        {
             "arguments": {
-                "label": "https://djot.net/"
+                "name": "bibentry:djot"
             },
-            "data": "https://djot.net/",
-            "name": "link"
-        },
-        {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
+            "data": "J. MacFarlane, “Djot.” Accessed: Jan. 23, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\s\\:\\/\\/\\d\\j\\o\\t\\.\\n\\e\\t\\/\"][https://djot.net/]",
+            "name": "target"
         },
         {
             "data": "",
             "name": "newline"
         },
         {
-            "data": "Eclipse Foundation, “AsciiDoc.” ",
-            "name": "__text"
-        },
-        {
             "arguments": {
-                "label": "http://asciidoc.org/"
+                "name": "bibentry:AsciiDoc"
             },
-            "data": "http://asciidoc.org/",
-            "name": "link"
-        },
-        {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
+            "data": "Eclipse Foundation, “AsciiDoc.” Accessed: Jan. 23, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\:\\/\\/\\a\\s\\c\\i\\i\\d\\o\\c\\.\\o\\r\\g\\/\"][http://asciidoc.org/]",
+            "name": "target"
         },
         {
             "data": "",
             "name": "newline"
         },
         {
-            "data": "J. MacFarlane, “Commonmark spec.” ",
-            "name": "__text"
-        },
-        {
             "arguments": {
-                "label": "https://spec.commonmark.org/0.30/"
+                "name": "bibentry:Commonmark"
             },
-            "data": "https://spec.commonmark.org/0.30/",
-            "name": "link"
-        },
-        {
-            "data": " (accessed: Mar. 21, 2023).",
-            "name": "__text"
+            "data": "J. MacFarlane, “Commonmark spec,” 2021. Accessed: Mar. 21, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\s\\:\\/\\/\\s\\p\\e\\c\\.\\c\\o\\m\\m\\o\\n\\m\\a\\r\\k\\.\\o\\r\\g\\/\\0\\.\\3\\0\\/\"][https://spec.commonmark.org/0.30/]",
+            "name": "target"
         },
         {
             "data": "",

--- a/packages/bibliography/tests/test_bibliography_unused_shown_html.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown_html.json
@@ -3,105 +3,60 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "visible",
         "file": "",
-        "unused-entries": "visible"
+        "visibility": "visible",
+        "unused-entries": "visible",
+        "insertion-type": "reparse",
+        "output": "plain",
+        "specialization": "enable",
+        "styling": "all"
     },
     "inline": false,
     "__test_transform_to": "html",
     "__test_expected_result": [
-        {
-            "data": "\n<style>\n    .modmark-bibliography {\n        display: flex;\n        flex-direction: column;\n        gap: 0.5rem;\n    }\n</style>",
-            "name": "raw"
-        },
-        {
-            "data": "<div class=\"modmark-bibliography\">",
-            "name": "raw"
-        },
-        {
-            "data": " <span class=\"modmark-bibliography-bibitem\" id=\"bibentry:djot\">",
-            "name": "raw"
-        },
-        {
-            "data": "J. MacFarlane, “Djot.” ",
-            "name": "__text"
-        },
+        "<style>",
+        ".modmark-bibliography {\n    display: flex;\n    flex-direction: column;\n    gap: 0.5rem;\n}\n",
+        "</style>",
+        "<div class=\"modmark-bibliography\">",
+        "<span class=\"modmark-bibliography-bibitem\">",
         {
             "arguments": {
-                "label": "https://djot.net/"
+                "name": "bibentry:djot"
             },
-            "data": "https://djot.net/",
-            "name": "link"
+            "data": "J. MacFarlane, “Djot.” Accessed: Jan. 23, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\s\\:\\/\\/\\d\\j\\o\\t\\.\\n\\e\\t\\/\"][https://djot.net/]",
+            "name": "target"
         },
-        {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "</span>",
-            "name": "raw"
-        },
+        "</span>",
         {
             "data": "",
             "name": "newline"
         },
-        {
-            "data": " <span class=\"modmark-bibliography-bibitem\" id=\"bibentry:AsciiDoc\">",
-            "name": "raw"
-        },
-        {
-            "data": "Eclipse Foundation, “AsciiDoc.” ",
-            "name": "__text"
-        },
+        "<span class=\"modmark-bibliography-bibitem\">",
         {
             "arguments": {
-                "label": "http://asciidoc.org/"
+                "name": "bibentry:AsciiDoc"
             },
-            "data": "http://asciidoc.org/",
-            "name": "link"
+            "data": "Eclipse Foundation, “AsciiDoc.” Accessed: Jan. 23, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\:\\/\\/\\a\\s\\c\\i\\i\\d\\o\\c\\.\\o\\r\\g\\/\"][http://asciidoc.org/]",
+            "name": "target"
         },
-        {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "</span>",
-            "name": "raw"
-        },
+        "</span>",
         {
             "data": "",
             "name": "newline"
         },
-        {
-            "data": " <span class=\"modmark-bibliography-bibitem\" id=\"bibentry:Commonmark\">",
-            "name": "raw"
-        },
-        {
-            "data": "J. MacFarlane, “Commonmark spec.” ",
-            "name": "__text"
-        },
+        "<span class=\"modmark-bibliography-bibitem\">",
         {
             "arguments": {
-                "label": "https://spec.commonmark.org/0.30/"
+                "name": "bibentry:Commonmark"
             },
-            "data": "https://spec.commonmark.org/0.30/",
-            "name": "link"
+            "data": "J. MacFarlane, “Commonmark spec,” 2021. Accessed: Mar. 21, 2023. \\[Online]. Available: [link label=\"\\h\\t\\t\\p\\s\\:\\/\\/\\s\\p\\e\\c\\.\\c\\o\\m\\m\\o\\n\\m\\a\\r\\k\\.\\o\\r\\g\\/\\0\\.\\3\\0\\/\"][https://spec.commonmark.org/0.30/]",
+            "name": "target"
         },
-        {
-            "data": " (accessed: Mar. 21, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "</span>",
-            "name": "raw"
-        },
+        "</span>",
         {
             "data": "",
             "name": "newline"
         },
-        {
-            "data": "</div>",
-            "name": "raw"
-        }
+        "</div>"
     ]
 }

--- a/packages/bibliography/tests/test_bibliography_unused_shown_latex.json
+++ b/packages/bibliography/tests/test_bibliography_unused_shown_latex.json
@@ -3,13 +3,25 @@
     "data": "@online{djot,\ntitle = {djot},\nauthor = {John MacFarlane},\nurl = {https://djot.net},\nurldate = {2023-01-23}\n}\n\n@online{AsciiDoc,\nauthor = {{Eclipse Foundation}},\ntitle = {{AsciiDoc}},\nurl = {http://asciidoc.org/},\nurldate = {2023-01-23}\n}\n\n@online{Commonmark,\nauthor = {John MacFarlane},\ntitle = {CommonMark Spec},\nyear = {2021},\nmonth = {6},\nurl = {https://spec.commonmark.org/0.30/},\nurldate = {2023-03-21}\n}\n",
     "arguments": {
         "style": "IEEE",
-        "visibility": "visible",
         "file": "",
-        "unused-entries": "visible"
+        "visibility": "visible",
+        "unused-entries": "visible",
+        "insertion-type": "reparse",
+        "output": "plain",
+        "specialization": "enable",
+        "styling": "all"
     },
     "inline": false,
     "__test_transform_to": "latex",
     "__test_expected_result": [
+        "\n",
+        "\\begin{thebibliography}{",
+        "",
+        "}\n",
+        "\\phantomsection\\addcontentsline{toc}{chapter}{Bibliography}\n",
+        "\\raggedright\n",
+        "\\item[{",
+        "}]\n",
         {
             "arguments": {
                 "name": "imports"
@@ -17,117 +29,76 @@
             "data": "\\usepackage[hidelinks]{hyperref}",
             "name": "set-add"
         },
+        "\\hypertarget{bibentry:djot}{",
         {
-            "data": "\n",
-            "name": "raw"
+            "data": "J. MacFarlane, “Djot.” Accessed: Jan. 23, 2023. \\[Online]. Available: ",
+            "name": "inline_content"
         },
         {
             "arguments": {
-                "name": "imports"
-            },
-            "data": "\\usepackage{tabularx}",
-            "name": "set-add"
-        },
-        {
-            "data": "\\renewcommand{\\arraystretch}{1.5}\n\\begin{tabularx}{\\textwidth}{>{\\raggedright\\arraybackslash} X}\n",
-            "name": "raw"
-        },
-        {
-            "data": "\\leavevmode \\hypertarget{bibentry:djot}{",
-            "name": "raw"
-        },
-        {
-            "data": "J. MacFarlane, “Djot.” ",
-            "name": "__text"
-        },
-        {
-            "arguments": {
-                "label": "https://djot.net/"
+                "label": "\\h\\t\\t\\p\\s\\:\\/\\/\\d\\j\\o\\t\\.\\n\\e\\t\\/"
             },
             "data": "https://djot.net/",
             "name": "link"
         },
         {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "}",
-            "name": "raw"
-        },
-        {
             "data": "",
-            "name": "newline"
+            "name": "inline_content"
         },
+        "}\n\n",
+        "\\item[{",
+        "}]\n",
         {
-            "data": "\n",
-            "name": "raw"
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage[hidelinks]{hyperref}",
+            "name": "set-add"
         },
+        "\\hypertarget{bibentry:AsciiDoc}{",
         {
-            "data": "\\leavevmode \\hypertarget{bibentry:AsciiDoc}{",
-            "name": "raw"
-        },
-        {
-            "data": "Eclipse Foundation, “AsciiDoc.” ",
-            "name": "__text"
+            "data": "Eclipse Foundation, “AsciiDoc.” Accessed: Jan. 23, 2023. \\[Online]. Available: ",
+            "name": "inline_content"
         },
         {
             "arguments": {
-                "label": "http://asciidoc.org/"
+                "label": "\\h\\t\\t\\p\\:\\/\\/\\a\\s\\c\\i\\i\\d\\o\\c\\.\\o\\r\\g\\/"
             },
             "data": "http://asciidoc.org/",
             "name": "link"
         },
         {
-            "data": " (accessed: Jan. 23, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "}",
-            "name": "raw"
-        },
-        {
             "data": "",
-            "name": "newline"
+            "name": "inline_content"
         },
+        "}\n\n",
+        "\\item[{",
+        "}]\n",
         {
-            "data": "\n",
-            "name": "raw"
+            "arguments": {
+                "name": "imports"
+            },
+            "data": "\\usepackage[hidelinks]{hyperref}",
+            "name": "set-add"
         },
+        "\\hypertarget{bibentry:Commonmark}{",
         {
-            "data": "\\leavevmode \\hypertarget{bibentry:Commonmark}{",
-            "name": "raw"
-        },
-        {
-            "data": "J. MacFarlane, “Commonmark spec.” ",
-            "name": "__text"
+            "data": "J. MacFarlane, “Commonmark spec,” 2021. Accessed: Mar. 21, 2023. \\[Online]. Available: ",
+            "name": "inline_content"
         },
         {
             "arguments": {
-                "label": "https://spec.commonmark.org/0.30/"
+                "label": "\\h\\t\\t\\p\\s\\:\\/\\/\\s\\p\\e\\c\\.\\c\\o\\m\\m\\o\\n\\m\\a\\r\\k\\.\\o\\r\\g\\/\\0\\.\\3\\0\\/"
             },
             "data": "https://spec.commonmark.org/0.30/",
             "name": "link"
         },
         {
-            "data": " (accessed: Mar. 21, 2023).",
-            "name": "__text"
-        },
-        {
-            "data": "}",
-            "name": "raw"
-        },
-        {
             "data": "",
-            "name": "newline"
+            "name": "inline_content"
         },
-        {
-            "data": "\n",
-            "name": "raw"
-        },
-        {
-            "data": "\\end{tabularx}\n\\renewcommand{\\arraystretch}{1}\n",
-            "name": "raw"
-        }
+        "}\n\n",
+        "\n\\centering\n",
+        "\\end{thebibliography}"
     ]
 }


### PR DESCRIPTION
This PR resolves GH-363 by improving the bibliography in several ways. As discussed in the issue, this PR makes the bibliography more language-agnostic again, by:
* Adding `output=table|plain*` which can be used to print the output in a table format, for output formats which has table implemented, while allowing just outputting in plain-text for output formats which doesn't have tables
* Adding `specialization=enable*|disable` to enable or disable specialization (where HTML and LaTeX output gets special treatment)
* Adding `styling=all|bold|italic|url|target` (zero or more can be enabled) which allows the bibliography to style only parts that are possible to style, so that one could disable bold styling for output languages not supporting bold, or URL for languages that doesn't have URLs. This also allows `[target]`-`[link]`-behaviour to any output format, which was added to std in #332 to be able to link one part of the document to another. This was previously specialized just to HTML/LaTeX. This is available (and respected) for both plaintext, table, and specialized output.

In addition to these changes, which makes the module more modular (hehe), some other notable changes are:
* The specialized output for LaTeX actually works now! (Previously, it only rendered one page)
* `web`-type articles works better now (by just forcing the type to be `article` lol
* The code is better split up with different functions handling different output types (specialized-html, specialized-latex, table and plain)
* Brackets for citation style isn't hard-coded anymore, they are fetched from Hayagriva
* Abbreviations for IEEE has been turned off (there were changes made to hayagriva which allows that now, but since that isn't released in Cargo yet, we have a Git-dependency)

You can try this out if you want, mix-and-match different parameters. Note that using `insertion-type = plain` sometimes fail (especially on HTML output) due to #362 . The HTML output is very similar to the one Eli merged in the last PR, but some of the multi-line CSS code has been moved out not to clutter the code as much. The LaTeX output is very similar, almost identical, to the one used in the thesis. Merging this (and solving #362) will probably remove the need for fetching the bibliography from the catalog.

This PR is ready for review immediately. There are no env-based tests, personally I think it is fine but I will be sure to add some if you think it is important!