### PR TITLE
GH-370: Add unique IDs

### DIFF
--- a/website/web_bindings/Cargo.toml
+++ b/website/web_bindings/Cargo.toml
@@ -25,6 +25,7 @@ wasmer-vfs = { version = "3.1.1", default-features = false, features = ["mem-fs"
 js-sys = "0.3.61"
 wasm-bindgen-futures = "0.4.34"
 once_cell = "1.17.1"
+rand = "0.8.1"
 
 [dependencies.web-sys]
 version = "0.3.61"


### PR DESCRIPTION
This PR adds a field `ID` to `JsonEntry` variants `Parent` and `Module`. This ID is guaranteed to be unique (per compilation cycle), so that if you get some data with ID 325, you know that no other modules or parents generated during the entire compilation cycle has ID 325. Moreover, this is "simulated" in the JSON output view with random numbers in the range `5 000-500 000`, to show that you can't depend on any property of IDs other than that they are unique. In practice, when Core is assigning IDs when compiling a document, they are assigned sequentially from 100, but keep in mind that it is undetermenistic what parts of the document is evaluated when, so this isn't dependable. When deserializing JsonEntries, IDs are discarded, and are re-assigned when serializing the entries again. This PR resolves GH-370.