### PR TITLE
GH-362: Check for char boundary before truncating

### DIFF
--- a/parser/src/punct.rs
+++ b/parser/src/punct.rs
@@ -145,7 +145,13 @@ fn try_smart_sequence(str: &mut String, last_escape: Option<usize>) {
             .take_while(|ch| ch == &last_char)
             .collect::<String>();
         if let Some(i) = last_escape {
-            seq.truncate(str.len() - i - 1);
+            for x in 1.. {
+                let ci = str.len() - i - x;
+                if seq.is_char_boundary(ci) {
+                    seq.truncate(ci);
+                    break;
+                }
+            }
         }
         let range = str.len() - seq.len()..str.len();
         match seq.as_str() {


### PR DESCRIPTION
This PR resolves GH-362 by checking that the index `try_smart_sequence` is going to split at is actually a char boundary. If not, it tries to backtrack not only one but two bytes, and if not, tries to backtrack three bytes etc.

You can try this out by doing `\😀` in the playground. Previously, the compiler would crash (and the status would be stuck at Compiling...), but now it works as expected. This is the code handling the smart sequences `...`, `--` and `---`, so you can try them out to see that they have not been broken. There might be better implementations of this, but I think this would be sufficient.